### PR TITLE
Remove `__slots__` declarations in `multidict.py`.

### DIFF
--- a/aiohttp/multidict.py
+++ b/aiohttp/multidict.py
@@ -27,8 +27,6 @@ class _upstr(str):
 
 class _Base:
 
-    __slots__ = ('_items',)
-
     def getall(self, key, default=_marker):
         """
         Return a list of all values matching the key (may be an empty list)
@@ -272,8 +270,6 @@ class _CIMultiDict(_CIBase, _MultiDict):
 
 
 class _ViewBase:
-
-    __slots__ = ('_keys', '_items')
 
     def __init__(self, items):
         self._items = items


### PR DESCRIPTION
The reason for this is twofold.

1. `_ItemsView` derives from `collections.abc.ItemsView`, which doesn't have `__slots__` on Python <= 3.4. That means the instances will have a `__dict__` anyway, and `__slots__` does nothing.

2. In Python 3.5 (alpha 1, of course, it hasn't been released yet) `collections.abc.ItemsView` *does* have `__slots__`...set to `()`, which causes an error when importing `aiohttp.multidict` due to a conflict with `__slots__ = ('_items',)` in class `_ViewBase`:

    ```
    Python 3.5.0a1+ (default, Mar  9 2015, 18:48:14) [GCC 4.9.1] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    py $ import aiohttp
      <stdin> line 1: 
      aiohttp/__init__.py line 6: from . import hdrs  # noqa
      aiohttp/hdrs.py line 2: from .multidict import upstr
      aiohttp/multidict.py line 285: class _ItemsView(_ViewBase, abc.ItemsView):
      CPython/Lib/abc.py line 133, __new__: cls = super().__new__(mcls, name, bases, namespace)
    TypeError: multiple bases have instance lay-out conflict
    ```