### PR TITLE
make chunked transfer encoding explicit

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -33,6 +33,10 @@ CHANGES
 - Convert `ConnectionError` to `aiohttp.DisconnectedError` and don't
   eat `ConnectionError` exceptions from web handlers.
 
+- Remove hop headers from Response class, wsgi response still uses hop headers.
+
+- Allow to send raw chunked encoded response.
+
 
 0.13.1 (12-31-2014)
 --------------------

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -539,6 +539,7 @@ class ClientRequest:
             request.add_compression_filter(self.compress)
 
         if self.chunked is not None:
+            request.enable_chunked_encoding()
             request.add_chunking_filter(self.chunked)
 
         request.add_headers(

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -287,7 +287,7 @@ class Router:
             hdrs.extend(headers.items())
 
         if chunked:
-            response.force_chunked()
+            response.enable_chunked_encoding()
 
         # headers
         response.add_headers(*hdrs)

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -392,6 +392,7 @@ class StreamResponse(HeadersMixin):
         self._body = None
         self._keep_alive = None
         self._chunked = False
+        self._chunk_size = None
         self._headers = CIMultiDict()
         self._cookies = http.cookies.SimpleCookie()
         self.set_status(status, reason)
@@ -434,9 +435,10 @@ class StreamResponse(HeadersMixin):
     def force_close(self):
         self._keep_alive = False
 
-    def enable_chunked_encoding(self):
+    def enable_chunked_encoding(self, chunk_size=None):
         """Enables automatic chunked transfer encoding."""
         self._chunked = True
+        self._chunk_size = chunk_size
 
     @property
     def headers(self):
@@ -568,6 +570,8 @@ class StreamResponse(HeadersMixin):
 
         if self._chunked:
             resp_impl.enable_chunked_encoding()
+            if self._chunk_size:
+                resp_impl.add_chunking_filter(self._chunk_size)
 
         headers = self.headers.items()
         for key, val in headers:

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -391,6 +391,7 @@ class StreamResponse(HeadersMixin):
     def __init__(self, *, status=200, reason=None):
         self._body = None
         self._keep_alive = None
+        self._chunked = False
         self._headers = CIMultiDict()
         self._cookies = http.cookies.SimpleCookie()
         self.set_status(status, reason)
@@ -413,6 +414,10 @@ class StreamResponse(HeadersMixin):
         return self._status
 
     @property
+    def chunked(self):
+        return self._chunked
+
+    @property
     def reason(self):
         return self._reason
 
@@ -428,6 +433,10 @@ class StreamResponse(HeadersMixin):
 
     def force_close(self):
         self._keep_alive = False
+
+    def enable_chunked_encoding(self):
+        """Enables automatic chunked transfer encoding."""
+        self._chunked = True
 
     @property
     def headers(self):
@@ -556,6 +565,9 @@ class StreamResponse(HeadersMixin):
             self._reason)
 
         self._copy_cookies()
+
+        if self._chunked:
+            resp_impl.enable_chunked_encoding()
 
         headers = self.headers.items()
         for key, val in headers:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -250,7 +250,7 @@ first positional parameter.
 
 
 Response classes
------------------
+----------------
 
 For now, :mod:`aiohttp.web` has two classes for the *HTTP response*:
 :class:`StreamResponse` and :class:`Response`.
@@ -336,6 +336,18 @@ StreamResponse
 
       Disable :attr:`keep_alive` for connection. There are no ways to
       enable it back.
+
+   .. attribute:: chunked
+
+      Read-only property, incicates if chunked encoding is on.
+
+      Can be enabled by :meth:`enable_chunked_encoding` call.
+
+   .. method:: enable_chunked_encoding
+
+      Enables :attr:`chunked` enacoding for response. There are no ways to
+      disable it back. With enabled :attr:`chunked` encoding each `write()`
+      operation encoded in separate chunk.
 
    .. attribute:: headers
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -1,6 +1,7 @@
 import asyncio
 import unittest
 from unittest import mock
