### PR TITLE
Mention aiohttp_jinja2 in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,10 @@ extensions = [
     'alabaster',
 ]
 
-intersphinx_mapping = {'python': ('http://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('http://docs.python.org/3', None),
+    'aiohttp_jinja2':
+        ('http://aiohttp-jinja2.readthedocs.org/en/stable/', None)}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -22,4 +22,4 @@
 
    web-handler
 
-       An enpoint that returns http response.
+       An endpoint that returns http response.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -19,3 +19,7 @@
 
       Any object that can be called. Use :func:`callable` to check
       that.
+
+   web-handler
+
+       An enpoint that returns http response.

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -174,6 +174,34 @@ The next example shows custom processing based on *HTTP Accept* header:
    chooser.reg_acceptor('application/xml', handle_xml)
 
 
+Template rendering
+------------------
+
+:mod:`aiohttp.web` has no support for template rendering out-of-the-box.
+
+But there is third-party library :mod:`aiohttp_jinja2` which is
+supported by *aiohttp* auhtors.
+
+The usage is simple: create dictionary with data and pass it into
+template renderer.
+
+Before template rendering you have to setup *jinja2 environment* first
+(:func:`aiohttp_jinja2.setup` call)::
+
+    app = web.Application(loop=self.loop)
+    aiohttp_jinja2.setup(app,
+        loader=jinja2.FileSystemLoader('/path/to/templates/folder'))
+
+
+After that you may use template engine in your *web-handlers*. The
+most convinient way is to use :func:`aiohttp_jinja2.template`
+decorator::
+
+    @aiohttp_jinja2.template('tmpl.jinja2')
+    def handler(request):
+        return {'name': 'Andrew', 'surname': 'Svetlov'}
+
+
 .. _aiohttp-web-expect-header:
 
 *Expect* header support

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -180,7 +180,7 @@ Template rendering
 :mod:`aiohttp.web` has no support for template rendering out-of-the-box.
 
 But there is third-party library :mod:`aiohttp_jinja2` which is
-supported by *aiohttp* auhtors.
+supported by *aiohttp* authors.
 
 The usage is simple: create dictionary with data and pass it into
 template renderer.


### PR DESCRIPTION
Add reference to `aiohttp_jinja2` library in `aiohttp.web` usage instructions.