### PR TITLE
add_routes() method to attach several HTTP methods to one handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .Python
 .coverage
 .idea
+*.iml
 .installed.cfg
 .noseids
 .tox

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -315,6 +315,12 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
                 self._routes[name] = route
         self._urls.append(route)
 
+    def add_routes(self, methods, path, handler,
+                   *args, name=None, expect_handler=None):
+        for method in methods:
+            self.add_route(method=method, path=path, handler=handler,
+                           name=name, expect_handler=expect_handler, *args)
+
     def add_route(self, method, path, handler,
                   *, name=None, expect_handler=None):
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -946,6 +946,8 @@ Router is any object that implements :class:`AbstractRouter` interface.
       Pay attention please: *handler* is converted to coroutine internally when
       it is a regular function.
 
+      *Note:* You can add several HTTP methods for one handler with *add_routes()* method. Same input parameters as *add_route()*.
+
       :param str path: route path
 
       :param callable handler: route handler

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -75,6 +75,22 @@ class TestUrlDispatcher(unittest.TestCase):
         self.assertIs(handler, info.handler)
         self.assertIsNone(info.route.name)
 
+    def test_add_routes_root(self):
+        handler = self.make_handler()
+        self.router.add_routes(['GET', 'POST'], '/', handler)
+        req = self.make_request('GET', '/')
+        info = self.loop.run_until_complete(self.router.resolve(req))
+        self.assertIsNotNone(info)
+        self.assertEqual(0, len(info))
+        self.assertIs(handler, info.handler)
+        self.assertIsNone(info.route.name)
+        req = self.make_request('POST', '/')
+        info = self.loop.run_until_complete(self.router.resolve(req))
+        self.assertIsNotNone(info)
+        self.assertEqual(0, len(info))
+        self.assertIs(handler, info.handler)
+        self.assertIsNone(info.route.name)
+
     def test_add_route_simple(self):
         handler = self.make_handler()
         self.router.add_route('GET', '/handler/to/path', handler)


### PR DESCRIPTION
Hi,

For `POST` and `PUT` methods, most of the time, we share business logic in our `aiohttp.web` daemons: We use `id` parameter in payload to know if it's a new object (empty id) or we need to update the database.

For now, we duplicate lines for POST and PUT, but for example, the biggest daemon we made has 100+ endpoints, it will reduce the number of lines we need to declare endpoints.
It's another method than `add_route`, to avoid that this feature could shoot your foot in your existing source code.
For documentation, maybe I should add another method documentation, as you like.

As I've discussed with @asvetlov during aiohttp PyCON sprint code, it's the latest feature we're missing compare to the fork of aiorest we've made. To remember, instead of to continue our fork, we've decided to abandon our fork, use `aiohttp.web` and promote this solution, to mutualize efforts.
To follow this idea, we wish to integrate as most as possible our HTTP practices with `aiohttp.web`.

Thanks for your feedbacks.