### PR TITLE
Fix Application kwargs

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -1604,7 +1604,7 @@ class Application(dict):
 
     def __init__(self, *, logger=web_logger, loop=None,
                  router=None, handler_factory=RequestHandlerFactory,
-                 middlewares=()):
+                 middlewares=(), **kwargs):
         if loop is None:
             loop = asyncio.get_event_loop()
         if router is None:
@@ -1620,6 +1620,8 @@ class Application(dict):
         for factory in middlewares:
             assert asyncio.iscoroutinefunction(factory), factory
         self._middlewares = tuple(middlewares)
+
+        self.update(kwargs)
 
     @property
     def router(self):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -90,6 +90,10 @@ class TestWeb(unittest.TestCase):
         app.logger = logger
         self.assertIs(app.logger, logger)
 
+    def test_app_kwargs(self):
+        app = web.Application(loop=self.loop, foo=123)
+        self.assertEqual(app['foo'], 123)
+
 
 class TestRequestHandlerFactory(unittest.TestCase):
 


### PR DESCRIPTION
web.Application docs says that optional kwargs may be passed for initializing self dict. Apparently it's not possible. This fixes it.