### PR TITLE
Cythonize multidicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ cover
 .idea
 pyvenv
 virtualenv.py
+aiohttp/_multidict.c
+aiohttp/_multidict.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 
 install:
   - pip install --upgrade setuptools
+  - pip install cython
   - pip install flake8
   - pip install docutils
   - pip install coverage

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,8 @@ CHANGES
 
 - websocket's ping and pong accept optional message parameter
 
+- multidict `getall=True` default is now instead of `False`.
+
 
 0.13.1 (12-31-2014)
 --------------------

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,19 @@ FLAGS=
 flake:
 	flake8 aiohttp tests examples
 
-test: flake
+develop:
+	python setup.py develop
+
+test: flake develop
 	nosetests -s $(FLAGS) ./tests/
 
-vtest: flake
+vtest: flake develop
 	nosetests -s -v $(FLAGS) ./tests/
 
-testloop:
+testloop: develop
 	while sleep 1; do python runtests.py $(FLAGS); done
 
-cov cover coverage: flake
+cov cover coverage: flake develop
 	nosetests -s --with-cover --cover-html --cover-branches --cover-html-dir ./coverage $(FLAGS) ./tests/
 	@echo "open file://`pwd`/coverage/index.html"
 
@@ -33,6 +36,7 @@ clean:
 	rm -rf build
 	rm -rf cover
 	make -C docs clean
+	python setup.py clean
 
 doc:
 	make -C docs html

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ vtest: flake develop
 
 cov cover coverage: flake
 	@coverage erase
-	@coverage run -m nose -s $(FLAGS); tests
+	@coverage run -m nose -s $(FLAGS) tests
 	@coverage report
 	@coverage html
 	@echo "open file://`pwd`/coverage/index.html"

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -83,7 +83,7 @@ cdef class MultiDict:
     def copy(self):
         """Returns a copy itself."""
         cls = self.__class__
-        return cls(self.items(getall=True))
+        return cls(self._items)
 
     # Mapping interface #
 
@@ -113,7 +113,7 @@ cdef class MultiDict:
 
     cdef _contains(self, str key):
         cdef str k
-        for k, v in self._items:
+        for k, _ in self._items:
             if k == key:
                 return True
         return False

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -48,13 +48,13 @@ cdef class MultiDict:
     cdef _add(self, tuple item):
         self._items.append(item)
 
-    def getall(self, key, default=_marker):
+    def getall(self, str key, default=_marker):
         """
         Return a list of all values matching the key (may be an empty list)
         """
         return self._getall(key, default)
 
-    cdef _getall(self, key, default):
+    cdef _getall(self, str key, default):
         cdef tuple res
         res = tuple(v for k, v in self._items if k == key)
         if res:
@@ -63,7 +63,7 @@ cdef class MultiDict:
             return default
         raise KeyError('Key not found: %r' % key)
 
-    def getone(self, key, default=_marker):
+    def getone(self, str key, default=_marker):
         """
         Get first value matching the key
         """
@@ -87,7 +87,7 @@ cdef class MultiDict:
 
     # Mapping interface #
 
-    def __getitem__(self, key):
+    def __getitem__(self, str key):
         return self._getitem(key)
 
     cdef _getitem(self, str key):
@@ -98,7 +98,7 @@ cdef class MultiDict:
                 return v
         raise KeyError(key)
 
-    def get(self, key, default=None):
+    def get(self, str key, default=None):
         return self._get(key, default)
 
     cdef _get(self, str key, default):
@@ -108,7 +108,7 @@ cdef class MultiDict:
                 return v
         return default
 
-    def __contains__(self, key):
+    def __contains__(self, str key):
         return self._contains(key)
 
     cdef _contains(self, str key):
@@ -203,19 +203,19 @@ cdef class CaseInsensitiveMultiDict(MultiDict):
     cdef _add(self, tuple item):
         self._items.append((item[0].upper(), item[1]))
 
-    def getall(self, key, default=_marker):
+    def getall(self, str key, default=_marker):
         return self._getall(key.upper(), default)
 
-    def getone(self, key, default=_marker):
+    def getone(self, str key, default=_marker):
         return self._getone(key.upper(), default)
 
-    def get(self, key, default=None):
+    def get(self, str key, default=None):
         return self._get(key.upper(), default)
 
-    def __getitem__(self, key):
+    def __getitem__(self, str key):
         return self._getitem(key.upper())
 
-    def __contains__(self, key):
+    def __contains__(self, str key):
         return self._contains(key.upper())
 
 
@@ -225,7 +225,7 @@ abc.Mapping.register(CaseInsensitiveMultiDict)
 cdef class MutableMultiDict(MultiDict):
     """An ordered dictionary that can have multiple values for each key."""
 
-    def add(self, key, value):
+    def add(self, str key, value):
         """
         Add the key and value, not overwriting any previous value.
         """
@@ -244,14 +244,14 @@ cdef class MutableMultiDict(MultiDict):
 
     # MutableMapping interface #
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, str key, value):
         self._delitem(key, False)
         self._add((key, value))
 
-    def __delitem__(self, key):
+    def __delitem__(self, str key):
         self._delitem(key, True)
 
-    def setdefault(self, key, default=None):
+    def setdefault(self, str key, default=None):
         for k, v in self._items:
             if k == key:
                 return v
@@ -277,7 +277,7 @@ abc.MutableMapping.register(MutableMultiDict)
 cdef class CaseInsensitiveMutableMultiDict(CaseInsensitiveMultiDict):
     """An ordered dictionary that can have multiple values for each key."""
 
-    def add(self, key, value):
+    def add(self, str key, value):
         """
         Add the key and value, not overwriting any previous value.
         """
@@ -296,15 +296,15 @@ cdef class CaseInsensitiveMutableMultiDict(CaseInsensitiveMultiDict):
 
     # MutableMapping interface #
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, str key, value):
         key = key.upper()
         self._delitem(key, False)
         self._add((key, value))
 
-    def __delitem__(self, key):
+    def __delitem__(self, str key):
         self._delitem(key.upper(), True)
 
-    def setdefault(self, key, default=None):
+    def setdefault(self, str key, default=None):
         key = key.upper()
         for k, v in self._items:
             if k == key:
@@ -312,7 +312,7 @@ cdef class CaseInsensitiveMutableMultiDict(CaseInsensitiveMultiDict):
         self._add((key, default))
         return default
 
-    def pop(self, key, default=None):
+    def pop(self, str key, default=None):
         """Method not allowed."""
         raise NotImplementedError
 

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -70,10 +70,10 @@ cdef class MultiDict:
         return self._getone(key, default)
 
     cdef _getone(self, str key, default):
-        cdef str k
-        for k, v in self._items:
-            if k == key:
-                return v
+        cdef tuple item
+        for item in self._items:
+            if item[0] == key:
+                return item[1]
         if default is not _marker:
             return default
         raise KeyError('Key not found: %r' % key)
@@ -404,13 +404,6 @@ cdef class _ViewBaseSet(_ViewBase):
             return NotImplemented
         return set(value for value in other if value in self)
 
-    def isdisjoint(self, other):
-        'Return True if two sets have a null intersection.'
-        for value in other:
-            if value in self:
-                return False
-        return True
-
     def __or__(self, other):
         if not isinstance(other, Iterable):
             return NotImplemented
@@ -433,6 +426,14 @@ cdef class _ViewBaseSet(_ViewBase):
 
 
 cdef class _ItemsView(_ViewBaseSet):
+
+    def isdisjoint(self, other):
+        'Return True if two sets have a null intersection.'
+        cdef tuple value
+        for value in self._items:
+            if value in other:
+                return False
+        return True
 
     def __contains__(self, item):
         assert isinstance(item, tuple) or isinstance(item, list)
@@ -463,6 +464,14 @@ abc.ValuesView.register(_ValuesView)
 
 
 cdef class _KeysView(_ViewBaseSet):
+
+    def isdisjoint(self, other):
+        'Return True if two sets have a null intersection.'
+        cdef str value
+        for value in self._keys:
+            if value in other:
+                return False
+        return True
 
     def __contains__(self, key):
         return key in self._keys

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -118,14 +118,14 @@ cdef class MultiDict:
                 return True
         return False
 
-    cdef _delitem(self, key):
+    cdef _delitem(self, str key, int raise_key_error):
         cdef int found
         found = False
         for i in range(len(self._items) - 1, -1, -1):
             if self._items[i][0] == key:
                 del self._items[i]
                 found = True
-        if not found:
+        if not found and raise_key_error:
             raise KeyError(key)
 
     def __iter__(self):
@@ -245,14 +245,11 @@ cdef class MutableMultiDict(MultiDict):
     # MutableMapping interface #
 
     def __setitem__(self, key, value):
-        try:
-            self._delitem(key)
-        except KeyError:
-            pass
+        self._delitem(key, False)
         self._add((key, value))
 
     def __delitem__(self, key):
-        self._delitem(key)
+        self._delitem(key, True)
 
     def setdefault(self, key, default=None):
         for k, v in self._items:
@@ -301,14 +298,11 @@ cdef class CaseInsensitiveMutableMultiDict(CaseInsensitiveMultiDict):
 
     def __setitem__(self, key, value):
         key = key.upper()
-        try:
-            self._delitem(key)
-        except KeyError:
-            pass
+        self._delitem(key, False)
         self._add((key, value))
 
     def __delitem__(self, key):
-        self._delitem(key.upper())
+        self._delitem(key.upper(), True)
 
     def setdefault(self, key, default=None):
         key = key.upper()

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -22,7 +22,7 @@ def _unique_everseen(iterable):
         yield element
 
 
