### PR TITLE
Don't send full URL in tunnelled HTTPS requests

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -398,9 +398,10 @@ class ProxyConnector(TCPConnector):
         except OSError as exc:
             raise ProxyConnectionError(*exc.args) from exc
 
-        req.path = '{scheme}://{host}{path}'.format(scheme=req.scheme,
-                                                    host=req.netloc,
-                                                    path=req.path)
+        if not req.ssl:
+            req.path = '{scheme}://{host}{path}'.format(scheme=req.scheme,
+                                                        host=req.netloc,
+                                                        path=req.path)
         if 'AUTHORIZATION' in proxy_req.headers:
             auth = proxy_req.headers['AUTHORIZATION']
             del proxy_req.headers['AUTHORIZATION']

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -606,6 +606,7 @@ class ProxyConnectorTests(unittest.TestCase):
         req = ClientRequest('GET', 'https://www.python.org')
         self.loop.run_until_complete(connector._create_connection(req))
 
+        self.assertEqual(req.path, '/')
         self.assertEqual(proxy_req.method, 'CONNECT')
         self.assertEqual(proxy_req.path, 'www.python.org:443')
         tr.pause_reading.assert_called_once_with()


### PR DESCRIPTION
Ordinarily, the ProxyConnector rewrites req.path to include the full URL
of the request. However, when tunnelling HTTPS through an HTTP proxy, this
is unnecessary (because the CONNECT command tells the proxy which server
to connect to) and can cause problems (because some servers deal badly
with full URLs in GET requests). Therefore, we *shouldn't* rewrite the
path when making an HTTPS connection.