### PR TITLE
Mask outgoing data for websocket frame

### DIFF
--- a/aiohttp/websocket.py
+++ b/aiohttp/websocket.py
@@ -179,16 +179,16 @@ def parse_message(buf):
 
 class WebSocketWriter:
 
-    def __init__(self, writer, *, mask=True, random=random.Random()):
+    def __init__(self, writer, *, use_mask=False, random=random.Random()):
         self.writer = writer
-        self.mask = mask
+        self.use_mask = use_mask
         self.randrange = random.randrange
 
     def _send_frame(self, message, opcode):
         """Send a frame over the websocket with message as its payload."""
         msg_length = len(message)
 
-        use_mask = self.mask
+        use_mask = self.use_mask
         if use_mask:
             mask_bit = 0x80
         else:

--- a/aiohttp/websocket_client.py
+++ b/aiohttp/websocket_client.py
@@ -64,7 +64,7 @@ def ws_connect(url, protocols=(), connector=None,
                 break
 
     reader = resp.connection.reader.set_parser(WebSocketParser)
-    writer = WebSocketWriter(resp.connection.writer)
+    writer = WebSocketWriter(resp.connection.writer, use_mask=True)
 
     return ClientWebSocketResponse(
         reader, writer, protocol, resp, autoclose, autoping, loop)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -311,42 +311,36 @@ class WebsocketWriterTests(unittest.TestCase):
 
     def setUp(self):
         self.transport = unittest.mock.Mock()
+        self.writer = websocket.WebSocketWriter(self.transport, mask=False)
 
     def test_pong(self):
-        self.writer = websocket.WebSocketWriter(self.transport, mask=False)
         self.writer.pong()
         self.transport.write.assert_called_with(b'\x8a\x00')
 
     def test_ping(self):
-        self.writer = websocket.WebSocketWriter(self.transport, mask=False)
         self.writer.ping()
         self.transport.write.assert_called_with(b'\x89\x00')
 
     def test_send_text(self):
-        self.writer = websocket.WebSocketWriter(self.transport, mask=False)
         self.writer.send(b'text')
         self.transport.write.assert_called_with(b'\x81\x04text')
 
     def test_send_binary(self):
-        self.writer = websocket.WebSocketWriter(self.transport, mask=False)
         self.writer.send('binary', True)
         self.transport.write.assert_called_with(b'\x82\x06binary')
 
     def test_send_binary_long(self):
-        self.writer = websocket.WebSocketWriter(self.transport, mask=False)
         self.writer.send(b'b' * 127, True)
         self.assertTrue(
             self.transport.write.call_args[0][0].startswith(b'\x82~\x00\x7fb'))
 
     def test_send_binary_very_long(self):
-        self.writer = websocket.WebSocketWriter(self.transport, mask=False)
         self.writer.send(b'b' * 65537, True)
         self.assertTrue(
             self.transport.write.call_args[0][0].startswith(
                 b'\x82\x7f\x00\x00\x00\x00\x00\x01\x00\x01b'))
 
     def test_close(self):
-        self.writer = websocket.WebSocketWriter(self.transport, mask=False)
         self.writer.close(1001, 'msg')
         self.transport.write.assert_called_with(b'\x88\x05\x03\xe9msg')
 
@@ -354,10 +348,10 @@ class WebsocketWriterTests(unittest.TestCase):
         self.transport.write.assert_called_with(b'\x88\x05\x03\xe9msg')
 
     def test_send_text_masked(self):
-        self.writer = websocket.WebSocketWriter(self.transport,
-                                                mask=True,
-                                                random=random.Random(123))
-        self.writer.send(b'text')
+        writer = websocket.WebSocketWriter(self.transport,
+                                           mask=True,
+                                           random=random.Random(123))
+        writer.send(b'text')
         self.transport.write.assert_called_with(
             b'\x81\x84\rg\xb3fy\x02\xcb\x12')
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -311,7 +311,7 @@ class WebsocketWriterTests(unittest.TestCase):
 
     def setUp(self):
         self.transport = unittest.mock.Mock()
-        self.writer = websocket.WebSocketWriter(self.transport, mask=False)
+        self.writer = websocket.WebSocketWriter(self.transport, use_mask=False)
 
     def test_pong(self):
         self.writer.pong()
@@ -349,7 +349,7 @@ class WebsocketWriterTests(unittest.TestCase):
 
     def test_send_text_masked(self):
         writer = websocket.WebSocketWriter(self.transport,
-                                           mask=True,
+                                           use_mask=True,
                                            random=random.Random(123))
         writer.send(b'text')
         self.transport.write.assert_called_with(


### PR DESCRIPTION
Now websocket applies mask only for incoming frames.
The PR fixes that for outgoing packets also.