### PR TITLE
Improve index and contributing docs by fixing some typos, links and more comprehensive English

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -10,7 +10,7 @@ HTTP Client
 Example
 -------
 
-Because most of *aiohttp* methods are generators, they will not work
+Because most of the *aiohttp* methods are generators, they will not work
 in the interactive python interpreter like regular functions
 would. For convenience, we show our examples as if they were run in
 the interactive interpreter, but please remember that actually running
@@ -34,7 +34,7 @@ Begin by importing the aiohttp module::
 
     >>> import aiohttp
 
-Now, let's try to get a webpage. For this example, let's get GitHub's public
+Now, let's try to get a webpage. For example let's get GitHub's public
 timeline ::
 
     >>> r = yield from aiohttp.request(
@@ -42,13 +42,14 @@ timeline ::
 
 Now, we have a :class:`ClientResponse` object called ``r``. We can get all the
 information we need from this object.
-First parameter is http method, in that case it is get and second is http url.
-this is how you make an HTTP POST request::
+The first parameter is the http method, in that case it is ``get``
+and the second is an http url.
+In order to make an HTTP POST request::
 
     >>> r = yield from aiohttp.request(
     ...     'post', 'http://httpbin.org/post')
 
-First parameter could be any valid http method. For example::
+The first parameter could be any valid http method. For example::
 
     >>> r = yield from aiohttp.request(
     ...     'put', 'http://httpbin.org/put')
@@ -58,6 +59,8 @@ First parameter could be any valid http method. For example::
     ...     'head', 'http://httpbin.org/get')
     >>> r = yield from aiohttp.request(
     ...     'options', 'http://httpbin.org/get')
+    >>> r = yield from aiohttp.request(
+    ...     'patch', 'http://httpbin.org/patch')
 
 
 Passing Parameters In URLs
@@ -81,7 +84,7 @@ You can see that the URL has been correctly encoded by printing the URL::
     >>> print(r.url)
     http://httpbin.org/get?key2=value2&key1=value1
 
-Also it is possible to pass list of 2 items tuples as parameters, in
+It is also possible to pass a list of 2 item tuples as parameters, in
 that case you can specifiy multiple values for each key::
 
     >>> payload = [('key', 'value1'), ('key': 'value2')]
@@ -104,8 +107,8 @@ again::
     >>> yield from r.text()
     '[{"repository":{"open_issues":0,"url":"https://github.com/...
 
-aiohttp will automatically decode content from the server. You can
-specify custom encoding for ``text()`` method.
+aiohttp will automatically decode the content from the server. You can
+specify custom encoding for the ``text()`` method.
 
 .. code::
 
