### PR TITLE
Router refactoring

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,8 @@ CHANGES
   (`MultiDictProxy` and `CIMultiDictProxy`). Previous edition of
   multidicts was not a part of public API BTW.
 
+- Router refactoring to push Not Allowed and Not Found in middleware processing
+
 
 0.13.1 (12-31-2014)
 --------------------

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -367,7 +367,7 @@ other, like displaying *403 Forbidden page* or raising
 resource.  Also middleware may render errors raised by handler, do
 some pre- and post- processing like handling *CORS* and so on.
 
-.. warning::
+.. versionchanged:: 0.14
 
-   Middleware is executing **after** routing, thus it cannot process
-   route exceptions.
+   Middleware accepts route exceptions (:exc:`HTTPNotFound` and
+   :exc:`HTTPMethodNotAllowed`).

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -924,11 +924,25 @@ Router is any object that implements :class:`AbstractRouter` interface.
    .. method:: resolve(requst)
 
       A :ref:`coroutine<coroutine>` that returns
-      :class:`AbstractMatchInfo` for *request* or raises http
-      exception like :exc:`HTTPNotFound` if there is no registered
-      route for *request*.
+      :class:`AbstractMatchInfo` for *request*.
+
+      The method never raises exception, but returns
+      :class:`AbstractMatchInfo` instance with ``None``
+      :attr:`~AbstractMatchInfo.route` and
+      :attr:`~AbstractMatchInfo.handler` which raises
+      :exc:`HTTPNotFound` or :exc:`HTTPMethodNotAllowed` on handler's
+      execution if there is no registered route for *request*.
+
+      *Middlewares* can process that exceptions to render
+      pretty-looking error page for example.
 
       Used by internal machinery, end user unlikely need to call the method.
+
+      .. versionchanged:: 0.14
+
+         The method don't raise :exc:`HTTPNotFound` and
+         :exc:`HTTPMethodNotAllowed` anymore.
+
 
 .. _aiohttp-web-route:
 

--- a/setup.py
+++ b/setup.py
@@ -91,9 +91,9 @@ args = dict(
 try:
     setup(**args)
 except BuildFailed:
-    print("*************************************************************")
-    print("Cannot compile C accellerator module, use pure python version")
-    print("*************************************************************")
+    print("************************************************************")
+    print("Cannot compile C accelerator module, use pure python version")
+    print("************************************************************")
     del args['ext_modules']
     del args['cmdclass']
     setup(**args)

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -130,8 +130,12 @@ class TestUrlDispatcher(unittest.TestCase):
         self.router.add_route('POST', '/', handler2)
         req = self.make_request('PUT', '/')
 
+        match_info = self.loop.run_until_complete(self.router.resolve(req))
+        self.assertIsNone(match_info.route)
+        self.assertEqual({}, match_info)
+
         with self.assertRaises(HTTPMethodNotAllowed) as ctx:
-            self.loop.run_until_complete(self.router.resolve(req))
+            self.loop.run_until_complete(match_info.handler(req))
 
         exc = ctx.exception
         self.assertEqual('PUT', exc.method)
@@ -143,8 +147,12 @@ class TestUrlDispatcher(unittest.TestCase):
         self.router.add_route('GET', '/a', handler)
         req = self.make_request('GET', '/b')
 
+        match_info = self.loop.run_until_complete(self.router.resolve(req))
+        self.assertIsNone(match_info.route)
+        self.assertEqual({}, match_info)
+
         with self.assertRaises(HTTPNotFound) as ctx:
-            self.loop.run_until_complete(self.router.resolve(req))
+            self.loop.run_until_complete(match_info.handler(req))
 
         exc = ctx.exception
         self.assertEqual(404, exc.status)
@@ -281,8 +289,11 @@ class TestUrlDispatcher(unittest.TestCase):
         self.router.add_route('GET', r'/handler/{to:\d+}', handler)
 
         req = self.make_request('GET', '/handler/tail')
+        match_info = self.loop.run_until_complete(self.router.resolve(req))
+        self.assertIsNone(match_info.route)
+        self.assertEqual({}, match_info)
         with self.assertRaises(HTTPNotFound):
-            self.loop.run_until_complete(self.router.resolve(req))
+            self.loop.run_until_complete(match_info.handler(req))
 
     def test_add_route_with_re_including_slashes(self):
         handler = asyncio.coroutine(lambda req: Response(req))


### PR DESCRIPTION
I've found the passing to middleware chain exception from router on "not found" makes sense.

`Router.resolve` should never raise `HTTPNotFound` and `HTTPMethodNotAllowed` anymore but return *match info* with handler that raises former exceptions.