### PR TITLE
Fix file upload not chunked

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -9,7 +9,7 @@ import urllib.parse
 import weakref
 import warnings
 import chardet
-from os.path import getsize
+from os import fstat
 
 import aiohttp
 from . import hdrs, helpers, streams
@@ -386,7 +386,8 @@ class ClientRequest:
             self.body = data
             if not self.chunked and isinstance(data, io.BufferedReader):
                 # Not chunking if content-length can be determined
-                self.headers[hdrs.CONTENT_LENGTH] = str(getsize(data.name))
+                size = fstat(data.fileno()).st_size - data.tell()
+                self.headers[hdrs.CONTENT_LENGTH] = str(size)
                 self.chunked = False
             else:
                 self.chunked = True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -554,6 +554,17 @@ class ClientRequestTests(unittest.TestCase):
             self.assertEqual(req.headers['CONTENT-LENGTH'],
                              str(os.path.getsize(fname)))
 
+    def test_file_upload_not_chunked_seek(self):
+        here = os.path.dirname(__file__)
+        fname = os.path.join(here, 'sample.key')
+        with open(fname, 'rb') as f:
+            f.seek(100)
+            req = ClientRequest(
+                'post', 'http://python.org/',
+                data=f)
+            self.assertEqual(req.headers['CONTENT-LENGTH'],
+                             str(os.path.getsize(fname) - 100))
+
     def test_file_upload_force_chunked(self):
         here = os.path.dirname(__file__)
         fname = os.path.join(here, 'sample.key')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,6 +7,7 @@ import io
 import unittest
 import unittest.mock
 import urllib.parse
+import os.path
 
 import aiohttp
 from aiohttp.client import ClientRequest, ClientResponse
@@ -541,6 +542,28 @@ class ClientRequestTests(unittest.TestCase):
         req.send(self.transport, self.protocol)
         self.assertEqual(req.headers['TRANSFER-ENCODING'], 'chunked')
         self.assertNotIn('CONTENT-LENGTH', req.headers)
+
+    def test_file_upload_not_chunked(self):
+        here = os.path.dirname(__file__)
+        fname = os.path.join(here, 'sample.key')
+        with open(fname, 'rb') as f:
+            req = ClientRequest(
+                'post', 'http://python.org/',
+                data=f)
+            self.assertFalse(req.chunked)
+            self.assertEqual(req.headers['CONTENT-LENGTH'],
+                             str(os.path.getsize(fname)))
+
+    def test_file_upload_force_chunked(self):
+        here = os.path.dirname(__file__)
+        fname = os.path.join(here, 'sample.key')
+        with open(fname, 'rb') as f:
+            req = ClientRequest(
+                'post', 'http://python.org/',
+                data=f,
+                chunked=True)
+            self.assertTrue(req.chunked)
+            self.assertNotIn('CONTENT-LENGTH', req.headers)
 
     def test_expect100(self):
         req = ClientRequest('get', 'http://python.org/',


### PR DESCRIPTION
The upload of a single file is not chunked anymore as the content-length can be determined,
except if the chunked argument is passed forced as True.

This fixes #126 for uploading a single file, but does not apply to multipart uploads.