### PR TITLE
added status code setter to web.Response

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -689,6 +689,14 @@ class Response(StreamResponse):
                 self.body = None
 
     @property
+    def status(self):
+        return self.status
+
+    @status.setter
+    def status(self, status):
+        self._status = status
+
+    @property
     def body(self):
         return self._body
 


### PR DESCRIPTION
Often times it's very handy to set the status code when creating the response class, for example, when you don't find a resource, you can simple do response=web.Response() and then response.status=404