-class _MultiDict(abc.Mapping):
+class MultiDict(abc.Mapping):
     """Read-only ordered dictionary that can have multiple values for each key.
 
     This type of MultiDict must be used for request headers and query args.
@@ -88,6 +88,12 @@ class _MultiDict(abc.Mapping):
                 return v
         raise KeyError(key)
 
+    def xget(self, key, default=None):
+        for k, v in self._items:
+            if k == key:
+                return v
+        return default
+
     def __iter__(self):
         return iter(self.keys())
 
@@ -106,7 +112,7 @@ class _MultiDict(abc.Mapping):
     def __eq__(self, other):
         if not isinstance(other, abc.Mapping):
             return NotImplemented
-        if isinstance(other, _MultiDict):
+        if isinstance(other, MultiDict):
             return self._items == other._items
         return dict(self.items()) == dict(other.items())
 
@@ -123,7 +129,7 @@ class _MultiDict(abc.Mapping):
         )
 
 
-class _CaseInsensitiveMultiDict(_MultiDict):
+class CaseInsensitiveMultiDict(MultiDict):
     """Case insensitive multi dict."""
 
     @classmethod
@@ -168,7 +174,7 @@ class MutableMultiDictMixin(abc.MutableMapping):
             raise TypeError("extend takes at most 2 positional arguments"
                             " ({} given)".format(len(args) + 1))
         if args:
-            if isinstance(args[0], _MultiDict):
+            if isinstance(args[0], MultiDict):
                 items = args[0].items(getall=True)
             elif hasattr(args[0], 'items'):
                 items = args[0].items()
@@ -222,12 +228,12 @@ class MutableMultiDictMixin(abc.MutableMapping):
         raise NotImplementedError("Use extend method instead")
 
 
-class _MutableMultiDict(MutableMultiDictMixin, _MultiDict):
+class MutableMultiDict(MutableMultiDictMixin, MultiDict):
     """An ordered dictionary that can have multiple values for each key."""
 
 
-class _CaseInsensitiveMutableMultiDict(
-        MutableMultiDictMixin, _CaseInsensitiveMultiDict):
+class CaseInsensitiveMutableMultiDict(
+        MutableMultiDictMixin, CaseInsensitiveMultiDict):
     """An ordered dictionary that can have multiple values for each key."""
 
     def add(self, key, value):
@@ -293,15 +299,3 @@ class _KeysView(_ViewBase, abc.KeysView):
 
     def __iter__(self):
         yield from self._keys
-
-
-try:
-    from ._multidict import (MultiDict,
-                             CaseInsensitiveMultiDict,
-                             MutableMultiDict,
-                             CaseInsensitiveMutableMultiDict)
-except ImportError:
-    MultiDict = _MultiDict
-    CaseInsensitiveMultiDict = _CaseInsensitiveMultiDict
-    MutableMultiDict = _MutableMultiDict
-    CaseInsensitiveMutableMultiDict = _CaseInsensitiveMutableMultiDict

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -52,6 +52,10 @@ cdef class MultiDict:
         """
         Return a list of all values matching the key (may be an empty list)
         """
+        return self._getall(key, default)
+
+    cdef _getall(self, key, default):
+        cdef tuple res
         res = tuple(v for k, v in self._items if k == key)
         if res:
             return res
@@ -63,6 +67,10 @@ cdef class MultiDict:
         """
         Get first value matching the key
         """
+        return self._getone(key, default)
+
+    cdef _getone(self, str key, default):
+        cdef str k
         for k, v in self._items:
             if k == key:
                 return v
@@ -80,16 +88,35 @@ cdef class MultiDict:
     # Mapping interface #
 
     def __getitem__(self, key):
+        return self._getitem(key)
+
+    cdef _getitem(self, str key):
+        cdef str k
+
         for k, v in self._items:
             if k == key:
                 return v
         raise KeyError(key)
 
     def get(self, key, default=None):
+        return self._get(key, default)
+
+    cdef _get(self, str key, default):
+        cdef str k
         for k, v in self._items:
             if k == key:
                 return v
         return default
+
+    def __contains__(self, key):
+        return self._contains(key)
+
+    cdef _contains(self, str key):
+        cdef str k
+        for k, v in self._items:
+            if k == key:
+                return True
+        return False
 
     def __iter__(self):
         return iter(self.keys())
@@ -134,12 +161,6 @@ cdef class MultiDict:
         else:
             return NotImplemented
 
-    def __contains__(self, key):
-        for k, v in self._items:
-            if k == key:
-                return True
-        return False
-
     def __repr__(self):
         return '<{}>\n{}'.format(
             self.__class__.__name__, pprint.pformat(
@@ -165,19 +186,19 @@ cdef class CaseInsensitiveMultiDict(MultiDict):
         self._items.append((item[0].upper(), item[1]))
 
     def getall(self, key, default=_marker):
-        return super().getall(key.upper(), default)
+        return self._getall(key.upper(), default)
 
     def getone(self, key, default=_marker):
-        return super().getone(key.upper(), default)
+        return self._getone(key.upper(), default)
 
     def get(self, key, default=None):
-        return super().get(key.upper(), default)
+        return self._get(key.upper(), default)
 
     def __getitem__(self, key):
-        return super().__getitem__(key.upper())
+        return self._getitem(key.upper())
 
     def __contains__(self, key):
-        return super().__contains__(key.upper())
+        return self._contains(key.upper())
 
 
 abc.Mapping.register(CaseInsensitiveMultiDict)

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -15,23 +15,27 @@ cdef class MultiDict:
     cdef list _items
 
     def __init__(self, *args, **kwargs):
-        cdef tuple item
-        if len(args) > 1:
-            raise TypeError("MultiDict takes at most 1 positional "
-                            "argument ({} given)".format(len(args)))
-
         self._items = []
+
+        self._extend(args, kwargs, self.__class__.__name__)
+
+    cdef _extend(self, tuple args, dict kwargs, str name):
+        cdef tuple item
+
+        if len(args) > 1:
+            raise TypeError("{} takes at most 1 positional argument"
+                            " ({} given)".format(name, len(args)))
+
         if args:
             if hasattr(args[0], 'items'):
                 for item in args[0].items():
                     self._add(item)
             else:
-                args = args[0]
-                for arg in args:
+                for arg in args[0]:
                     if not len(arg) == 2:
                         raise TypeError(
                             "{} takes either dict or list of (key, value) "
-                            "tuples".format(self.__class__.__name__))
+                            "tuples".format(name))
                     if not isinstance(arg, tuple):
                         item = tuple(arg)
                     else:
@@ -190,24 +194,7 @@ cdef class MutableMultiDict(MultiDict):
 
         This method must be used instead of update.
         """
-        if len(args) > 1:
-            raise TypeError("extend takes at most 2 positional arguments"
-                            " ({} given)".format(len(args) + 1))
-        if args:
-            if isinstance(args[0], MultiDict):
-                items = args[0].items(getall=True)
-            elif hasattr(args[0], 'items'):
-                items = args[0].items()
-            else:
-                items = args[0]
-        else:
-            items = []
-
-        for item in items:
-            self._add(item)
-
-        for item in kwargs.items():
-            self._add(item)
+        self._extend(args, kwargs, "extend")
 
     def clear(self):
         """Remove all items from MutableMultiDict"""
@@ -269,24 +256,7 @@ cdef class CaseInsensitiveMutableMultiDict(CaseInsensitiveMultiDict):
 
         This method must be used instead of update.
         """
-        if len(args) > 1:
-            raise TypeError("extend takes at most 2 positional arguments"
-                            " ({} given)".format(len(args) + 1))
-        if args:
-            if isinstance(args[0], MultiDict):
-                items = args[0].items(getall=True)
-            elif hasattr(args[0], 'items'):
-                items = args[0].items()
-            else:
-                items = args[0]
-        else:
-            items = []
-
-        for item in items:
-            self._add(item)
-
-        for item in kwargs.items():
-            self._add(item)
+        self._extend(args, kwargs, "extend")
 
     def clear(self):
         """Remove all items from MutableMultiDict"""

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -246,7 +246,7 @@ cdef class MutableMultiDict(MultiDict):
 
     def __setitem__(self, key, value):
         try:
-            del self[key]
+            self._delitem(key)
         except KeyError:
             pass
         self._add((key, value))
@@ -302,7 +302,7 @@ cdef class CaseInsensitiveMutableMultiDict(CaseInsensitiveMultiDict):
     def __setitem__(self, key, value):
         key = key.upper()
         try:
-            del self[key]
+            self._delitem(key)
         except KeyError:
             pass
         self._add((key, value))

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -354,28 +354,28 @@ abc.MutableMapping.register(CaseInsensitiveMutableMultiDict)
 
 cdef class _ViewBase:
 
-    cdef int _getall
     cdef list _keys
     cdef list _items
 
     def __init__(self, list items, int getall=False):
-        self._getall = getall
-        self._keys = [item[0] for item in items]
-        if not getall:
-            self._keys = list(_unique_everseen(self._keys))
+        cdef list items_to_use
+        cdef str key
+        cdef set keys
 
-        items_to_use = []
         if getall:
-            items_to_use = items
+            self._items = items
+            self._keys = [item[0] for item in items]
         else:
-            for key in self._keys:
-                for k, v in items:
-                    if k == key:
-                        items_to_use.append((k, v))
-                        break
-        assert len(items_to_use) == len(self._keys)
-
-        self._items = items_to_use
+            self._items = []
+            keys = set()
+            self._keys = []
+            for i in items:
+                key = i[0]
+                if key in keys:
+                    continue
+                keys.add(key)
+                self._keys.append(key)
+                self._items.append(i)
 
 
 cdef class _ItemsView(_ViewBase):

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -194,7 +194,7 @@ abc.Mapping.register(CaseInsensitiveMultiDict)
 cdef class MutableMultiDict(MultiDict):
     """An ordered dictionary that can have multiple values for each key."""
 
-    def add(self, key, value):
+    cpdef add(self, key, value):
         """
         Add the key and value, not overwriting any previous value.
         """
@@ -273,7 +273,7 @@ abc.MutableMapping.register(MutableMultiDict)
 cdef class CaseInsensitiveMutableMultiDict(CaseInsensitiveMultiDict):
     """An ordered dictionary that can have multiple values for each key."""
 
-    def add(self, key, value):
+    cpdef add(self, key, value):
         """
         Add the key and value, not overwriting any previous value.
         """
@@ -358,7 +358,7 @@ cdef class _ViewBase:
     cdef list _keys
     cdef list _items
 
-    def __init__(self, items, *, getall=False):
+    def __init__(self, list items, int getall=False):
         self._getall = getall
         self._keys = [item[0] for item in items]
         if not getall:

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -22,7 +22,7 @@ def _unique_everseen(iterable):
         yield element
 
 
-class MultiDict(abc.Mapping):
+class MultiDict:
     """Read-only ordered dictionary that can have multiple values for each key.
 
     This type of MultiDict must be used for request headers and query args.
