### PR TITLE
Note that aiohttp.web can be used in production

### DIFF
--- a/docs/web.rst
+++ b/docs/web.rst
@@ -48,6 +48,12 @@ After that, create a server and run the *asyncio loop* as usual::
 
 That's it.
 
+.. tip::
+
+   The :mod:`aiohttp.web` server requires no additional configuration to be
+   deployed in production environments.
+
+
 .. _aiohttp-web-handler:
 
 Handler


### PR DESCRIPTION
Users coming from Flask, Django, and Bottle anticipate special
instructions about deployment. Closes #234.