+from aiohttp import hdrs
 from aiohttp.multidict import CIMultiDict
 from aiohttp.web import Request, StreamResponse, Response
 from aiohttp.protocol import RawRequestMessage, HttpVersion11
@@ -138,6 +139,50 @@ class TestStreamResponse(unittest.TestCase):
 
         msg = resp.start(req)
         self.assertTrue(msg.chunked)
+        msg.add_chunking_filter.assert_called_with(8192)
+        self.assertIsNotNone(msg.filter)
+
+    @mock.patch('aiohttp.web.ResponseImpl')
+    def test_compression_no_accept(self, ResponseImpl):
+        req = self.make_request('GET', '/')
+        resp = StreamResponse()
+        self.assertFalse(resp.chunked)
+
+        self.assertFalse(resp.compression)
+        resp.enable_compression()
+        self.assertTrue(resp.compression)
+
+        msg = resp.start(req)
+        self.assertFalse(msg.add_compression_filter.called)
+
+    @mock.patch('aiohttp.web.ResponseImpl')
+    def test_force_compression_no_accept(self, ResponseImpl):
+        req = self.make_request('GET', '/')
+        resp = StreamResponse()
+        self.assertFalse(resp.chunked)
+
+        self.assertFalse(resp.compression)
+        resp.enable_compression(force=True)
+        self.assertTrue(resp.compression)
+
+        msg = resp.start(req)
+        self.assertTrue(msg.add_compression_filter.called)
+        self.assertIsNotNone(msg.filter)
+
+    @mock.patch('aiohttp.web.ResponseImpl')
+    def test_compression(self, ResponseImpl):
+        req = self.make_request(
+            'GET', '/',
+            headers=CIMultiDict({str(hdrs.ACCEPT_ENCODING): 'gzip, deflate'}))
+        resp = StreamResponse()
+        self.assertFalse(resp.chunked)
+
+        self.assertFalse(resp.compression)
+        resp.enable_compression()
+        self.assertTrue(resp.compression)
+
+        msg = resp.start(req)
+        self.assertTrue(msg.add_compression_filter.called)
         self.assertIsNotNone(msg.filter)
 
     def test_write_non_byteish(self):

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -127,6 +127,19 @@ class TestStreamResponse(unittest.TestCase):
         msg = resp.start(req)
         self.assertTrue(msg.chunked)
 
+    @mock.patch('aiohttp.web.ResponseImpl')
+    def test_chunk_size(self, ResponseImpl):
+        req = self.make_request('GET', '/')
+        resp = StreamResponse()
+        self.assertFalse(resp.chunked)
+
+        resp.enable_chunked_encoding(chunk_size=8192)
+        self.assertTrue(resp.chunked)
+
+        msg = resp.start(req)
+        self.assertTrue(msg.chunked)
+        self.assertIsNotNone(msg.filter)
+
     def test_write_non_byteish(self):
         resp = StreamResponse()
         resp.start(self.make_request('GET', '/'))

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -115,6 +115,18 @@ class TestStreamResponse(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             resp.start(req2)
 
+    @mock.patch('aiohttp.web.ResponseImpl')
+    def test_chunked_encoding(self, ResponseImpl):
+        req = self.make_request('GET', '/')
+        resp = StreamResponse()
+        self.assertFalse(resp.chunked)
+
+        resp.enable_chunked_encoding()
+        self.assertTrue(resp.chunked)
+
+        msg = resp.start(req)
+        self.assertTrue(msg.chunked)
+
     def test_write_non_byteish(self):
         resp = StreamResponse()
         resp.start(self.make_request('GET', '/'))


### PR DESCRIPTION
@asvetlov 

1. hop headers removed, there is no any reason to cut them off, aiohttp is a framework
2. chunked encoding is explicit
3. wsgi behave same as before