@@ -129,6 +129,9 @@ class MultiDict(abc.Mapping):
         )
 
 
+abc.Mapping.register(MultiDict)
+
+
 class CaseInsensitiveMultiDict(MultiDict):
     """Case insensitive multi dict."""
 
@@ -160,7 +163,10 @@ class CaseInsensitiveMultiDict(MultiDict):
         return super().__contains__(key.upper())
 
 
-class MutableMultiDictMixin(abc.MutableMapping):
+abc.Mapping.register(CaseInsensitiveMultiDict)
+
+
+class MutableMultiDictMixin:
 
     def add(self, key, value):
         """
@@ -231,8 +237,13 @@ class MutableMultiDictMixin(abc.MutableMapping):
         raise NotImplementedError("Use extend method instead")
 
 
+
+
 class MutableMultiDict(MutableMultiDictMixin, MultiDict):
     """An ordered dictionary that can have multiple values for each key."""
+
+
+abc.MutableMapping.register(MutableMultiDict)
 
 
 class CaseInsensitiveMutableMultiDict(
@@ -247,6 +258,9 @@ class CaseInsensitiveMutableMultiDict(
 
     def __delitem__(self, key):
         super().__delitem__(key.upper())
+
+
+abc.MutableMapping.register(CaseInsensitiveMutableMultiDict)
 
 
 class _ViewBase:

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -118,6 +118,16 @@ cdef class MultiDict:
                 return True
         return False
 
+    cdef _delitem(self, key):
+        cdef int found
+        found = False
+        for i in range(len(self._items) - 1, -1, -1):
+            if self._items[i][0] == key:
+                del self._items[i]
+                found = True
+        if not found:
+            raise KeyError(key)
+
     def __iter__(self):
         return iter(self.keys())
 
@@ -242,14 +252,7 @@ cdef class MutableMultiDict(MultiDict):
         self._add((key, value))
 
     def __delitem__(self, key):
-        items = self._items
-        found = False
-        for i in range(len(items) - 1, -1, -1):
-            if items[i][0] == key:
-                del items[i]
-                found = True
-        if not found:
-            raise KeyError(key)
+        self._delitem(key)
 
     def setdefault(self, key, default=None):
         for k, v in self._items:
@@ -305,15 +308,7 @@ cdef class CaseInsensitiveMutableMultiDict(CaseInsensitiveMultiDict):
         self._add((key, value))
 
     def __delitem__(self, key):
-        key = key.upper()
-        items = self._items
-        found = False
-        for i in range(len(items) - 1, -1, -1):
-            if items[i][0] == key:
-                del items[i]
-                found = True
-        if not found:
-            raise KeyError(key)
+        self._delitem(key.upper())
 
     def setdefault(self, key, default=None):
         key = key.upper()

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -2,8 +2,6 @@ import pprint
 from itertools import filterfalse
 from collections import abc
 
-__all__ = ['MultiDict', 'CaseInsensitiveMultiDict',
-           'MutableMultiDict', 'CaseInsensitiveMutableMultiDict']
 
 _marker = object()
 
@@ -60,7 +58,7 @@ cdef class MultiDict:
         """
         Return a list of all values matching the key (may be an empty list)
         """
-        res = tuple([v for k, v in self._items if k == key])
+        res = tuple(v for k, v in self._items if k == key)
         if res:
             return res
         if not res and default is not _marker:

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -154,9 +154,12 @@ cdef class CaseInsensitiveMultiDict(MultiDict):
     """Case insensitive multi dict."""
 
     @classmethod
-    def _from_uppercase_multidict(cls, dct):
+    def _from_uppercase_multidict(cls, MultiDict dct):
         # NB: doesn't check for uppercase keys!
-        return cls(dct)
+        cdef CaseInsensitiveMultiDict ret
+        ret = cls.__new__(cls)
+        ret._items = dct._items
+        return ret
 
     cdef _add(self, tuple item):
         self._items.append((item[0].upper(), item[1]))

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -1,6 +1,6 @@
 import pprint
 from collections import abc
-from collections.abc import Set
+from collections.abc import Iterable, Set
 
 
 _marker = object()
@@ -402,6 +402,38 @@ cdef class _ViewBaseSet(_ViewBase):
                 if elem not in self:
                     return False
             return True
+
+    def __and__(self, other):
+        if not isinstance(other, Iterable):
+            return NotImplemented
+        return set(value for value in other if value in self)
+
+    def isdisjoint(self, other):
+        'Return True if two sets have a null intersection.'
+        for value in other:
+            if value in self:
+                return False
+        return True
+
+    def __or__(self, other):
+        if not isinstance(other, Iterable):
+            return NotImplemented
+        return {e for s in (self, other) for e in s}
+
+    def __sub__(self, other):
+        if not isinstance(other, Set):
+            if not isinstance(other, Iterable):
+                return NotImplemented
+            other = set(other)
+        return {value for value in self
+                if value not in other}
+
+    def __xor__(self, other):
+        if not isinstance(other, Set):
+            if not isinstance(other, Iterable):
+                return NotImplemented
+            other = set(other)
+        return (self - other) | (other - self)
 
 
 cdef class _ItemsView(_ViewBaseSet):

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -154,19 +154,19 @@ cdef class MultiDict:
     def __len__(self):
         return len(self._items)
 
-    def keys(self, *, getall=False):
+    def keys(self, *, getall=True):
         return self._keys_view(getall)
 
     cdef _KeysView _keys_view(self, getall):
         return _KeysView.__new__(_KeysView, self._items, getall)
 
-    def items(self, *, getall=False):
+    def items(self, *, getall=True):
         return self._items_view(getall)
 
     cdef _ItemsView _items_view(self, getall):
         return _ItemsView.__new__(_ItemsView, self._items, getall)
 
-    def values(self, *, getall=False):
+    def values(self, *, getall=True):
         return self._values_view(getall)
 
     cdef _ValuesView _values_view(self, getall):

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -352,7 +352,11 @@ cdef class CaseInsensitiveMutableMultiDict(CaseInsensitiveMultiDict):
 abc.MutableMapping.register(CaseInsensitiveMutableMultiDict)
 
 
-class _ViewBase:
+cdef class _ViewBase:
+
+    cdef int _getall
+    cdef list _keys
+    cdef list _items
 
     def __init__(self, items, *, getall=False):
         self._getall = getall
@@ -371,37 +375,46 @@ class _ViewBase:
                         break
         assert len(items_to_use) == len(self._keys)
 
-        super().__init__(items_to_use)
+        self._items = items_to_use
 
 
-class _ItemsView(_ViewBase, abc.ItemsView):
+cdef class _ItemsView(_ViewBase):
 
     def __contains__(self, item):
         assert isinstance(item, tuple) or isinstance(item, list)
         assert len(item) == 2
-        return item in self._mapping
+        return item in self._items
 
     def __iter__(self):
-        yield from self._mapping
+        yield from self._items
 
 
-class _ValuesView(_ViewBase, abc.ValuesView):
+abc.ItemsView.register(_ItemsView)
+
+
+cdef class _ValuesView(_ViewBase):
 
     def __contains__(self, value):
-        for item in self._mapping:
+        for item in self._items:
             if item[1] == value:
                 return True
         return False
 
     def __iter__(self):
-        for item in self._mapping:
+        for item in self._items:
             yield item[1]
 
 
-class _KeysView(_ViewBase, abc.KeysView):
+abc.ValuesView.register(_ValuesView)
+
+
+cdef class _KeysView(_ViewBase):
 
     def __contains__(self, key):
         return key in self._keys
 
     def __iter__(self):
         yield from self._keys
+
+
+abc.KeysView.register(_KeysView)

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -88,7 +88,7 @@ class MultiDict(abc.Mapping):
                 return v
         raise KeyError(key)
 
-    def xget(self, key, default=None):
+    def get(self, key, default=None):
         for k, v in self._items:
             if k == key:
                 return v
@@ -149,6 +149,9 @@ class CaseInsensitiveMultiDict(MultiDict):
 
     def getone(self, key, default=_marker):
         return super().getone(key.upper(), default)
+
+    def get(self, key, default=None):
+        return super().get(key.upper(), default)
 
     def __getitem__(self, key):
         return super().__getitem__(key.upper())

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -288,7 +288,7 @@ class ClientRequest:
         if isinstance(params, dict):
             params = list(params.items())
         elif isinstance(params, MultiDict):
-            params = list(params.items(getall=True))
+            params = list(params.items())
 
         if params:
             params = urllib.parse.urlencode(params)
@@ -307,7 +307,7 @@ class ClientRequest:
             if isinstance(headers, dict):
                 headers = headers.items()
             elif isinstance(headers, MultiDict):
-                headers = headers.items(getall=True)
+                headers = headers.items()
 
             for key, value in headers:
                 self.headers.add(key.upper(), value)
@@ -558,7 +558,7 @@ class ClientRequest:
         request.add_headers(
             *((k, v)
               for k, v in ((k, value)
-                           for k, value in self.headers.items(getall=True))))
+                           for k, value in self.headers.items())))
         request.send_headers()
 
         self._writer = asyncio.async(
@@ -664,7 +664,7 @@ class ClientResponse:
 
         # headers
         self.headers = CaseInsensitiveMultiDict(
-            self.message.headers.items(getall=True))
+            self.message.headers.items())
 
         # payload
         response_with_body = self.method.lower() != 'head'

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -41,7 +41,7 @@ class FormData:
     application/x-www-form-urlencoded body generation."""
 
     CONTENT_TYPE_ID = multidict.cistr('Content-Type')
