### PR TITLE
Have setup.py handle possible carriage returns when reading __init.py__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ class ve_build_ext(build_ext):
 with codecs.open(os.path.join(os.path.abspath(os.path.dirname(
         __file__)), 'aiohttp', '__init__.py'), 'r', 'latin1') as fp:
     try:
-        version = re.findall(r"^__version__ = '([^']+)'$", fp.read(), re.M)[0]
+        version = re.findall(r"^__version__ = '([^']+)'\r?$", fp.read(), re.M)[0]
     except IndexError:
         raise RuntimeError('Unable to determine version.')
 


### PR DESCRIPTION
`setup.py` is reading the `__version__` string from the `__init__.py` file by reading the file in as a single string and then running a regexp against the string. It's looking for `^__version__ = '([^']+)'$`

While that works for standard installs, if working on the repo under Windows, there's a good chance that msysgit has autocrlf set and quietly converts the `\n` to `\r\n`. When that happens, `setup.py` can't find the version string because there's now a `\r` before the `\n` that `$` matches.

The patch adjusts the regexp to accept an optional `\r` before the EOL.