### PR TITLE
support keep-alive for http 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.tar.gz
 *~
 .DS_Store
+.Python
 .coverage
 .idea
 .installed.cfg
@@ -25,6 +26,9 @@ develop-eggs
 dist
 docs/_build/
 eggs
+include/
+lib/
+man/
 nosetests.xml
 parts
 pyvenv

--- a/aiohttp/protocol.py
+++ b/aiohttp/protocol.py
@@ -550,8 +550,11 @@ class HttpMessage:
 
     def keep_alive(self):
         if self.keepalive is None:
-            if self.version <= HttpVersion10:
-                if self.headers.get('Connection') == 'keep-alive':
+            if self.version < HttpVersion10:
+                # keep alive not supported at all
+                return False
+            if self.version == HttpVersion10:
+                if self.headers.get(hdrs.CONNECTION) == 'keep-alive':
                     return True
                 else:  # no headers means we close for Http 1.0
                     return False

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -18,7 +18,7 @@ from .multidict import (CIMultiDictProxy,
                         CIMultiDict,
                         MultiDictProxy,
                         MultiDict)
-from .protocol import Response as ResponseImpl
+from .protocol import Response as ResponseImpl, HttpVersion10
 from .streams import EOF_MARKER
 
 
@@ -95,7 +95,10 @@ class Request(dict, HeadersMixin):
         self._post = None
         self._post_files_cache = None
         self._headers = CIMultiDictProxy(message.headers)
-        self._keep_alive = not message.should_close
+        if self._version < HttpVersion10:
+            self._keep_alive = False
+        else:
+            self._keep_alive = not message.should_close
 
         # matchdict, route_name, handler
         # or information about traversal lookup

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -18,7 +18,7 @@ from .multidict import (CIMultiDictProxy,
                         CIMultiDict,
                         MultiDictProxy,
                         MultiDict)
-from .protocol import Response as ResponseImpl, HttpVersion11
+from .protocol import Response as ResponseImpl
 from .streams import EOF_MARKER
 
 
@@ -95,13 +95,7 @@ class Request(dict, HeadersMixin):
         self._post = None
         self._post_files_cache = None
         self._headers = CIMultiDictProxy(message.headers)
-
-        if self._version < HttpVersion11:
-            self._keep_alive = False
-        elif message.should_close:
-            self._keep_alive = False
-        else:
-            self._keep_alive = True
+        self._keep_alive = not message.should_close
 
         # matchdict, route_name, handler
         # or information about traversal lookup

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -5,7 +5,7 @@ import socket
 import unittest
 from aiohttp import web, request, FormData
 from aiohttp.multidict import MultiDict
-from aiohttp.protocol import HttpVersion11
+from aiohttp.protocol import HttpVersion10, HttpVersion11
 from aiohttp.streams import EOF_MARKER
 
 
@@ -460,5 +460,27 @@ class TestWebFunctional(unittest.TestCase):
                 expect100=True,  # wait until server returns 100 continue
                 loop=self.loop)
             self.assertEqual(403, resp.status)
+
+        self.loop.run_until_complete(go())
+
+    def test_http10_keep_alive(self):
+
+        @asyncio.coroutine
+        def handler(request):
+            body = yield from request.read()
+            return web.Response(body=b'OK')
+
+        @asyncio.coroutine
+        def go():
+            _, _, url = yield from self.create_server('GET', '/', handler)
+            resp = yield from request('GET', url, loop=self.loop,
+                                      version=HttpVersion10)
+            self.assertEqual('close', resp.headers['CONNECTION'])
+
+            _, _, url = yield from self.create_server('GET', '/', handler)
+            headers = {'Connection': 'keep-alive'}
+            resp = yield from request('GET', url, loop=self.loop,
+                                      headers=headers, version=HttpVersion10)
+            self.assertEqual('keep-alive', resp.headers['CONNECTION'])
 
         self.loop.run_until_complete(go())

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -463,11 +463,11 @@ class TestWebFunctional(unittest.TestCase):
 
         self.loop.run_until_complete(go())
 
-    def test_http10_keep_alive(self):
+    def test_http10_keep_alive_default(self):
 
         @asyncio.coroutine
         def handler(request):
-            body = yield from request.read()
+            yield from request.read()
             return web.Response(body=b'OK')
 
         @asyncio.coroutine
@@ -477,6 +477,34 @@ class TestWebFunctional(unittest.TestCase):
                                       version=HttpVersion10)
             self.assertEqual('close', resp.headers['CONNECTION'])
 
+        self.loop.run_until_complete(go())
+
+    def test_http10_keep_alive_with_headers_close(self):
+
+        @asyncio.coroutine
+        def handler(request):
+            yield from request.read()
+            return web.Response(body=b'OK')
+
+        @asyncio.coroutine
+        def go():
+            _, _, url = yield from self.create_server('GET', '/', handler)
+            headers = {'Connection': 'close'}
+            resp = yield from request('GET', url, loop=self.loop,
+                                      headers=headers, version=HttpVersion10)
+            self.assertEqual('close', resp.headers['CONNECTION'])
+
+        self.loop.run_until_complete(go())
+
+    def test_http10_keep_alive_with_headers(self):
+
+        @asyncio.coroutine
+        def handler(request):
+            yield from request.read()
+            return web.Response(body=b'OK')
+
+        @asyncio.coroutine
+        def go():
             _, _, url = yield from self.create_server('GET', '/', handler)
             headers = {'Connection': 'keep-alive'}
             resp = yield from request('GET', url, loop=self.loop,

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -18,6 +18,8 @@ class TestWebRequest(unittest.TestCase):
 
     def make_request(self, method, path, headers=CIMultiDict(), *,
                      version=HttpVersion(1, 1), closing=False):
+        if version < HttpVersion(1, 1):
+            closing = True
         self.app = mock.Mock()
         message = RawRequestMessage(method, path, version, headers, closing,
                                     False)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -4,7 +4,8 @@ from unittest import mock
 from aiohttp import hdrs
 from aiohttp.multidict import CIMultiDict
 from aiohttp.web import Request, StreamResponse, Response
-from aiohttp.protocol import RawRequestMessage, HttpVersion11, HttpVersion10
+from aiohttp.protocol import HttpVersion, HttpVersion11, HttpVersion10
+from aiohttp.protocol import RawRequestMessage
 
 
 class TestStreamResponse(unittest.TestCase):
@@ -356,7 +357,7 @@ class TestStreamResponse(unittest.TestCase):
         req = self.request_from_message(message)
         resp = StreamResponse()
         resp.start(req)
-        self.assertEqual(resp.keep_alive, False)
+        self.assertFalse(resp.keep_alive)
 
         headers = CIMultiDict(Connection='keep-alive')
         message = RawRequestMessage('GET', '/', HttpVersion10, headers,
@@ -365,6 +366,15 @@ class TestStreamResponse(unittest.TestCase):
         resp = StreamResponse()
         resp.start(req)
         self.assertEqual(resp.keep_alive, True)
+
+    def test_keep_alive_http09(self):
+        headers = CIMultiDict(Connection='keep-alive')
+        message = RawRequestMessage('GET', '/', HttpVersion(0, 9), headers,
+                                    False, False)
+        req = self.request_from_message(message)
+        resp = StreamResponse()
+        resp.start(req)
+        self.assertFalse(resp.keep_alive)
 
 
 class TestResponse(unittest.TestCase):


### PR DESCRIPTION
keep alive is on by default for http 1.1 and off
by default for http 1.0. parse connection headers
for 1.0 and obey. Anything less than 0.9 always
gets connection closed.

(was https://github.com/KeepSafe/aiohttp/pull/323, switched branches)