### PR TITLE
Mention aiohttp_session in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,9 @@ extensions = [
 intersphinx_mapping = {
     'python': ('http://docs.python.org/3', None),
     'aiohttp_jinja2':
-        ('http://aiohttp-jinja2.readthedocs.org/en/stable/', None)}
+        ('http://aiohttp-jinja2.readthedocs.org/en/stable/', None),
+    'aiohttp_session':
+        ('http://aiohttp-session.readthedocs.org/en/stable/', None)}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -202,6 +202,32 @@ decorator::
         return {'name': 'Andrew', 'surname': 'Svetlov'}
 
 
+User sessions
+-------------
+
+Often you need a container for storing per-user data. The concept is
+usually called *session*.
+
+:mod:`aiohttp.web` has no *sessions* but there is third-party
+:mod:`aiohttp_session` library for that::
+
+    import asycio
+    import time
+    from aiohttp import web
+    import aiohttp_session
+
+    @asyncio.coroutine
+    def handler(request):
+        session = aiohttp_session.get_session(request)
+        session['last_visit'] = time.time()
+        return web.Response('OK')
+
+    app = web.Application(middlewares=aiohttp_session.session_middleware(
+        aiohttp_session.EncryptedCookieStorage(b'Sixteen byte key')))
+
+    app.router.add_route('GET', '/', handler)
+
+
 .. _aiohttp-web-expect-header:
 
 *Expect* header support


### PR DESCRIPTION
I prefer to keep aiohttp_session as third-party library, at least for a while.