-    CONTENT_TRANSFER_ENCODING = multidict.cistr('Content-Transfer-Encoding')
+    CONTENT_TRANSFER_ENCODING_ID = multidict.cistr('Content-Transfer-Encoding')
 
     def __init__(self, fields=()):
         self._fields = []
@@ -83,7 +83,8 @@ class FormData:
             headers[self.CONTENT_TYPE_ID] = content_type
             self._is_multipart = True
         if content_transfer_encoding is not None:
-            headers[self.CONTENT_TRANSFER_ENCODING] = content_transfer_encoding
+            CTE = self.CONTENT_TRANSFER_ENCODING_ID
+            headers[CTE] = content_transfer_encoding
             self._is_multipart = True
             supported_tranfer_encoding = {
                 'base64': binascii.b2a_base64,

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -40,6 +40,9 @@ class FormData:
     """Helper class for multipart/form-data and
     application/x-www-form-urlencoded body generation."""
 
+    CONTENT_TYPE_ID = multidict.cistr('Content-Type')
+    CONTENT_TRANSFER_ENCODING = multidict.cistr('Content-Transfer-Encoding')
+
     def __init__(self, fields=()):
         self._fields = []
         self._is_multipart = False
@@ -77,10 +80,10 @@ class FormData:
 
         headers = {}
         if content_type is not None:
-            headers['Content-Type'] = content_type
+            headers[self.CONTENT_TYPE_ID] = content_type
             self._is_multipart = True
         if content_transfer_encoding is not None:
-            headers['Content-Transfer-Encoding'] = content_transfer_encoding
+            headers[self.CONTENT_TRANSFER_ENCODING] = content_transfer_encoding
             self._is_multipart = True
             supported_tranfer_encoding = {
                 'base64': binascii.b2a_base64,

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -107,7 +107,7 @@ class FormData:
                 self.add_field(k, rec)
 
             elif isinstance(rec, multidict.MultiDict):
-                to_add.extend(rec.items(getall=True))
+                to_add.extend(rec.items())
 
             elif isinstance(rec, (list, tuple)) and len(rec) == 2:
                 k, fp = rec

--- a/aiohttp/multidict.py
+++ b/aiohttp/multidict.py
@@ -55,7 +55,7 @@ class _MultiDict(abc.Mapping):
         """
         Return a list of all values matching the key (may be an empty list)
         """
-        res = tuple([v for k, v in self._items if k == key])
+        res = tuple(v for k, v in self._items if k == key)
         if res:
             return res
         if not res and default is not _marker:

--- a/aiohttp/multidict.py
+++ b/aiohttp/multidict.py
@@ -1,11 +1,32 @@
 import pprint
 from itertools import chain
 from collections import abc
+import sys
 
 __all__ = ['MultiDict', 'CaseInsensitiveMultiDict',
            'MutableMultiDict', 'CaseInsensitiveMutableMultiDict']
 
 _marker = object()
+
+
+class _cistr(str):
+    """Case insensitive str"""
+
+    def __new__(cls, val='',
+                encoding=sys.getdefaultencoding(), errors='strict'):
+        if isinstance(val, (bytes, bytearray, memoryview)):
+            val = str(val, encoding, errors)
+        elif isinstance(val, str):
+            pass
+        elif hasattr(val, '__str__'):
+            val = val.__str__()
+        else:
+            val = repr(val)
+        val = val.upper()
+        return str.__new__(cls, val)
+
+    def upper(self):
+        return self
 
 
 class _MultiDict(abc.Mapping):
@@ -302,9 +323,11 @@ try:
     from ._multidict import (MultiDict,
                              CaseInsensitiveMultiDict,
                              MutableMultiDict,
-                             CaseInsensitiveMutableMultiDict)
+                             CaseInsensitiveMutableMultiDict,
+                             cistr)
 except ImportError:
     MultiDict = _MultiDict
     CaseInsensitiveMultiDict = _CaseInsensitiveMultiDict
     MutableMultiDict = _MutableMultiDict
     CaseInsensitiveMutableMultiDict = _CaseInsensitiveMutableMultiDict
+    cistr = _cistr

--- a/aiohttp/multidict.py
+++ b/aiohttp/multidict.py
@@ -114,7 +114,11 @@ class _MultiDict(abc.Mapping):
             return NotImplemented
         if isinstance(other, _MultiDict):
             return self._items == other._items
-        return dict(self.items()) == dict(other.items())
+        for k, v in self.items(getall=True):
+            nv = other.get(k, _marker)
+            if v != nv:
+                return False
+        return True
 
     def __contains__(self, key):
         for k, v in self._items:

--- a/aiohttp/multidict.py
+++ b/aiohttp/multidict.py
@@ -85,7 +85,7 @@ class _MultiDict(abc.Mapping):
     def copy(self):
         """Returns a copy itself."""
         cls = self.__class__
-        return cls(self.items(getall=True))
+        return cls(self.items())
 
     # Mapping interface #
 
@@ -107,13 +107,13 @@ class _MultiDict(abc.Mapping):
     def __len__(self):
         return len(self._items)
 
-    def keys(self, *, getall=False):
+    def keys(self, *, getall=True):
         return _KeysView(self._items, getall=getall)
 
-    def items(self, *, getall=False):
+    def items(self, *, getall=True):
         return _ItemsView(self._items, getall=getall)
 
-    def values(self, *, getall=False):
+    def values(self, *, getall=True):
         return _ValuesView(self._items, getall=getall)
 
     def __eq__(self, other):
@@ -121,7 +121,7 @@ class _MultiDict(abc.Mapping):
             return NotImplemented
         if isinstance(other, _MultiDict):
             return self._items == other._items
-        for k, v in self.items(getall=True):
+        for k, v in self.items():
             nv = other.get(k, _marker)
             if v != nv:
                 return False
@@ -136,7 +136,7 @@ class _MultiDict(abc.Mapping):
     def __repr__(self):
         return '<{}>\n{}'.format(
             self.__class__.__name__, pprint.pformat(
-                list(self.items(getall=True)))
+                list(self.items()))
         )
 
 
@@ -189,7 +189,7 @@ class MutableMultiDictMixin(abc.MutableMapping):
                             " ({} given)".format(len(args) + 1))
         if args:
             if isinstance(args[0], _MultiDict):
-                items = args[0].items(getall=True)
+                items = args[0].items()
             elif hasattr(args[0], 'items'):
                 items = args[0].items()
             else:
@@ -264,7 +264,7 @@ class _ViewBase:
 
     __slots__ = ('_keys', '_items')
 
-    def __init__(self, items, *, getall=False):
+    def __init__(self, items, getall):
         if getall:
             items_to_use = items
             self._keys = [item[0] for item in items]

--- a/aiohttp/multidict.py
+++ b/aiohttp/multidict.py
@@ -88,6 +88,12 @@ class _MultiDict(abc.Mapping):
                 return v
         raise KeyError(key)
 
+    def get(self, key, default=None):
+        for k, v in self._items:
+            if k == key:
+                return v
+        return default
+
     def __iter__(self):
         return iter(self.keys())
 
@@ -143,6 +149,9 @@ class _CaseInsensitiveMultiDict(_MultiDict):
 
     def getone(self, key, default=_marker):
         return super().getone(key.upper(), default)
+
+    def get(self, key, default=None):
+        return super().get(key.upper(), default)
 
     def __getitem__(self, key):
         return super().__getitem__(key.upper())

--- a/aiohttp/multidict.py
+++ b/aiohttp/multidict.py
@@ -22,7 +22,7 @@ def _unique_everseen(iterable):
         yield element
 
 
