### PR TITLE
Trivial patch: Break a cycle

### DIFF
--- a/aiohttp/parsers.py
+++ b/aiohttp/parsers.py
@@ -249,7 +249,7 @@ class StreamProtocol(asyncio.streams.FlowControlMixin, asyncio.Protocol):
             transport, self, self.reader, self._loop)
 
     def connection_lost(self, exc):
-        self.transport = None
+        self.transport = self.writer = None
 
         if exc is None:
             self.reader.feed_eof()

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -371,6 +371,7 @@ class StreamProtocolTests(unittest.TestCase):
         proto.connection_made(unittest.mock.Mock())
         proto.connection_lost(None)
         self.assertIsNone(proto.transport)
+        self.assertIsNone(proto.writer)
         self.assertTrue(proto.reader._eof)
 
     def test_connection_lost_exc(self):


### PR DESCRIPTION
Once the connection is closed, remove the references from the protocol to the
reader and writer objects. It will effectively break a references cycle and
allow a large group of objects to be freed thanks to the reference counting
mechanism, instead of be garbage collected.

This obviously a really trivial patch, but in a large application emitting
a large amount of requests, it reduces the working time of the gc, and thus,
the latency.