### PR TITLE
Implement the third example of the `POST multipart encoded file` of the documentation

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -138,8 +138,8 @@ class FormData:
                              for i in type_options.items())
 
             out_headers.append(
-                ('Content-Disposition: form-data; ' + opts).encode(encoding)
-                + b'\r\n')
+                ('Content-Disposition: form-data; ' + opts).encode(encoding) +
+                b'\r\n')
 
             for k, v in headers.items():
                 out_headers.append('{}: {}\r\n'.format(k, v).encode(encoding))

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -246,15 +246,6 @@ You can set the filename, content_type explicitly::
 
     >>> yield from aiohttp.request('post', url, data=data)
 
-If you want, you can send strings to be received as files::
-
-    >>> url = 'http://httpbin.org/post'
-    >>> files = {'file': ('report.csv',
-    ...                   'some,data,to,send\nanother,row,to,send\n')
-    ... }
-
-    >>> yield from aiohttp.request('post', url, data=files)
-
 If you pass file object as data parameter, aiohttp will stream it to server
 automatically. Check :class:`aiohttp.stream.StreamReader` for supported format
 information.


### PR DESCRIPTION
If i'm not mistaken, the third example given in the documentation (here)[http://aiohttp.readthedocs.org/en/v0.14.4/client.html#post-a-multipart-encoded-file] is not implemented:

```
>>> url = 'http://httpbin.org/post'
>>> files = {'file': ('report.csv',
...                   'some,data,to,send\nanother,row,to,send\n')
... }

>>> yield from aiohttp.request('post', url, data=files)
```
would post nothing