-class MultiDict(abc.Mapping):
+class _MultiDict(abc.Mapping):
     """Read-only ordered dictionary that can have multiple values for each key.
 
     This type of MultiDict must be used for request headers and query args.
@@ -106,7 +106,7 @@ class MultiDict(abc.Mapping):
     def __eq__(self, other):
         if not isinstance(other, abc.Mapping):
             return NotImplemented
-        if isinstance(other, MultiDict):
+        if isinstance(other, _MultiDict):
             return self._items == other._items
         return dict(self.items()) == dict(other.items())
 
@@ -123,7 +123,7 @@ class MultiDict(abc.Mapping):
         )
 
 
-class CaseInsensitiveMultiDict(MultiDict):
+class _CaseInsensitiveMultiDict(_MultiDict):
     """Case insensitive multi dict."""
 
     @classmethod
@@ -168,7 +168,7 @@ class MutableMultiDictMixin(abc.MutableMapping):
             raise TypeError("extend takes at most 2 positional arguments"
                             " ({} given)".format(len(args) + 1))
         if args:
-            if isinstance(args[0], MultiDict):
+            if isinstance(args[0], _MultiDict):
                 items = args[0].items(getall=True)
             elif hasattr(args[0], 'items'):
                 items = args[0].items()
@@ -215,12 +215,12 @@ class MutableMultiDictMixin(abc.MutableMapping):
         raise NotImplementedError("Use extend method instead")
 
 
-class MutableMultiDict(MutableMultiDictMixin, MultiDict):
+class _MutableMultiDict(MutableMultiDictMixin, _MultiDict):
     """An ordered dictionary that can have multiple values for each key."""
 
 
-class CaseInsensitiveMutableMultiDict(
-        MutableMultiDictMixin, CaseInsensitiveMultiDict):
+class _CaseInsensitiveMutableMultiDict(
+        MutableMultiDictMixin, _CaseInsensitiveMultiDict):
     """An ordered dictionary that can have multiple values for each key."""
 
     def add(self, key, value):
@@ -286,3 +286,15 @@ class _KeysView(_ViewBase, abc.KeysView):
 
     def __iter__(self):
         yield from self._keys
+
+
+try:
+    from _multidict import (MultiDict,
+                            CaseInsensitiveMultiDict,
+                            MutableMultiDict,
+                            CaseInsensitiveMutableMultiDict)
+except ImportError:
+    MultiDict = _MultiDict
+    CaseInsensitiveMultiDict = _CaseInsensitiveMultiDict
+    MutableMultiDict = _MutableMultiDict
+    CaseInsensitiveMutableMultiDict = _CaseInsensitiveMutableMultiDict

--- a/aiohttp/protocol.py
+++ b/aiohttp/protocol.py
@@ -641,7 +641,7 @@ class HttpMessage:
             (self.status_line,),
             *((k, ': ', v, '\r\n')
               for k, v in ((k, value)
-                           for k, value in self.headers.items(getall=True)))))
+                           for k, value in self.headers.items()))))
         hdrs = hdrs.encode('utf-8') + b'\r\n'
 
         self.output_length += len(hdrs)

--- a/aiohttp/protocol.py
+++ b/aiohttp/protocol.py
@@ -257,7 +257,7 @@ class HttpPayloadParser:
 
     CONTENT_LENGTH_ID = multidict.cistr('CONTENT-LENGTH')
     SEC_WEBSOCKET_KEY1_ID = multidict.cistr('SEC-WEBSOCKET-KEY1')
-    TRANSFER_ENCODING = multidict.cistr('TRANSFER-ENCODING')
+    TRANSFER_ENCODING_ID = multidict.cistr('TRANSFER-ENCODING')
 
     def __init__(self, message, length=None, compression=True,
                  readall=False, response_with_body=True):
@@ -283,7 +283,7 @@ class HttpPayloadParser:
             pass
 
         elif 'chunked' in self.message.headers.get(
-                self.TRANSFER_ENCODING, ''):
+                self.TRANSFER_ENCODING_ID, ''):
             yield from self.parse_chunked_payload(out, buf)
 
         elif length is not None:

--- a/aiohttp/protocol.py
+++ b/aiohttp/protocol.py
@@ -255,6 +255,10 @@ class HttpResponseParser(HttpParser):
 
 class HttpPayloadParser:
 
+    CONTENT_LENGTH_ID = multidict.cistr('CONTENT-LENGTH')
+    SEC_WEBSOCKET_KEY1_ID = multidict.cistr('SEC-WEBSOCKET-KEY1')
+    TRANSFER_ENCODING = multidict.cistr('TRANSFER-ENCODING')
+
     def __init__(self, message, length=None, compression=True,
                  readall=False, response_with_body=True):
         self.message = message
@@ -265,8 +269,8 @@ class HttpPayloadParser:
 
     def __call__(self, out, buf):
         # payload params
-        length = self.message.headers.get('CONTENT-LENGTH', self.length)
-        if 'SEC-WEBSOCKET-KEY1' in self.message.headers:
+        length = self.message.headers.get(self.CONTENT_LENGTH_ID, self.length)
+        if self.SEC_WEBSOCKET_KEY1_ID in self.message.headers:
             length = 8
 
         # payload decompression wrapper
@@ -278,17 +282,18 @@ class HttpPayloadParser:
             # don't parse payload if it's not expected to be received
             pass
 
-        elif 'chunked' in self.message.headers.get('TRANSFER-ENCODING', ''):
+        elif 'chunked' in self.message.headers.get(
+                self.TRANSFER_ENCODING, ''):
             yield from self.parse_chunked_payload(out, buf)
 
         elif length is not None:
             try:
                 length = int(length)
             except ValueError:
-                raise errors.InvalidHeader('CONTENT-LENGTH') from None
+                raise errors.InvalidHeader(self.CONTENT_LENGTH_ID) from None
 
             if length < 0:
-                raise errors.InvalidHeader('CONTENT-LENGTH')
+                raise errors.InvalidHeader(self.CONTENT_LENGTH_ID)
             elif length > 0:
                 yield from self.parse_length_payload(out, buf, length)
         else:
@@ -423,7 +428,8 @@ def wrap_payload_filter(func):
     return wrapper
 
 
-def filter_pipe(filter, filter2):
+def filter_pipe(filter, filter2, *,
+                EOF_MARKER=EOF_MARKER, EOL_MARKER=EOL_MARKER):
     """Creates pipe between two filters.
 
     filter_pipe() feeds first filter with incoming data and then
@@ -508,6 +514,9 @@ class HttpMessage:
     filter = None
 
     HOP_HEADERS = None  # Must be set by subclass.
+
+    TRANSFER_ENCODING_ID = multidict.cistr('TRANSFER-ENCODING')
+    CONNECTION_ID = multidict.cistr('CONNECTION')
 
     SERVER_SOFTWARE = 'Python/{0[0]}.{0[1]} aiohttp/{1}'.format(
         sys.version_info, aiohttp.__version__)
@@ -648,11 +657,11 @@ class HttpMessage:
             connection = 'close'
 
         if self.chunked:
-            self.headers['TRANSFER-ENCODING'] = 'chunked'
+            self.headers[self.TRANSFER_ENCODING_ID] = 'chunked'
 
-        self.headers['CONNECTION'] = connection
+        self.headers[self.CONNECTION_ID] = connection
 
