### PR TITLE
Added a safeguard in an example and fixed a test

### DIFF
--- a/examples/mpsrv.py
+++ b/examples/mpsrv.py
@@ -280,6 +280,9 @@ class Supervisor:
 
 
 def main():
+    if getattr(os, "fork", None) is None:
+        print("os.fork isn't supported by your OS")
+        return
     args = ARGS.parse_args()
     if ':' in args.host:
         args.host, port = args.host.split(':', 1)

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -154,8 +154,8 @@ class TestWebFunctional(unittest.TestCase):
 
         def check_file(fs):
             fullname = os.path.join(here, fs.filename)
-            with open(fullname, 'rb') as f:
-                test_data = f.read()
+            with open(fullname, 'r') as f:
+                test_data = f.read().encode()
                 data = fs.file.read()
                 self.assertEqual(test_data, data)
 
@@ -188,8 +188,8 @@ class TestWebFunctional(unittest.TestCase):
 
         def check_file(fs):
             fullname = os.path.join(here, fs.filename)
-            with open(fullname, 'rb') as f:
-                test_data = f.read()
+            with open(fullname, 'r') as f:
+                test_data = f.read().encode()
                 data = fs.file.read()
                 self.assertEqual(test_data, data)
 
@@ -265,7 +265,7 @@ class TestWebFunctional(unittest.TestCase):
             resp = yield from request('GET', url, loop=self.loop)
             self.assertEqual(200, resp.status)
             txt = yield from resp.text()
-            self.assertEqual('file content\n', txt)
+            self.assertEqual('file content{}'.format(os.linesep), txt)
             ct = resp.headers['CONTENT-TYPE']
             self.assertEqual('application/octet-stream', ct)
             self.assertEqual(resp.headers.get('CONTENT-ENCODING'), None)


### PR DESCRIPTION
Added a os.fork safeguard for Windows in the multiprocessing server example; fixed the test_web_functional test to pass in Windows.