@@ -135,8 +138,8 @@ There's also a builtin JSON decoder, in case you're dealing with JSON data::
     >>> yield from r.json()
     [{'repository': {'open_issues': 0, 'url': 'https://github.com/...
 
-In case the JSON decoding fails, ``r.json()`` raises an exception. It
-is possible to specify custom encoding and decoder function for
+In case that JSON decoding fails, ``r.json()`` will raise an exception. It
+is possible to specify custom encoding and decoder functions for the
 ``json()`` call.
 
 
@@ -144,10 +147,10 @@ Streaming Response Content
 --------------------------
 
 While methods ``read()``, ``json()`` and ``text()`` are very convenient
-you should be careful. All of this methods load whole response into memory.
-For example if you want to download several gigabyte sized file, this methods
-will load whole data into memory. But you can use ``ClientResponse.content``
-attribute. It is instance of ``aiohttp.StreamReader`` class. The ``gzip``
+you should use them carefully. All this methods loads the whole response in memory.
+For example if you want to download several gigabyte sized files, this methods
+will load all the data in memory. Instead you can use the ``ClientResponse.content``
+attribute. It is an instance of the ``aiohttp.StreamReader`` class. The ``gzip``
 and ``deflate`` transfer-encodings are automatically decoded for you.
 
 .. code::
@@ -169,16 +172,17 @@ streamed to a file::
     ...             break
     ...         fd.write(chunk)
 
-It is not possible to use ``read()``, ``json()`` and ``text()`` after that.
+It is not possible to use ``read()``, ``json()`` and ``text()`` after reading the file
+with ``chunk_size``.
 
 
 Custom Headers
 --------------
 
-If you'd like to add HTTP headers to a request, simply pass in a ``dict`` to the
+If you need to add HTTP headers to a request, pass them in a ``dict`` to the
 ``headers`` parameter.
 
-For example, we didn't specify our content-type in the previous example::
+For example, if you want to specify the content-type for the previous example::
 
     >>> import json
     >>> url = 'https://api.github.com/some/endpoint'
@@ -212,9 +216,8 @@ dictionary of data will automatically be form-encoded when the request is made::
       ...
     }
 
-There are many times that you want to send data that is not
-form-encoded. If you pass in a ``string`` instead of a ``dict``, that
-data will be posted directly.
+If you want to send data that is not form-encoded you can do it by passing a ``string``
+instead of a ``dict``. This data will be posted directly.
 
 For example, the GitHub API v3 accepts JSON-Encoded POST/PATCH data::
 
@@ -247,7 +250,7 @@ You can set the filename, content_type explicitly::
 
     >>> yield from aiohttp.request('post', url, data=data)
 
-If you pass file object as data parameter, aiohttp will stream it to server
+If you pass a file object as data parameter, aiohttp will stream it to the server
 automatically. Check :class:`aiohttp.stream.StreamReader` for supported format
 information.
 
@@ -259,14 +262,14 @@ Streaming uploads
 aiohttp support multiple types of streaming uploads, which allows you to
 send large files without reading them into memory.
 
-In simple case, simply provide a file-like object for your body::
+As a simple case, simply provide a file-like object for your body::
 
     >>> with open('massive-body', 'rb') as f:
     ...   yield from aiohttp.request(
     ...       'post', 'http://some.url/streamed', data=f)
 
 
-Or you can provide ``asyncio`` coroutine that yields bytes objects::
+Or you can provide an ``asyncio`` coroutine that yields bytes objects::
 
    >>> @asyncio.coroutine
    ... def my_coroutine():
@@ -278,10 +281,10 @@ Or you can provide ``asyncio`` coroutine that yields bytes objects::
 .. note::
    It is not a standard ``asyncio`` coroutine as it yields values so it
    can not be used like ``yield from my_coroutine()``.
-   ``aiohttp`` internally handles such a coroutines.
+   ``aiohttp`` internally handles such coroutines.
 
-Also it is possible to use ``StreamReader`` object. Lets say we want to upload
-file from another request and calculate file sha1 hash::
+Also it is possible to use a ``StreamReader`` object. Lets say we want to upload
+a file from another request and calculate the file sha1 hash::
 
    >>> def feed_stream(resp, stream):
    ...    h = hashlib.sha1()
@@ -303,8 +306,8 @@ file from another request and calculate file sha1 hash::
    >>> file_hash = yield from feed_stream(resp, stream)
 
 
-Because response's content attribute is a StreamReader, you can chain get and
-post requests togethere::
+Because the response content attribute is a StreamReader, you can chain get and
+post requests together::
 
    >>> r = yield from aiohttp.request('get', 'http://python.org')
    >>> yield from aiohttp.request('post',
@@ -319,7 +322,7 @@ Keep-Alive and connection pooling
 
 By default aiohttp does not use connection pooling. To enable connection pooling
 you should use one of the ``connector`` objects. There are several of them.
-Most widly used is :class:`aiohttp.connector.TCPConnector`::
+The most widely used is :class:`aiohttp.connector.TCPConnector`::
 
   >>> conn = aiohttp.TCPConnector()
   >>> r = yield from aiohttp.request(
@@ -341,8 +344,8 @@ checks can be relaxed by passing ``verify_ssl=False``::
 
 
 If you need to setup custom ssl parameters (use own certification
-files for example) you can create :class:`ssl.SSLContext` instance and
-pass it into connector::
+files for example) you can create a :class:`ssl.SSLContext` instance and
+pass it into the connector::
 
   >>> sslcontext = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
   >>> sslcontext.verify_mode = ssl.CERT_REQUIRED
@@ -355,7 +358,7 @@ pass it into connector::
 Unix domain sockets
 -------------------
 
-If your http server uses unix domain socket you can use
+If your http server uses unix domain sockets you can use
 :class:`aiohttp.connector.UnixConnector`::
 
   >>> conn = aiohttp.UnixConnector(path='/path/to/socket')

--- a/docs/client_websockets.rst
+++ b/docs/client_websockets.rst
@@ -12,8 +12,8 @@ WebSockets Client
 
 :mod:`aiohttp` works with client websockets out-of-the-box.
 
-You have to use :func:`aiohttp.ws_connect()` function for client
-websocket connection. It accepts *url* as a first parameter and returns
+You have to use the :func:`aiohttp.ws_connect()` function for client
+websocket connection. It accepts a *url* as a first parameter and returns
 :class:`ClientWebSocketResponse`, with that object you can communicate with
 websocket server using response's methods:
 
@@ -44,14 +44,14 @@ data asynchronously (by ``yield from ws.send_str('data')`` for example).
 ClientWebSocketResponse
 -----------------------
 
-To connect to websocket server you have to use `aiohttp.ws_connect()` function,
-do not create instance of class :class:`ClientWebSocketResponse` manually.
+To connect to a websocket server you have to use the `aiohttp.ws_connect()` function,
+do not create an instance of class :class:`ClientWebSocketResponse` manually.
 
 .. py:function:: ws_connect(url, protocols=(), connector=None, autoclose=True, autoping=True, loop=None)
 
-   This function creates websocket connection, checks response and
-   returns :class:`ClientWebSocketResponse` object. It may raise
-   :exc:`~aiohttp.errors.WSServerHandshakeError` exception.
+   This function creates a websocket connection, checks the response and
+   returns a :class:`ClientWebSocketResponse` object. In case of failure
+   it may raise a :exc:`~aiohttp.errors.WSServerHandshakeError` exception.
 
    :param str url: websocket server url
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,25 +5,25 @@ Contributing
 
 .. _GitHub: https://github.com/KeepSafe/aiohttp
 
-Instruction for contributors
+Instructions for contributors
 ----------------------------
 
 
-At first make a clone of _GitHub repo: open the link and press "Fork"
-button on upper-right side of web page.
+In order to make a clone of the GitHub_ repo: open the link and press the
+"Fork" button on the upper-right menu of the web page.
 
-I hope everybody know how to work with git and github for todays :)
+I hope everybody knows how to work with git and github nowadays :)
 
 Make a change.
 
-**But**, before sending pull request please run test suite at least.
+**But**, before sending a pull request please at least run the test suite.
 
 Preconditions for running aiohttp test suite
 --------------------------------------------
 
-We expect existing python virtual environment for running our tests.
+We expect you to use a python virtual environment to run our tests.
 
-There are several ways for making virtual environment.
+There are several ways to make a virtual environment.
 
 If you like to use *virtualenv* please run::
 
@@ -41,9 +41,9 @@ For *virtualenvwrapper* (my choice)::
    $ mkvirtualenv --python=`which python3` aiohttp
 
 There are other tools like *pyvenv* but you know the rule of thumb
-now: create python3 virtual environment and activate it.
+now: create a python3 virtual environment and activate it.
 
-After that please install libraries requered for development::
+After that please install libraries required for development::
 
    $ pip install -r requirements-dev.txt
 
@@ -51,22 +51,23 @@ We also recommend to install *ipdb* but it's on your own::
 
    $ pip install ipdb
 
-Congratulations, you are ready to run test suite
+Congratulations, you are ready to run the test suite
 
 
 Run aiohhtp test suite
 ----------------------
 
-After all preconditions are done you can run tests::
+After all the preconditions are met you can run tests typing the next
+command::
 
    $ make test
 
-The command at first will run *flake8* tool (sorry, we don't accept
-pull requests with pep8 of pyflakes errors).
+The command at first will run the *flake8* tool (sorry, we don't accept
+pull requests with pep8 or pyflakes errors).
 
 On *flake8* success the tests will be run.
 
-Please take a look on produced output.
+Please take a look on the produced output.
 
 Any extra texts (print statements and so on) should be removed.
 
@@ -74,35 +75,37 @@ Any extra texts (print statements and so on) should be removed.
 Tests coverage
 --------------
 
-We are strongly keeping our test coverage, please don't make it worse.
+We are strongly trying to have a good test coverage, 
+please don't make it worst.
 
 Use::
 
    $ make cov
 
-to run test suite and collect coverage information. At the end command
-execution prints line like
+to run test suite and collect coverage information. Once the command
+has finished check your coverage at the file that appears in the last
+line of the output:
 ``open file:///.../aiohttp/coverage/index.html``
 
-Please go to the link and make sure that your code change is good covered.
+Please go to the link and make sure that your code change is covered.
 
 
 Documentation
 -------------
 
-We are encourage documentation improvements.
+We encourage documentation improvements.
 
-Please before making Pull Request about documentation changes do run::
+Please before making a Pull Request about documentation changes run::
 
    $ make doc
 
-It's finished by print
+Once it finishes it will output the index html page
 ``open file:///.../aiohttp/docs/_build/html/index.html``
 , like :command:`make cov` does.
 
-Go to the link and make sure your docs change looks good.
+Go to the link and make sure your doc changes looks good.
 
 The End
 -------
 
-After finishing all steps make GutHub Pull Request, thanks.
+After finishing all steps make a GitHub_ Pull Request, thanks.

--- a/docs/gunicorn.rst
+++ b/docs/gunicorn.rst
@@ -12,7 +12,7 @@ Everything was tested on Ubuntu 14.04::
   >> mkdir myapp
   >> cd myapp
 
-Ubuntu has bug in pyenv, so to create virtualenv you need to do some
+Ubuntu has a bug in pyenv, so to create virtualenv you need to do some
 extra manipulation::
  
   >> pyvenv-3.4 --without-pip venv
@@ -21,7 +21,7 @@ extra manipulation::
   >> deactivate
   >> source venv/bin/activate
 
-Virtual environment is ready, now we need to install aiohttp and gunicorn::
+The Virtual environment should be ready, now we need to install aiohttp and gunicorn::
 
   >> pip install gunicorn
   >> pip install -e git+https://github.com/KeepSafe/aiohttp.git#egg=aiohttp
@@ -30,7 +30,7 @@ Virtual environment is ready, now we need to install aiohttp and gunicorn::
 Application
 -----------
 
-Lets write simple application:
+Lets write a simple application:
 
 .. code-block:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 aiohttp
 =======
 
-http client/server for asyncio (:pep:`3156`).
+HTTP client/server for asyncio (:pep:`3156`).
 
 .. _GitHub: https://github.com/KeepSafe/aiohttp
 
@@ -25,12 +25,12 @@ Library Installation
 
    pip install aiohttp
 
-For smart detection of *Content-Type* by client API you would like to
+For smart detection of *Content-Type* by the client API you would need to
 install `chardet` also::
 
    pip install chardet
 
-*Optional*: To improve performances, you can install `Cython`
+*Optional*: To improve performance, you can install `Cython`
 **before** `aiohttp`::
 
    pip install cython
@@ -89,9 +89,9 @@ Source code
 
 The project is hosted on GitHub_
 
-Please feel free to file an issue on `bug tracker
+Please feel free to file an issue on the `bug tracker
 <https://github.com/KeepSafe/aiohttp/issues>`_ if you have found a bug
-or have some suggestion for library improvement.
+or have some suggestion in order to improve the library.
 
 The library uses `Travis <https://travis-ci.org/KeepSafe/aiohttp>`_ for
 Continuous Integration.
@@ -106,8 +106,8 @@ Dependencies
 Contributing
 ------------
 
-Please read :ref:`instruction for contributors<aiohttp-contributing>`
-before making Pull Request.
+Please read the :ref:`instructions for contributors<aiohttp-contributing>`
+before making a Pull Request.
 
 
 Authors and License

--- a/docs/multidict.rst
+++ b/docs/multidict.rst
@@ -9,7 +9,7 @@ Multidicts
 
 
 *HTTP Headers* and *URL query string* require specific data structure:
-*multidict*. It behaves mostly like a :class:`dict` but may have
+*multidict*. It behaves mostly like a :class:`dict` but it can have
 several *values* for the same *key*.
 
 :mod:`aiohttp.multidict` has four multidict classes:
@@ -18,12 +18,12 @@ and :class:`CIMultiDictProxy`.
 
 Immutable proxies (:class:`MultiDictProxy` and
 :class:`CIMultiDictProxy`) provide a dynamic view on the
-proxied multidict, the view reflects the multidict changes. They are
-implement :class:`~collections.abc.Mapping` interface.
+proxied multidict, the view reflects the multidict changes. They
+implement the :class:`~collections.abc.Mapping` interface.
 
 Regular mutable (:class:`MultiDict` and :class:`CIMultiDict`) classes
-implement :class:`~collections.abc.MutableMapping` and allow to change
-own content.
+implement :class:`~collections.abc.MutableMapping` and allows to change
+their own content.
 
 
 *Case insensitive* (:class:`CIMultiDict` and
@@ -46,11 +46,11 @@ MultiDict
            MultiDict(mapping, **kwargs)
            MultiDict(iterable, **kwargs)
 
-   Create a mutable multidict instance.
+   Creates a mutable multidict instance.
 
    Accepted parameters are the same as for :class:`dict`.
 
-   If the same key produced several times it will be added, e.g.::
+   If the same key appears several times it will be added, e.g.::
 
       >>> d = MultiDict[('a', 1), ('b', 2), ('a', 3)])
       >>> d
@@ -58,7 +58,7 @@ MultiDict
 
    .. method:: len(d)
 
-      Return number of items in multidict *d*.
+      Return the number of items in multidict *d*.
 
    .. method:: d[key]
 
@@ -343,10 +343,10 @@ upstr
 :class:`CIMultiDict` accepts :class:`str` as *key* argument for dict
 lookups but converts it to upper case internally.
 
-For more effective processing it should to know if *key* is already upper cased.
+For more effective processing it should know if the *key* is already upper cased.
 
-To skip :meth:`~str.upper()` call you may create upper cased string by
-hands, e.g::
+To skip the :meth:`~str.upper()` call you may want to create upper cased strings by
+hand, e.g::
 
    >>> key = upstr('Key')
    >>> key
@@ -358,13 +358,13 @@ hands, e.g::
    'value'
 
 For performance you should create :class:`upstr` strings once and
-store it globally, like :mod:`aiohttp.hdrs` does.
+store them globally, like :mod:`aiohttp.hdrs` does.
 
 .. class:: upstr(object='')
            upstr(bytes_or_buffer[, encoding[, errors]])
 
       Create a new **upper cased** string object from the given
-      *object*. If *encoding* or *errors* is specified, then the
+      *object*. If *encoding* or *errors* are specified, then the
       object must expose a data buffer that will be decoded using the
       given encoding and error handler.
 

--- a/docs/multipart.rst
+++ b/docs/multipart.rst
@@ -7,30 +7,31 @@
 Working with Multipart
 ======================
 
-`aiohttp` supports full featured multipart reader and writer. Both are designed
+`aiohttp` supports a full featured multipart reader and writer. Both are designed
 with steaming processing in mind to avoid unwanted footprint which may be
 significant if you're dealing with large payloads, but this also means that
-most I/O operation are only possible to execute only a single time.
+most I/O operation are only possible to be executed a single time.
 
 Reading Multipart Responses
 ---------------------------
 
-Assume you made a request, as usual, and want to process the respond multipart
+Assume you made a request, as usual, and want to process the response multipart
 data::
 
     >>> resp = yield from aiohttp.request(...)
 
 First, you need to wrap the response with a
-:meth:`MultipartReader.from_response`. This needs to keep implementation of
-:class:`MultipartReader` separated from response and connection routines what
-makes him more portable::
+:meth:`MultipartReader.from_response`. This needs to keep the implementation of
+:class:`MultipartReader` separated from the response and the connection routines 
+which makes it more portable::
 
     >>> reader = aiohttp.MultipartReader.from_response(resp)
 
 Let's assume with this response you'd received some JSON document and multiple
 files for it, but you don't need all of them, just a specific one.
 
-So first you need to enter into a loop where multipart body will be processed::
+So first you need to enter into a loop where the multipart body will 
+be processed::
 
     >>> metadata = None
     >>> filedata = None
@@ -38,11 +39,11 @@ So first you need to enter into a loop where multipart body will be processed::
     ...     part = yield from reader.next()
 
 The returned type depends on what the next part is: if it's a simple body part
-than you'll get :class:`BodyPartReader` instance here, otherwise, it will
+then you'll get :class:`BodyPartReader` instance here, otherwise, it will
 be another :class:`MultipartReader` instance for the nested multipart. Remember,
 that multipart format is recursive and supports multiple levels of nested body
 parts. When there are no more parts left to fetch, ``None`` value will be
-returned - that's our signal to break the loop::
+returned - that's the signal to break the loop::
 
     ...     if part is None:
     ...         break
@@ -55,23 +56,24 @@ body part headers: this allows you to filter parts by their attributes::
     ...         continue
 
 Nor :class:`BodyPartReader` or :class:`MultipartReader` instances doesn't
-reads whole body part data without explicit asking for. :class:`BodyPartReader`
-provides a set of helpers to fetch popular content types in friendly way:
+read the whole body part data without explicitly asking for.
+:class:`BodyPartReader` provides a set of helpers methods 
+to fetch popular content types in friendly way:
 
 - :meth:`BodyPartReader.text` for plaintext data;
 - :meth:`BodyPartReader.json` for JSON;
 - :meth:`BodyPartReader.form` for `application/www-urlform-encode`
 
-Each of these helpers automagically recognizes if content is compressed by
+Each of these methods automagically recognizes if content is compressed by
 using `gzip` and `deflate` encoding (while it respects `identity` one), or if
 transfer encoding is base64 or `quoted-printable` - in each case the result
-will get automagically decoded. But in case if you need to access to raw binary
+will get automagically decoded. But in case you need to access to raw binary
 data as it is, there are :meth:`BodyPartReader.read` and
 :meth:`BodyPartReader.read_chunk` coroutine methods as well to read raw binary
 data as it is all-in-single-shot or by chunks respectively.
 
 When you have to deal with multipart files, the :attr:`BodyPartReader.filename`
-property comes to the aid. It's very smart helper which handles
+property comes to help. It's a very smart helper which handles
 `Content-Disposition` handler right and extracts the right filename attribute
 from it::
 
@@ -79,9 +81,9 @@ from it::
     ...         continue
 
 If current body part doesn't matches your expectation and you want to skip it
-- just continue a loop to start a next iteration of it. Here the magic happens.
-Before fetch next body part ``yield from reader.next()`` ensures that previous
-one was read completely. If it wasn't even started to be, all it content
+- just continue a loop to start a next iteration of it. Here is where magic 
+happens. Before fetching the next body part ``yield from reader.next()`` it 
+ensures that the previous one was read completely. If it wasn't, all its content
 sends to the void in term to fetch the next part. So you don't have to care
 about cleanup routines while you're within a loop.
 
@@ -95,11 +97,11 @@ to do::
 
     ...     filedata = part.decode(filedata)
 
-Once you done multipart processing, just break a loop::
+Once you are done wirh multipart processing, just break a loop::
 
     ...     break
 
-And release connection to not let it hold a response in the middle of the data::
+And release the connection to do not hang the response in the middle of the data::
 
     ...  yield from resp.release()  # or yield from reader.release()
 
@@ -129,8 +131,8 @@ to design your multipart data closer to how it will be::
     ...         ...
     ...     mpwriter.append(subwriter)
 
-The :meth:`MultipartWriter.append` is used join a new body parts into the
-single stream. It accepts various input and determines which default headers
+The :meth:`MultipartWriter.append` is used to join new body parts into a
+single stream. It accepts various inputs and determines what default headers
 should be used for.
 
 For text data default `Content-Type` is :mimetype:`text/plain; charset=utf-8`::
@@ -141,7 +143,7 @@ For binary data :mimetype:`application/octet-stream` is used::
 
     ...     mpwriter.append(b'aiohttp')
 
-You can always override these default by passing own headers with the second
+You can always override these default by passing your own headers with the second
 argument::
 
     ...     mpwriter.append(io.BytesIO(b'GIF89a...'),
@@ -149,18 +151,18 @@ argument::
 
 For file objects `Content-Type` will be determined by using Python's
 `mimetypes`_ module and additionally `Content-Disposition` header will include
-file's basename::
+the file's basename::
 
     ...     part = root.append(open(__file__, 'rb))
 
-If you want to send a file with different name, just handle the
-:class:`BodyPartWriter` instance which :meth:`MultipartWriter.append` always
-returns and set `Content-Disposition` explicitly by using
-:meth:`BodyPartWriter.set_content_disposition` helper::
+If you want to send a file with a different name, just handle the
+:class:`BodyPartWriter` instance which :meth:`MultipartWriter.append` will
+always return and set `Content-Disposition` explicitly by using
+the :meth:`BodyPartWriter.set_content_disposition` helper::
 
     ...     part.set_content_disposition('attachment', filename='secret.txt')
 
-Additionally, you may set other headers here::
+Additionally, you may want to set other headers here::
 
     ...     part.headers[aiohttp.hdrs.CONTENT_ID] = 'X-12345'
 
@@ -176,25 +178,25 @@ and form urlencoded data, so you don't have to encode it every time manually::
     ...     mpwriter.append_json({'test': 'passed'})
     ...     mpwriter.append_form([('key', 'value')])
 
-When it's done, to make a request just pass root :class:`MultipartWriter`
+When it's done, to make a request just pass a root :class:`MultipartWriter`
 instance as :func:`aiohttp.client.request` `data` argument::
 
     >>> yield from aiohttp.request('POST', 'http://example.com', data=mpwriter)
 
-Behind the scene :meth:`MultipartWriter.serialize` will yield by chunks every
+Behind the scenes :meth:`MultipartWriter.serialize` will yield chunks of every
 part and if body part has `Content-Encoding` or `Content-Transfer-Encoding`
 they will be applied on streaming content.
 
 Please note, that on :meth:`MultipartWriter.serialize` all the file objects
-will be read till the end and there is no way to repeat a request without rewind
-their pointers to the start.
+will be read until the end and there is no way to repeat a request without 
+rewinding their pointers to the start.
 
 Hacking Multipart
 -----------------
 
-The Internet is a full of terror and sometimes you may find a server which
-implements a multipart support in a strange ways when an oblivious solution
-doesn't works.
+The Internet is full of terror and sometimes you may find a server which
+implements multipart support in strange ways when an oblivious solution
+doesn't work.
 
 For instance, is server used `cgi.FieldStorage`_ then you have to ensure that
 no body part contains a `Content-Length` header::
@@ -205,18 +207,18 @@ no body part contains a `Content-Length` header::
 On the other hand, some server may require to specify `Content-Length` for the
 whole multipart request. `aiohttp` doesn't do that since it sends multipart
 using chunked transfer encoding by default. To overcome this issue, you have
-to serialize a :class:`MultipartWriter` by our own in the way to calculate it
+to serialize a :class:`MultipartWriter` by our own in the way to calculate its
 size::
 
     body = b''.join(mpwriter.serialize())
     yield from aiohttp.request('POST', 'http://example.com',
                                data=body, headers=mpwriter.headers)
 
-Sometimes the server response may not be well structured: it may or may not
-contains nested parts. For instance, we requesting a resource which returns
-JSON documents with the files attached to it. If document has any attachments,
-they are returned as a nested multipart thing. If it has not it comes as plain
-body part::
+Sometimes the server response may not be well formed: it may or may not
+contains nested parts. For instance, we request a resource which returns
+JSON documents with the files attached to it. If the document has any 
+attachments, they are returned as a nested multipart.
+If it has not it responds as plain body parts::
 
     CONTENT-TYPE: multipart/mixed; boundary=--:
 
@@ -256,7 +258,8 @@ body part::
     ----:--
     --:--
 
-Reading such kind of data in single stream is possible, but not clean a lot::
+Reading such kind of data in single stream is possible, but is not clean at 
+all::
 
     result = []
     while True:

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -7,14 +7,14 @@ Low-level HTTP Server
 
 .. note::
 
-   The topic describes low-level HTTP support. For high-level
+   This topic describes the low-level HTTP support. For high-level
    interface please take a look on :mod:`aiohttp.web`.
 
 Run a basic server
 ------------------
 
 Start implementing the basic server by inheriting
-aiohttp.server.ServerHttpProtocol object. Your class
+the aiohttp.server.ServerHttpProtocol object. Your class
 should implement the only method handle_request which must
 be a coroutine to handle requests asynchronously
 
@@ -42,7 +42,7 @@ be a coroutine to handle requests asynchronously
             response.write(b'<h1>It Works!</h1>')
             yield from response.write_eof()
 
-Next step is creating a loop and registering your handler within a server.
+The next step is to create a loop and register your handler within a server.
 KeyboardInterrupt exception handling is necessary so you can stop
 your server with Ctrl+C at any time.
 
@@ -63,10 +63,10 @@ your server with Ctrl+C at any time.
 Headers
 -------
 
-Data is passed to handler in the ``message``, while request body is
+Data is passed to the handler in the ``message``, while request body is
 passed in ``payload`` param.  HTTP headers are accessed through
-``headers`` member of the message.  To check what current request
-method is, use ``method`` member of the ``message``. It should be one
+``headers`` member of the message.  To check what the current method of
+the request is use the ``method`` member of the ``message``. It should be one
 of ``GET``, ``POST``, ``PUT`` or ``DELETE`` strings.
 
 Handling GET params
@@ -98,7 +98,7 @@ Handling POST data
 ------------------
 
 POST data is accessed through the ``payload.read()`` generator method.
-If you have form data in the request body, you can parse it the same way as
+If you have form data in the request body, you can parse it in the same way as
 GET params.
 
  .. code-block:: python

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -9,16 +9,16 @@ HTTP Server Usage
 
 .. versionchanged:: 0.12
 
-   The module was deeply refactored in backward incompatible manner.
+   The module was deeply refactored which makes it backward incompatible.
 
 Run a simple web server
 -----------------------
 
-For implementing a web server, first create a :ref:`request
+In order to implement a web server, first create a :ref:`request
 handler<aiohttp-web-handler>`.
 
 Handler is a :ref:`coroutine<coroutine>` or a regular function that
-accepts only *request* parameter of type :class:`Request`
+accepts only *request* parameters of type :class:`Request`
 and returns :class:`Response` instance::
 
    import asyncio
@@ -67,7 +67,7 @@ Handlers are connected to the :class:`Application` via routes::
 
 .. _aiohttp-web-variable-handler:
 
-You can also use *variable routes*. If route contains string like
+You can also use *variable routes*. If route contains strings like
 ``'/a/{name}/c'`` that means the route matches to the path like
 ``'/a/b/c'`` or ``'/a/1/c'``.
 
@@ -82,7 +82,7 @@ Parsed *path part* will be available in the *request handler* as
    app.router.add_route('GET', '/{name}', variable_handler)
 
 
-Also you can specify regex for variable route in form ``{name:regex}``::
+You can also specify regex for variable route in the form ``{name:regex}``::
 
    app.router.add_route('GET', r'/{name:\d+}', variable_handler)
 
@@ -134,11 +134,11 @@ Custom conditions for routes lookup
 Sometimes you need to distinguish *web-handlers* on more complex
 criteria than *HTTP method* and *path*.
 
-While :class:`UrlDispatcher` doesn't accept extra criterias there is
+While :class:`UrlDispatcher` doesn't accept extra criterias there is an 
 easy way to do the task by implementing the second routing layer by
-hands.
+hand.
 
-The example shows custom processing based on *HTTP Accept* header:
+The next example shows custom processing based on *HTTP Accept* header:
 
 .. code-block:: python
 
@@ -182,12 +182,12 @@ The example shows custom processing based on *HTTP Accept* header:
 .. versionadded:: 0.15
 
 :mod:`aiohttp.web` supports *Expect* header. By default
-it responses with *HTTP/1.1 100 Continue* status code.
+it responds with an *HTTP/1.1 100 Continue* status code.
 It is possible to specify custom *Expect* header handler on per route basis.
-This handler get called after receiving all headers and before
+This handler gets called after receiving all headers and before
 processing application middlewares :ref:`aiohttp-web-middlewares` and route
-handler. Handler can return *None*, in that case request processing
-continues as usual. If handler returns instance of
+handler. Handler can return *None*, in that case the request processing
+continues as usual. If handler returns an instance of
 class :class:`StreamResponse`, *request handler* uses it as response.
 Custom handler *must* write *HTTP/1.1 100 Continue* status if all checks pass.
 
@@ -220,7 +220,7 @@ File Uploads
 
 There are two steps necessary for handling file uploads. The first is
 to make sure that you have a form that has been setup correctly to accept
-files. This means adding *enctype* attribute to your form element with
+files. This means adding the *enctype* attribute to your form element with
 the value of *multipart/form-data*. A very simple example would be a
 form that accepts a mp3 file. Notice, we have set up the form as
 previously explained and also added the *input* element of the *file*
@@ -278,7 +278,7 @@ WebSockets
 
 You have to create :class:`WebSocketResponse` in
 :ref:`web-handler<aiohttp-web-handler>` and communicate with peer
-using response's methods::
+using response's methods:
 
 .. code-block:: python
 
@@ -299,7 +299,7 @@ using response's methods::
                 print(exc.code, exc.message)
                 return ws
 
-You can have the only websocket reader task (which can call ``yield
+You can have only one websocket reader task (which can call ``yield
 from ws.receive_str()``) and multiple writer tasks which can only send
 data asynchronously (by ``yield from ws.send_str('data')`` for example).
 
@@ -317,7 +317,7 @@ subclass of the :class:`~HTTPException`.
 Those exceptions are derived from :class:`Response` too, so you can
 either return exception object from :ref:`aiohttp-web-handler` or raise it.
 
-The following snippets are equal::
+The following snippets are the same::
 
     @asyncio.coroutine
     def handler(request):
@@ -435,7 +435,7 @@ middleware chain.
 The last handler is :ref:`web-handler<aiohttp-web-handler>` selected
 by routing itself (:meth:`~UrlDispatcher.resolve` call).
 
-Middleware should return new coroutine by wrapping *handler*
+Middleware should return a new coroutine by wrapping *handler*
 parameter. Signature of returned handler should be the same as for
 :ref:`web-handler<aiohttp-web-handler>`: accept single *request*
 parameter, return *response* or raise exception.


### PR DESCRIPTION
I was going to read the documentation in order to start contributing and I saw there was some typos, a broken link to ```_GitHub``` instead of ```GitHub_``` and some English was difficult to understand.

I hope it makes sense. If you want me I can review the rest of the documentation for typos/improvements.