### PR TITLE
Convert ConnectionError to ClientDisconnectedError of ServerDisconnectedError

### DIFF
--- a/aiohttp/parsers.py
+++ b/aiohttp/parsers.py
@@ -120,6 +120,11 @@ class StreamParser(asyncio.streams.StreamReader):
         return self._exception
 
     def set_exception(self, exc):
+        if isinstance(exc, ConnectionError):
+            exc, old_exc = self._eof_exc_class(), exc
+            exc.__cause__ = old_exc
+            exc.__context__ = old_exc
+
         self._exception = exc
 
         if self._output is not None:

--- a/aiohttp/server.py
+++ b/aiohttp/server.py
@@ -239,7 +239,7 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
                         isinstance(handler, asyncio.Future)):
                     yield from handler
 
-            except (ConnectionError, asyncio.CancelledError,
+            except (asyncio.CancelledError,
                     errors.ClientDisconnectedError):
                 self.log_debug('Ignored premature client disconnection.')
                 break

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -48,6 +48,17 @@ class StreamParserTests(unittest.TestCase):
         stream.set_exception(exc)
         self.assertIs(stream.exception(), exc)
 
+    def test_exception_connection_error(self):
+        stream = parsers.StreamParser()
+        self.assertIsNone(stream.exception())
+
+        exc = ConnectionError()
+        stream.set_exception(exc)
+        self.assertIsNot(stream.exception(), exc)
+        self.assertIsInstance(stream.exception(), RuntimeError)
+        self.assertIs(stream.exception().__cause__, exc)
+        self.assertIs(stream.exception().__context__, exc)
+
     def test_exception_waiter(self):
         stream = parsers.StreamParser()
 


### PR DESCRIPTION
My co-worker has found the issue: when web-handler get's an `ConnectionError` exception the handler closed without any errror.

The exception was from handler code, not aiohttp: it just try to send email via sync python api.

Any code used in handler may raise `ConnectionError` -- that's standard behavior for python libraries.

I guess to handle HTTP connection problems in aiohttp parser, convert those to `aiohttp.DisconnectedError` and don't silently close server connection on exception from web handler -- it should be *500 Internal Server Error*.