### PR TITLE
Add FormData validation at the add_field method.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -42,6 +42,7 @@ Sebastian Hanula
 Simon Kennedy
 Stephen Granade
 Taras Voinarovskyi
+Tolga Tezel
 Vaibhav Sagar
 Vitaly Haritonsky
 W. Trevor King

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -68,6 +68,9 @@ class FormData:
             self._is_multipart = True
 
         type_options = multidict.MultiDict({'name': name})
+        if filename is not None and not isinstance(filename, str):
+            raise TypeError('filename must be an instance of str. '
+                            'Got: %s' % filename)
         if filename is None and isinstance(value, io.IOBase):
             filename = guess_filename(value, name)
         if filename is not None:
@@ -76,9 +79,15 @@ class FormData:
 
         headers = {}
         if content_type is not None:
+            if not isinstance(content_type, str):
+                raise TypeError('content_type must be an instance of str. '
+                                'Got: %s' % content_type)
             headers[hdrs.CONTENT_TYPE] = content_type
             self._is_multipart = True
         if content_transfer_encoding is not None:
+            if not isinstance(content_transfer_encoding, str):
+                raise TypeError('content_transfer_encoding must be an instance'
+                                ' of str. Got: %s' % content_transfer_encoding)
             headers[hdrs.CONTENT_TRANSFER_ENCODING] = content_transfer_encoding
             self._is_multipart = True
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -62,14 +62,28 @@ class HelpersTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             helpers.FormData('as')  # 2-char str is not allowed
 
-    def test_invalid_formdata_fields(self):
+    def test_invalid_formdata_content_type(self):
         form = helpers.FormData()
-        invalid_vals = [0, 0.1, {}, []]
-        param_names = ['content_type', 'filename', 'content_transfer_encoding']
-        for param_name in param_names:
-            for invalid_val in invalid_vals:
-                with self.assertRaises(TypeError):
-                    form.add_field('foo', 'bar', **{param_name: invalid_val})
+        invalid_vals = [0, 0.1, {}, [], b'foo']
+        for invalid_val in invalid_vals:
+            with self.assertRaises(TypeError):
+                form.add_field('foo', 'bar', content_type=invalid_val)
+
+    def test_invalid_formdata_filename(self):
+        form = helpers.FormData()
+        invalid_vals = [0, 0.1, {}, [], b'foo']
+        for invalid_val in invalid_vals:
+            with self.assertRaises(TypeError):
+                form.add_field('foo', 'bar', filename=invalid_val)
+
+    def test_invalid_formdata_content_transfer_encoding(self):
+        form = helpers.FormData()
+        invalid_vals = [0, 0.1, {}, [], b'foo']
+        for invalid_val in invalid_vals:
+            with self.assertRaises(TypeError):
+                form.add_field('foo',
+                               'bar',
+                               content_transfer_encoding=invalid_val)
 
     def test_reify(self):
         class A:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -62,6 +62,15 @@ class HelpersTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             helpers.FormData('as')  # 2-char str is not allowed
 
+    def test_invalid_formdata_fields(self):
+        form = helpers.FormData()
+        invalid_vals = [0, 0.1, {}, []]
+        param_names = ['content_type', 'filename', 'content_transfer_encoding']
+        for param_name in param_names:
+            for invalid_val in invalid_vals:
+                with self.assertRaises(TypeError):
+                    form.add_field('foo', 'bar', **{param_name: invalid_val})
+
     def test_reify(self):
         class A:
             @helpers.reify


### PR DESCRIPTION
Prevent errors being raised further down the stack by ensuring content_type, content_transfer_encoding and filename are instances of str in `add_field`. Technically filename can be a bytes instance, but I think for sanity we probably just want to ensure that it is a str as well.