-    def write(self, chunk):
+    def write(self, chunk, *, EOF_MARKER=EOF_MARKER, EOL_MARKER=EOL_MARKER):
         """Writes chunk of data to a stream by using different writers.
 
         writer uses filter to modify chunk of data.
@@ -743,7 +752,8 @@ class HttpMessage:
             self.output_length += len(chunk)
 
     @wrap_payload_filter
-    def add_chunking_filter(self, chunk_size=16*1024):
+    def add_chunking_filter(self, chunk_size=16*1024, *,
+                            EOF_MARKER=EOF_MARKER, EOL_MARKER=EOL_MARKER):
         """Split incoming stream into chunks."""
         buf = bytearray()
         chunk = yield
@@ -766,7 +776,8 @@ class HttpMessage:
                 chunk = yield EOL_MARKER
 
     @wrap_payload_filter
-    def add_compression_filter(self, encoding='deflate'):
+    def add_compression_filter(self, encoding='deflate', *,
+                               EOF_MARKER=EOF_MARKER, EOL_MARKER=EOL_MARKER):
         """Compress incoming stream with deflate or gzip encoding."""
         zlib_mode = (16 + zlib.MAX_WBITS
                      if encoding == 'gzip' else -zlib.MAX_WBITS)
@@ -802,6 +813,9 @@ class Response(HttpMessage):
         'UPGRADE',
     }
 
+    DATE_ID = multidict.cistr('DATE')
+    SERVER_ID = multidict.cistr('SERVER')
+
     @staticmethod
     def calc_reason(status):
         record = RESPONSES.get(status)
@@ -826,15 +840,16 @@ class Response(HttpMessage):
     def _add_default_headers(self):
         super()._add_default_headers()
 
-        if 'DATE' not in self.headers:
+        if self.DATE_ID not in self.headers:
             # format_date_time(None) is quite expensive
-            self.headers.setdefault('DATE', format_date_time(None))
-        self.headers.setdefault('SERVER', self.SERVER_SOFTWARE)
+            self.headers.setdefault(self.DATE_ID, format_date_time(None))
+        self.headers.setdefault(self.SERVER_ID, self.SERVER_SOFTWARE)
 
 
 class Request(HttpMessage):
 
     HOP_HEADERS = ()
+    USER_AGENT_ID = multidict.cistr('USER-AGENT')
 
     def __init__(self, transport, method, path,
                  http_version=HttpVersion11, close=False):
@@ -848,4 +863,4 @@ class Request(HttpMessage):
     def _add_default_headers(self):
         super()._add_default_headers()
 
-        self.headers.setdefault('USER-AGENT', self.SERVER_SOFTWARE)
+        self.headers.setdefault(self.USER_AGENT_ID, self.SERVER_SOFTWARE)

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -74,7 +74,7 @@ def run_server(loop, *, listen_addr=('127.0.0.1', 0),
             if properties.get('noresponse', False):
                 yield from asyncio.sleep(99999)
 
-            for hdr, val in message.headers.items(getall=True):
+            for hdr, val in message.headers.items():
                 if (hdr == 'EXPECT') and (val == '100-continue'):
                     self.transport.write(b'HTTP/1.0 100 Continue\r\n\r\n')
                     break
@@ -166,7 +166,7 @@ class Router:
     def __init__(self, srv, props, transport, message, payload):
         # headers
         self._headers = http.client.HTTPMessage()
-        for hdr, val in message.headers.items(getall=True):
+        for hdr, val in message.headers.items():
             self._headers.add_header(hdr, val)
 
         self._srv = srv

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -18,7 +18,8 @@ from .log import web_logger
 from .multidict import (CaseInsensitiveMultiDict,
                         CaseInsensitiveMutableMultiDict,
                         MultiDict,
-                        MutableMultiDict)
+                        MutableMultiDict,
+                        cistr)
 from .protocol import Response as ResponseImpl, HttpVersion, HttpVersion11
 from .server import ServerHttpProtocol
 from .streams import EOF_MARKER
@@ -88,6 +89,10 @@ __all__ = [
 sentinel = object()
 
 
+CONTENT_TYPE_ID = cistr('Content-Type')
+CONTENT_LENGTH_ID = cistr('Content-Length')
+
+
 class HeadersMixin:
 
     _content_type = None
@@ -104,25 +109,25 @@ class HeadersMixin:
             self._content_type, self._content_dict = cgi.parse_header(raw)
 
     @property
-    def content_type(self):
+    def content_type(self, CONTENT_TYPE_ID=CONTENT_TYPE_ID):
         """The value of content part for Content-Type HTTP header."""
-        raw = self.headers.get('Content-Type')
+        raw = self.headers.get(CONTENT_TYPE_ID)
         if self._stored_content_type != raw:
             self._parse_content_type(raw)
         return self._content_type
 
     @property
-    def charset(self):
+    def charset(self, CONTENT_TYPE_ID=CONTENT_TYPE_ID):
         """The value of charset part for Content-Type HTTP header."""
-        raw = self.headers.get('Content-Type')
+        raw = self.headers.get(CONTENT_TYPE_ID)
         if self._stored_content_type != raw:
             self._parse_content_type(raw)
         return self._content_dict.get('charset')
 
     @property
-    def content_length(self):
+    def content_length(self, CONTENT_LENGTH_ID=CONTENT_LENGTH_ID):
         """The value of Content-Length HTTP header."""
-        l = self.headers.get('Content-Length')
+        l = self.headers.get(CONTENT_LENGTH_ID)
         if l is None:
             return None
         else:
@@ -341,7 +346,7 @@ class Request(HeadersMixin):
         environ = {'REQUEST_METHOD': self.method,
                    'CONTENT_LENGTH': str(len(body)),
                    'QUERY_STRING': '',
-                   'CONTENT_TYPE': self.headers.get('CONTENT-TYPE')}
+                   'CONTENT_TYPE': self.headers.get(CONTENT_TYPE_ID)}
 
         fs = cgi.FieldStorage(fp=io.BytesIO(body),
                               environ=environ,
@@ -517,13 +522,13 @@ class StreamResponse(HeadersMixin):
             self._content_dict['charset'] = str(value).lower()
         self._generate_content_type_header()
 
-    def _generate_content_type_header(self):
+    def _generate_content_type_header(self, CONTENT_TYPE_ID=CONTENT_TYPE_ID):
         params = '; '.join("%s=%s" % i for i in self._content_dict.items())
         if params:
             ctype = self._content_type + '; ' + params
         else:
             ctype = self._content_type
-        self.headers['Content-Type'] = ctype
+        self.headers[CONTENT_TYPE_ID] = ctype
 
     def _start_pre_check(self, request):
         if self._resp_impl is not None:
@@ -608,14 +613,15 @@ class Response(StreamResponse):
             raise ValueError("body and text are not allowed together.")
 
         if text is not None:
-            if 'CONTENT-TYPE' not in self.headers:
+            if CONTENT_TYPE_ID not in self.headers:
                 # fast path for filling headers
                 if not isinstance(text, str):
                     raise TypeError('text argument must be str (%r)' %
                                     type(text))
                 if content_type is None:
                     content_type = 'text/plain'
-                self.headers['Content-Type'] = content_type + '; charset=utf-8'
+                self.headers[CONTENT_TYPE_ID] = (content_type +
+                                                 '; charset=utf-8')
                 self._content_type = content_type
                 self._content_dict = {'charset': 'utf-8'}
                 self.body = text.encode('utf-8')

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -380,7 +380,7 @@ class Request(HeadersMixin):
                         transfer_encoding](value)
                 out.add(field.name, value)
 
-        self._post = MultiDict(out.items(getall=True))
+        self._post = MultiDict(out.items())
         return self._post
 
 
@@ -560,7 +560,7 @@ class StreamResponse(HeadersMixin):
 
         self._copy_cookies()
 
-        headers = self.headers.items(getall=True)
+        headers = self.headers.items()
         for key, val in headers:
             resp_impl.add_header(key, val)
 

--- a/aiohttp/wsgi.py
+++ b/aiohttp/wsgi.py
@@ -71,7 +71,7 @@ class WSGIServerHttpProtocol(server.ServerHttpProtocol):
         script_name = self.SCRIPT_NAME
         server = forward
 
-        for hdr_name, hdr_value in message.headers.items(getall=True):
+        for hdr_name, hdr_value in message.headers.items():
             if hdr_name == 'HOST':
                 server = hdr_value
             elif hdr_name == 'SCRIPT_NAME':

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,23 @@ import codecs
 import os
 import re
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Extension
+
+
+try:
+    import Cython
+    USE_CYTHON = True
+except ImportError:
+    USE_CYTHON = False
+
+ext = '.pyx' if USE_CYTHON else '.c'
+
+extensions = [Extension('aiohttp._multidict', ['aiohttp/_multidict' + ext])]
+
+
+if USE_CYTHON:
+    from Cython.Build import cythonize
+    extensions = cythonize(extensions)
 
 
 with codecs.open(os.path.join(os.path.abspath(os.path.dirname(
@@ -45,4 +61,5 @@ setup(name='aiohttp',
       install_requires=install_requires,
       tests_require=tests_require,
       test_suite='nose.collector',
-      include_package_data=True)
+      include_package_data=True,
+      ext_modules=extensions)

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -25,7 +25,6 @@ class _Root:
         while name.startswith('_'):
             name = name[1:]
         self.assertIn(name, aiohttp.__all__)
-        self.assertIs(self.cls, getattr(aiohttp, name))
 
 
 class _BaseTest(_Root):
@@ -303,6 +302,13 @@ class _BaseMutableMultiDictTests(_BaseTest):
         with self.assertRaises(KeyError):
             del d['key']
 
+    def test_set_default(self):
+        d = self.make_dict([('key', 'one'), ('key', 'two')], foo='bar')
+        self.assertEqual('one', d.setdefault('key', 'three'))
+        self.assertEqual('three', d.setdefault('otherkey', 'three'))
+        self.assertIn('otherkey', d)
+        self.assertEqual('three', d['otherkey'])
+
     def test_not_implemented_methods(self):
         d = self.make_dict()
 
@@ -365,8 +371,9 @@ class PyMutableMultiDictTests(_BaseMutableMultiDictTests, unittest.TestCase):
     cls = _MutableMultiDict
 
 
-class PyCaseInsensitiveMutableMultiDictTests(_CaseInsensitiveMultiDictTests,
-                                             unittest.TestCase):
+class PyCaseInsensitiveMutableMultiDictTests(
+        _CaseInsensitiveMutableMultiDictTests,
+        unittest.TestCase):
 
     cls = _CaseInsensitiveMutableMultiDict
 
@@ -387,7 +394,8 @@ class MutableMultiDictTests(_BaseMutableMultiDictTests, unittest.TestCase):
     cls = MutableMultiDict
 
 
-class CaseInsensitiveMutableMultiDictTests(_CaseInsensitiveMultiDictTests,
-                                           unittest.TestCase):
+class CaseInsensitiveMutableMultiDictTests(
+        _CaseInsensitiveMutableMultiDictTests,
+        unittest.TestCase):
 
     cls = CaseInsensitiveMutableMultiDict

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -150,6 +150,36 @@ class _BaseTest(_Root):
         with self.assertRaises(TypeError):
             self.make_dict([(1, 2, 3)])
 
+    def test_keys_is_set_less(self):
+        d = self.make_dict([('key', 'value1')])
+
+        self.assertLess(d.keys(), {'key', 'key2'})
+
+    def test_keys_is_set_less_equal(self):
+        d = self.make_dict([('key', 'value1')])
+
+        self.assertLessEqual(d.keys(), {'key'})
+
+    def test_keys_is_set_equal(self):
+        d = self.make_dict([('key', 'value1')])
+
+        self.assertEqual(d.keys(), {'key'})
+
+    def test_keys_is_set_greater(self):
+        d = self.make_dict([('key', 'value1')])
+
+        self.assertGreater({'key', 'key2'}, d.keys())
+
+    def test_keys_is_set_greater_equal(self):
+        d = self.make_dict([('key', 'value1')])
+
+        self.assertGreaterEqual({'key'}, d.keys())
+
+    def test_keys_is_set_not_equal(self):
+        d = self.make_dict([('key', 'value1')])
+
+        self.assertNotEqual(d.keys(), {'key2'})
+
 
 class _MultiDictTests(_BaseTest):
 

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -180,6 +180,10 @@ class _BaseTest(_Root):
 
         self.assertNotEqual(d.keys(), {'key2'})
 
+    def test_eq(self):
+        d = self.make_dict([('key', 'value1')])
+        self.assertEqual({'key': 'value1'}, d)
+
 
 class _MultiDictTests(_BaseTest):
 

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -5,10 +5,12 @@ from aiohttp.multidict import (MultiDict,
                                MutableMultiDict,
                                CaseInsensitiveMultiDict,
                                CaseInsensitiveMutableMultiDict,
+                               cistr,
                                _MultiDict,
                                _MutableMultiDict,
                                _CaseInsensitiveMultiDict,
-                               _CaseInsensitiveMutableMultiDict)
+                               _CaseInsensitiveMutableMultiDict,
+                               _cistr)
 
 
 import aiohttp
@@ -484,3 +486,42 @@ class CaseInsensitiveMutableMultiDictTests(
         unittest.TestCase):
 
     cls = CaseInsensitiveMutableMultiDict
+
+
+class _CaseInsensitiveStrMixin:
+
+    cls = None
+
+    def test_ctor(self):
+        s = self.cls()
+        self.assertEqual('', s)
+
+    def test_ctor_str(self):
+        s = self.cls('a')
+        self.assertEqual('A', s)
+
+    def test_ctor_str_uppercase(self):
+        s = self.cls('A')
+        self.assertEqual('A', s)
+
+    def test_ctor_buffer(self):
+        s = self.cls(b'a')
+        self.assertEqual('A', s)
+
+    def test_ctor_repr(self):
+        s = self.cls(None)
+        self.assertEqual('NONE', s)
+
+    def test_upper(self):
+        s = self.cls('a')
+        self.assertIs(s, s.upper())
+
+
+class PyCaseInsensitiveStr(_CaseInsensitiveStrMixin, unittest.TestCase):
+
+    cls = _cistr
+
+
+class CaseInsensitiveStr(_CaseInsensitiveStrMixin, unittest.TestCase):
+
+    cls = cistr

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -103,53 +103,57 @@ class _BaseTest(_Root):
 
     def test__iter__(self):
         d = self.make_dict([('key', 'one'), ('key2', 'two'), ('key', 3)])
-        self.assertEqual(['key', 'key2'], list(d))
+        self.assertEqual(['key', 'key2', 'key'], list(d))
 
     def test_keys__contains(self):
         d = self.make_dict([('key', 'one'), ('key2', 'two'), ('key', 3)])
-        self.assertEqual(list(d.keys()), ['key', 'key2'])
+        self.assertEqual(list(d.keys(getall=False)), ['key', 'key2'])
         self.assertEqual(list(d.keys(getall=True)), ['key', 'key2', 'key'])
+        self.assertEqual(list(d.keys()), ['key', 'key2', 'key'])
 
-        self.assertIn('key', d.keys())
-        self.assertIn('key2', d.keys())
+        self.assertIn('key', d.keys(getall=False))
+        self.assertIn('key2', d.keys(getall=False))
 
         self.assertIn('key', d.keys(getall=True))
         self.assertIn('key2', d.keys(getall=True))
 
-        self.assertNotIn('foo', d.keys())
+        self.assertNotIn('foo', d.keys(getall=False))
         self.assertNotIn('foo', d.keys(getall=True))
 
     def test_values__contains(self):
         d = self.make_dict([('key', 'one'), ('key', 'two'), ('key', 3)])
-        self.assertEqual(list(d.values()), ['one'])
+        self.assertEqual(list(d.values(getall=False)), ['one'])
         self.assertEqual(list(d.values(getall=True)), ['one', 'two', 3])
+        self.assertEqual(list(d.values()), ['one', 'two', 3])
 
-        self.assertIn('one', d.values())
-        self.assertNotIn('two', d.values())
-        self.assertNotIn(3, d.values())
+        self.assertIn('one', d.values(getall=False))
+        self.assertNotIn('two', d.values(getall=False))
+        self.assertNotIn(3, d.values(getall=False))
 
         self.assertIn('one', d.values(getall=True))
         self.assertIn('two', d.values(getall=True))
         self.assertIn(3, d.values(getall=True))
 
-        self.assertNotIn('foo', d.values())
+        self.assertNotIn('foo', d.values(getall=False))
         self.assertNotIn('foo', d.values(getall=True))
 
     def test_items__contains(self):
         d = self.make_dict([('key', 'one'), ('key', 'two'), ('key', 3)])
-        self.assertEqual(list(d.items()), [('key', 'one')])
+        self.assertEqual(list(d.items(getall=False)), [('key', 'one')])
         self.assertEqual(list(d.items(getall=True)),
                          [('key', 'one'), ('key', 'two'), ('key', 3)])
+        self.assertEqual(list(d.items()),
+                         [('key', 'one'), ('key', 'two'), ('key', 3)])
 
-        self.assertIn(('key', 'one'), d.items())
-        self.assertNotIn(('key', 'two'), d.items())
-        self.assertNotIn(('key', 3), d.items())
+        self.assertIn(('key', 'one'), d.items(getall=False))
+        self.assertNotIn(('key', 'two'), d.items(getall=False))
+        self.assertNotIn(('key', 3), d.items(getall=False))
 
         self.assertIn(('key', 'one'), d.items(getall=True))
         self.assertIn(('key', 'two'), d.items(getall=True))
         self.assertIn(('key', 3), d.items(getall=True))
 
-        self.assertNotIn(('foo', 'bar'), d.items())
+        self.assertNotIn(('foo', 'bar'), d.items(getall=False))
         self.assertNotIn(('foo', 'bar'), d.items(getall=True))
 
     def test_cannot_create_from_unaccepted(self):

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -164,7 +164,7 @@ class _MultiDictTests(_BaseTest):
     def test_getall(self):
         d = self.make_dict([('key', 'value1')], key='value2')
 
-        self.assertEqual(d, {'key': 'value1'})
+        self.assertNotEqual(d, {'key': 'value1'})
         self.assertEqual(len(d), 2)
 
         self.assertEqual(d.getall('key'), ('value1', 'value2'))
@@ -200,7 +200,7 @@ class _CaseInsensitiveMultiDictTests(_Root):
     def test_getall(self):
         d = self.make_dict([('KEY', 'value1')], KEY='value2')
 
-        self.assertEqual(d, {'KEY': 'value1'})
+        self.assertNotEqual(d, {'KEY': 'value1'})
         self.assertEqual(len(d), 2)
 
         self.assertEqual(d.getall('key'), ('value1', 'value2'))
@@ -246,11 +246,11 @@ class _BaseMutableMultiDictTests(_BaseTest):
         self.assertEqual(d.getall('key'), ('two',))
 
         d.add('key', 'one')
-        self.assertEqual(d, {'key': 'two'})
+        self.assertEqual(2, len(d))
         self.assertEqual(d.getall('key'), ('two', 'one'))
 
         d.add('foo', 'bar')
-        self.assertEqual(d, {'key': 'two', 'foo': 'bar'})
+        self.assertEqual(3, len(d))
         self.assertEqual(d.getall('foo'), ('bar',))
 
     def test_extend(self):
@@ -258,7 +258,8 @@ class _BaseMutableMultiDictTests(_BaseTest):
         self.assertEqual(d, {})
 
         d.extend([('key', 'one'), ('key', 'two')], key=3, foo='bar')
-        self.assertEqual(d, {'key': 'one', 'foo': 'bar'})
+        self.assertNotEqual(d, {'key': 'one', 'foo': 'bar'})
+        self.assertEqual(4, len(d))
         itms = d.items(getall=True)
         # we can't guarantee order of kwargs
         self.assertTrue(('key', 'one') in itms)
@@ -270,22 +271,19 @@ class _BaseMutableMultiDictTests(_BaseTest):
         self.assertEqual(other, {'bar': 'baz'})
 
         d.extend(other)
-        self.assertEqual(d, {'key': 'one', 'foo': 'bar', 'bar': 'baz'})
         self.assertIn(('bar', 'baz'), d.items(getall=True))
 
         d.extend({'foo': 'moo'})
-        self.assertEqual(d, {'key': 'one', 'foo': 'bar', 'bar': 'baz'})
         self.assertIn(('foo', 'moo'), d.items(getall=True))
 
         d.extend()
-        self.assertEqual(d, {'key': 'one', 'foo': 'bar', 'bar': 'baz'})
+        self.assertEqual(6, len(d))
 
         with self.assertRaises(TypeError):
             d.extend('foo', 'bar')
 
     def test_clear(self):
         d = self.make_dict([('key', 'one')], key='two', foo='bar')
-        self.assertEqual(d, {'key': 'one', 'foo': 'bar'})
 
         d.clear()
         self.assertEqual(d, {})
@@ -293,7 +291,6 @@ class _BaseMutableMultiDictTests(_BaseTest):
 
     def test_del(self):
         d = self.make_dict([('key', 'one'), ('key', 'two')], foo='bar')
-        self.assertEqual(d, {'key': 'one', 'foo': 'bar'})
 
         del d['key']
         self.assertEqual(d, {'foo': 'bar'})
@@ -325,7 +322,7 @@ class _CaseInsensitiveMutableMultiDictTests(_Root):
     def test_getall(self):
         d = self.make_dict([('KEY', 'value1')], KEY='value2')
 
-        self.assertEqual(d, {'KEY': 'value1'})
+        self.assertNotEqual(d, {'KEY': 'value1'})
         self.assertEqual(len(d), 2)
 
         self.assertEqual(d.getall('key'), ('value1', 'value2'))

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -3,7 +3,11 @@ import unittest
 from aiohttp.multidict import (MultiDict,
                                MutableMultiDict,
                                CaseInsensitiveMultiDict,
-                               CaseInsensitiveMutableMultiDict)
+                               CaseInsensitiveMutableMultiDict,
+                               _MultiDict,
+                               _MutableMultiDict,
+                               _CaseInsensitiveMultiDict,
+                               _CaseInsensitiveMutableMultiDict)
 
 
 import aiohttp
@@ -343,6 +347,28 @@ class _CaseInsensitiveMutableMultiDictTests(_Root):
         self.assertIn('K1', d)
         del d['k1']
         self.assertNotIn('K1', d)
+
+
+class PyMultiDictTests(_MultiDictTests, unittest.TestCase):
+
+    cls = _MultiDict
+
+
+class PyCaseInsensitiveMultiDictTests(_CaseInsensitiveMultiDictTests,
+                                      unittest.TestCase):
+
+    cls = _CaseInsensitiveMultiDict
+
+
+class PyMutableMultiDictTests(_BaseMutableMultiDictTests, unittest.TestCase):
+
+    cls = _MutableMultiDict
+
+
+class PyCaseInsensitiveMutableMultiDictTests(_CaseInsensitiveMultiDictTests,
+                                             unittest.TestCase):
+
+    cls = _CaseInsensitiveMutableMultiDict
 
 
 class MultiDictTests(_MultiDictTests, unittest.TestCase):

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -18,6 +18,8 @@ class _Root:
 
     def test_exposed_names(self):
         name = self.cls.__name__
+        while name.startswith('_'):
+            name = name[1:]
         self.assertIn(name, aiohttp.__all__)
         self.assertIs(self.cls, getattr(aiohttp, name))
 
@@ -146,16 +148,15 @@ class _BaseTest(_Root):
             self.make_dict([(1, 2, 3)])
 
 
-class MultiDictTests(_BaseTest, unittest.TestCase):
-
-    cls = MultiDict
+class _MultiDictTests(_BaseTest):
 
     def test__repr__(self):
         d = self.make_dict()
-        self.assertEqual(str(d), "<MultiDict>\n[]")
+        self.assertEqual(str(d), "<%s>\n[]" % self.cls.__name__)
         d = self.make_dict([('key', 'one'), ('key', 'two')])
-        self.assertEqual(str(d),
-                         "<MultiDict>\n[('key', 'one'), ('key', 'two')]")
+        self.assertEqual(
+            str(d),
+            "<%s>\n[('key', 'one'), ('key', 'two')]" % self.cls.__name__)
 
     def test_getall(self):
         d = self.make_dict([('key', 'value1')], key='value2')
@@ -178,9 +179,7 @@ class MultiDictTests(_BaseTest, unittest.TestCase):
         self.assertEqual('a=1&b=2&a=3', s)
 
 
-class CaseInsensitiveMultiDictTests(_Root, unittest.TestCase):
-
-    cls = CaseInsensitiveMultiDict
+class _CaseInsensitiveMultiDictTests(_Root):
 
     def test_basics(self):
         d = self.make_dict([('KEY', 'value1')], KEY='value2')
@@ -211,13 +210,13 @@ class _BaseMutableMultiDictTests(_BaseTest):
 
     def test__repr__(self):
         d = self.make_dict()
-        self.assertEqual(str(d), "<MutableMultiDict>\n[]")
+        self.assertEqual(str(d), "<%s>\n[]" % self.cls.__name__)
 
         d = self.make_dict([('key', 'one'), ('key', 'two')])
 
         self.assertEqual(
             str(d),
-            "<MutableMultiDict>\n[('key', 'one'), ('key', 'two')]")
+            "<%s>\n[('key', 'one'), ('key', 'two')]" % self.cls.__name__)
 
     def test_getall(self):
         d = self.make_dict([('key', 'value1')], key='value2')
@@ -311,14 +310,7 @@ class _BaseMutableMultiDictTests(_BaseTest):
             d.update(bar='baz')
 
 
-class MutableMultiDictTests(_BaseMutableMultiDictTests, unittest.TestCase):
-
-    cls = MutableMultiDict
-
-
-class CaseInsensitiveMutableMultiDictTests(_Root, unittest.TestCase):
-
-    cls = CaseInsensitiveMutableMultiDict
+class _CaseInsensitiveMutableMultiDictTests(_Root):
 
     def test_getall(self):
         d = self.make_dict([('KEY', 'value1')], KEY='value2')
@@ -351,3 +343,25 @@ class CaseInsensitiveMutableMultiDictTests(_Root, unittest.TestCase):
         self.assertIn('K1', d)
         del d['k1']
         self.assertNotIn('K1', d)
+
+
+class MultiDictTests(_MultiDictTests, unittest.TestCase):
+
+    cls = MultiDict
+
+
+class CaseInsensitiveMultiDictTests(_CaseInsensitiveMultiDictTests,
+                                    unittest.TestCase):
+
+    cls = CaseInsensitiveMultiDict
+
+
+class MutableMultiDictTests(_BaseMutableMultiDictTests, unittest.TestCase):
+
+    cls = MutableMultiDict
+
+
+class CaseInsensitiveMutableMultiDictTests(_CaseInsensitiveMultiDictTests,
+                                           unittest.TestCase):
+
+    cls = CaseInsensitiveMutableMultiDict

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -184,6 +184,30 @@ class _BaseTest(_Root):
         d = self.make_dict([('key', 'value1')])
         self.assertEqual({'key': 'value1'}, d)
 
+    def test_and(self):
+        d = self.make_dict([('key', 'value1')])
+        self.assertEqual({'key'}, d.keys() & {'key', 'key2'})
+
+    def test_or(self):
+        d = self.make_dict([('key', 'value1')])
+        self.assertEqual({'key', 'key2'}, d.keys() | {'key2'})
+
+    def test_sub(self):
+        d = self.make_dict([('key', 'value1'), ('key2', 'value2')])
+        self.assertEqual({'key'}, d.keys() - {'key2'})
+
+    def test_xor(self):
+        d = self.make_dict([('key', 'value1'), ('key2', 'value2')])
+        self.assertEqual({'key', 'key3'}, d.keys() ^ {'key2', 'key3'})
+
+    def test_isdisjoint(self):
+        d = self.make_dict([('key', 'value1')])
+        self.assertTrue(d.keys().isdisjoint({'key2'}))
+
+    def test_isdisjoint2(self):
+        d = self.make_dict([('key', 'value1')])
+        self.assertFalse(d.keys().isdisjoint({'key'}))
+
 
 class _MultiDictTests(_BaseTest):
 

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 from aiohttp.multidict import (MultiDict,
@@ -11,6 +12,9 @@ from aiohttp.multidict import (MultiDict,
 
 
 import aiohttp
+
+
+HAS_NO_SET_OPS_FOR_VIEW = sys.version_info < (3, 4)
 
 
 class _Root:
@@ -150,60 +154,86 @@ class _BaseTest(_Root):
         with self.assertRaises(TypeError):
             self.make_dict([(1, 2, 3)])
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_keys_is_set_less(self):
         d = self.make_dict([('key', 'value1')])
 
         self.assertLess(d.keys(), {'key', 'key2'})
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_keys_is_set_less_equal(self):
         d = self.make_dict([('key', 'value1')])
 
         self.assertLessEqual(d.keys(), {'key'})
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_keys_is_set_equal(self):
         d = self.make_dict([('key', 'value1')])
 
         self.assertEqual(d.keys(), {'key'})
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_keys_is_set_greater(self):
         d = self.make_dict([('key', 'value1')])
 
         self.assertGreater({'key', 'key2'}, d.keys())
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_keys_is_set_greater_equal(self):
         d = self.make_dict([('key', 'value1')])
 
         self.assertGreaterEqual({'key'}, d.keys())
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_keys_is_set_not_equal(self):
         d = self.make_dict([('key', 'value1')])
 
         self.assertNotEqual(d.keys(), {'key2'})
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_eq(self):
         d = self.make_dict([('key', 'value1')])
         self.assertEqual({'key': 'value1'}, d)
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_and(self):
         d = self.make_dict([('key', 'value1')])
         self.assertEqual({'key'}, d.keys() & {'key', 'key2'})
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_or(self):
         d = self.make_dict([('key', 'value1')])
         self.assertEqual({'key', 'key2'}, d.keys() | {'key2'})
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_sub(self):
         d = self.make_dict([('key', 'value1'), ('key2', 'value2')])
         self.assertEqual({'key'}, d.keys() - {'key2'})
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_xor(self):
         d = self.make_dict([('key', 'value1'), ('key2', 'value2')])
         self.assertEqual({'key', 'key3'}, d.keys() ^ {'key2', 'key3'})
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_isdisjoint(self):
         d = self.make_dict([('key', 'value1')])
         self.assertTrue(d.keys().isdisjoint({'key2'}))
 
+    @unittest.skipIf(HAS_NO_SET_OPS_FOR_VIEW,
+                     "Set operations on views not supported")
     def test_isdisjoint2(self):
         d = self.make_dict([('key', 'value1')])
         self.assertFalse(d.keys().isdisjoint({'key'}))


### PR DESCRIPTION
Deep refactoring of multidicts.

1. They are cythonazed, but pure python version is also available.
2. Added multidict.cistr as case-insentsitive-str with zero cost for `.upper()`.
3. aiohttp code converted to use `cistr`.