### PR TITLE
Websocket pack optimizing

### DIFF
--- a/aiohttp/websocket.py
+++ b/aiohttp/websocket.py
@@ -33,6 +33,7 @@ Message = collections.namedtuple('Message', ['tp', 'data', 'extra'])
 UNPACK_HEADER = struct.Struct('!BB').unpack
 UNPACK_LEN2 = struct.Struct('!H').unpack_from
 UNPACK_LEN3 = struct.Struct('!Q').unpack_from
+UNPACK_CLOSE_CODE = struct.Struct('!H').unpack
 PACK_LEN1 = struct.Struct('!BB').pack
 PACK_LEN2 = struct.Struct('!BBH').pack
 PACK_LEN3 = struct.Struct('!BBQ').pack
@@ -139,7 +140,7 @@ def parse_message(buf):
 
     if opcode == OPCODE_CLOSE:
         if len(payload) >= 2:
-            close_code = struct.unpack('!H', payload[:2])[0]
+            close_code = UNPACK_CLOSE_CODE(payload[:2])[0]
             close_message = payload[2:]
             return Message(OPCODE_CLOSE, close_code, close_message)
         elif payload:

--- a/aiohttp/websocket.py
+++ b/aiohttp/websocket.py
@@ -30,7 +30,6 @@ WS_HDRS = (hdrs.UPGRADE,
 
 Message = collections.namedtuple('Message', ['tp', 'data', 'extra'])
 
-UNPACK_HEADER = Struct('!BB').unpack
 UNPACK_LEN2 = Struct('!H').unpack_from
 UNPACK_LEN3 = Struct('!Q').unpack_from
 UNPACK_CLOSE_CODE = Struct('!H').unpack
@@ -83,7 +82,7 @@ def parse_frame(buf):
     """Return the next frame from the socket."""
     # read header
     data = yield from buf.read(2)
-    first_byte, second_byte = UNPACK_HEADER(data)
+    first_byte, second_byte = data
 
     fin = (first_byte >> 7) & 1
     rsv1 = (first_byte >> 6) & 1

--- a/aiohttp/websocket.py
+++ b/aiohttp/websocket.py
@@ -5,7 +5,7 @@ import binascii
 import collections
 import hashlib
 import os
-import struct
+from struct import Struct
 from aiohttp import errors, hdrs
 from aiohttp.log import ws_logger
 
@@ -30,14 +30,14 @@ WS_HDRS = (hdrs.UPGRADE,
 
 Message = collections.namedtuple('Message', ['tp', 'data', 'extra'])
 
-UNPACK_HEADER = struct.Struct('!BB').unpack
-UNPACK_LEN2 = struct.Struct('!H').unpack_from
-UNPACK_LEN3 = struct.Struct('!Q').unpack_from
-UNPACK_CLOSE_CODE = struct.Struct('!H').unpack
-PACK_LEN1 = struct.Struct('!BB').pack
-PACK_LEN2 = struct.Struct('!BBH').pack
-PACK_LEN3 = struct.Struct('!BBQ').pack
-PACK_CLOSE_CODE = struct.Struct('!H').pack
+UNPACK_HEADER = Struct('!BB').unpack
+UNPACK_LEN2 = Struct('!H').unpack_from
+UNPACK_LEN3 = Struct('!Q').unpack_from
+UNPACK_CLOSE_CODE = Struct('!H').unpack
+PACK_LEN1 = Struct('!BB').pack
+PACK_LEN2 = Struct('!BBH').pack
+PACK_LEN3 = Struct('!BBQ').pack
+PACK_CLOSE_CODE = Struct('!H').pack
 
 
 class WebSocketError(Exception):

--- a/aiohttp/websocket.py
+++ b/aiohttp/websocket.py
@@ -37,6 +37,7 @@ UNPACK_CLOSE_CODE = struct.Struct('!H').unpack
 PACK_LEN1 = struct.Struct('!BB').pack
 PACK_LEN2 = struct.Struct('!BBH').pack
 PACK_LEN3 = struct.Struct('!BBQ').pack
+PACK_CLOSE_CODE = struct.Struct('!H').pack
 
 
 class WebSocketError(Exception):
@@ -219,7 +220,7 @@ class WebSocketWriter:
         if isinstance(message, str):
             message = message.encode('utf-8')
         self._send_frame(
-            struct.pack('!H%ds' % len(message), code, message),
+            PACK_CLOSE_CODE(code) + message,
             opcode=OPCODE_CLOSE)
 
 


### PR DESCRIPTION
Use precompiled `struct.Struct(fmt).pack(...)` objects instead of `struct.pack(fmt, ...)` etc.