### PR TITLE
Fix aiohttp.server examples to run with the latest version of aiohttp

### DIFF
--- a/examples/mpsrv.py
+++ b/examples/mpsrv.py
@@ -43,12 +43,12 @@ class HttpRequestHandler(aiohttp.server.ServerHttpProtocol):
                 isdir = os.path.isdir(path)
 
         if not path:
-            raise aiohttp.HttpProcessingError(404)
+            raise aiohttp.HttpProcessingError(code=404)
 
         if isdir and not path.endswith('/'):
             path = path + '/'
             raise aiohttp.HttpProcessingError(
-                302, headers=(('URI', path), ('Location', path)))
+                code=302, headers=(('URI', path), ('Location', path)))
 
         response = aiohttp.Response(
             self.writer, 200, http_version=message.version)

--- a/examples/srv.py
+++ b/examples/srv.py
@@ -40,8 +40,8 @@ class HttpRequestHandler(aiohttp.server.ServerHttpProtocol):
         if not path:
             raise aiohttp.HttpProcessingError(code=404)
 
-        for hdr in message.headers:
-            print(hdr, message.headers[hdr])
+        for hdr, val in message.headers.items():
+            print(hdr, val)
 
         if isdir and not path.endswith('/'):
             path = path + '/'

--- a/examples/srv.py
+++ b/examples/srv.py
@@ -38,15 +38,15 @@ class HttpRequestHandler(aiohttp.server.ServerHttpProtocol):
                 isdir = os.path.isdir(path)
 
         if not path:
-            raise aiohttp.HttpProcessingError(404)
+            raise aiohttp.HttpProcessingError(code=404)
 
-        for hdr, val in message.headers.items(getall=True):
-            print(hdr, val)
+        for hdr in message.headers:
+            print(hdr, message.headers[hdr])
 
         if isdir and not path.endswith('/'):
             path = path + '/'
             raise aiohttp.HttpProcessingError(
-                302, headers=(('URI', path), ('Location', path)))
+                code=302, headers=(('URI', path), ('Location', path)))
 
         response = aiohttp.Response(
             self.writer, 200, http_version=message.version)


### PR DESCRIPTION
Without theses fixes, you have stacktraces to read headers and for 404 and 302 pages.