### PR TITLE
json -> ujson.

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -3,7 +3,7 @@
 import asyncio
 import http.cookies
 import io
-import json
+import ujson
 import mimetypes
 import os
 import urllib.parse
@@ -936,7 +936,7 @@ class ClientResponse:
         return self._content.decode(encoding)
 
     @asyncio.coroutine
-    def json(self, *, encoding=None, loads=json.loads):
+    def json(self, *, encoding=None, loads=ujson.loads):
         """Reads and decodes JSON response."""
         if self._content is None:
             yield from self.read()

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -1,7 +1,7 @@
 import asyncio
 import binascii
 import base64
-import json
+import ujson
 import io
 import mimetypes
 import os
@@ -316,7 +316,7 @@ class BodyPartReader(object):
         if not data:
             return None
         encoding = encoding or self.get_charset(default='utf-8')
-        return json.loads(data.decode(encoding))
+        return ujson.loads(data.decode(encoding))
 
     @asyncio.coroutine
     def form(self, *, encoding=None):
@@ -670,7 +670,7 @@ class BodyPartWriter(object):
 
     def _serialize_json(self, obj):
         *_, params = parse_mimetype(self.headers.get(CONTENT_TYPE))
-        yield json.dumps(obj).encode(params.get('charset', 'utf-8'))
+        yield ujson.dumps(obj).encode(params.get('charset', 'utf-8'))
 
     def _serialize_form(self, obj):
         if isinstance(obj, Mapping):

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -5,7 +5,7 @@ import contextlib
 import gc
 import email.parser
 import http.server
-import json
+import ujson
 import logging
 import io
 import os
@@ -272,7 +272,7 @@ class Router:
                         if cte is not None:
                             resp['content-transfer-encoding'] = cte
                         resp['multipart-data'].append(params)
-        body = json.dumps(resp, indent=4, sort_keys=True)
+        body = ujson.dumps(resp)
 
         # default headers
         hdrs = [('Connection', 'close'),

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -6,7 +6,7 @@ import cgi
 import collections
 import http.cookies
 import io
-import json
+import ujson
 import warnings
 
 from urllib.parse import urlsplit, parse_qsl, unquote
@@ -261,7 +261,7 @@ class Request(dict, HeadersMixin):
         return bytes_body.decode(encoding)
 
     @asyncio.coroutine
-    def json(self, *, loader=json.loads):
+    def json(self, *, loader=ujson.loads):
         """Return BODY as JSON."""
         body = yield from self.text()
         return loader(body)

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -4,7 +4,7 @@ import binascii
 import gc
 import io
 import os.path
-import json
+import ujson
 import http.cookies
 import asyncio
 import unittest
@@ -44,7 +44,7 @@ class HttpClientFunctionalTests(unittest.TestCase):
                 if meth == 'head':
                     self.assertEqual(b'', content1)
                 else:
-                    self.assertIn('"method": "%s"' % meth.upper(), content)
+                    self.assertIn('"method":"%s"' % meth.upper(), content)
                 self.assertEqual(content1, content2)
                 r.close()
 
@@ -67,7 +67,7 @@ class HttpClientFunctionalTests(unittest.TestCase):
                 if meth == 'head':
                     self.assertEqual(b'', content1)
                 else:
-                    self.assertIn('"method": "%s"' % meth.upper(), content)
+                    self.assertIn('"method":"%s"' % meth.upper(), content)
                 self.assertEqual(content1, content2)
                 r.close()
 
@@ -112,7 +112,7 @@ class HttpClientFunctionalTests(unittest.TestCase):
             content = content1.decode()
 
             self.assertEqual(r.status, 200)
-            self.assertIn('"method": "GET"', content)
+            self.assertIn('"method":"GET"', content)
             self.assertEqual(content1, content2)
             r.close()
 
@@ -149,7 +149,7 @@ class HttpClientFunctionalTests(unittest.TestCase):
             content = content.decode()
 
             self.assertEqual(r.status, 200)
-            self.assertIn('"method": "GET"', content)
+            self.assertIn('"method":"GET"', content)
             self.assertEqual(2, httpd['redirects'])
             r.close()
 
@@ -162,7 +162,7 @@ class HttpClientFunctionalTests(unittest.TestCase):
             content = content.decode()
 
             self.assertEqual(r.status, 200)
-            self.assertIn('"method": "POST"', content)
+            self.assertIn('"method":"POST"', content)
             self.assertEqual(2, httpd['redirects'])
             r.close()
 
@@ -184,7 +184,7 @@ class HttpClientFunctionalTests(unittest.TestCase):
             content = self.loop.run_until_complete(r.content.read())
             content = content.decode()
 
-            self.assertIn('"query": "q=test"', content)
+            self.assertIn('"query":"q=test"', content)
             self.assertEqual(r.status, 200)
             r.close()
 
@@ -198,7 +198,7 @@ class HttpClientFunctionalTests(unittest.TestCase):
             content = self.loop.run_until_complete(r.content.read())
             content = content.decode()
 
-            self.assertIn('"query": "q=test1&q=test2"', content)
+            self.assertIn('"query":"q=test1&q=test2"', content)
             self.assertEqual(r.status, 200)
             r.close()
 
@@ -212,7 +212,7 @@ class HttpClientFunctionalTests(unittest.TestCase):
                 content = yield from r.content.read()
                 content = content.decode()
 
-                self.assertIn('"query": "test=true&q=test"', content)
+                self.assertIn('"query":"test=true&q=test"', content)
                 self.assertEqual(r.status, 200)
                 r.close()
                 # let loop to make one iteration to call connection_lost
@@ -580,7 +580,7 @@ class HttpClientFunctionalTests(unittest.TestCase):
             self.assertEqual({'content-type': 'text/plain', 'data': 'foo'},
                              content['multipart-data'][0])
             self.assertEqual({'content-type': 'application/json',
-                              'data': '{"bar": "\\u0431\\u0430\\u0437"}'},
+                              'data': '{"bar":"\\u0431\\u0430\\u0437"}'},
                              content['multipart-data'][1])
             self.assertEqual(
                 {'content-type': 'application/x-www-form-urlencoded',
@@ -806,7 +806,7 @@ class HttpClientFunctionalTests(unittest.TestCase):
             self.assertEqual(r.status, 200)
 
             content = self.loop.run_until_complete(r.content.read())
-            self.assertIn(b'"Cookie": "test1=123; test3=456"', bytes(content))
+            self.assertIn(b'"Cookie":"test1=123; test3=456"', bytes(content))
             r.close()
 
     @mock.patch('aiohttp.client.client_logger')
@@ -1339,5 +1339,5 @@ class Functional(test_utils.Router):
 
         self._response(
             resp,
-            body=json.dumps({'t': (b'0' * 1024).decode('utf-8')}),
+            body=ujson.dumps({'t': (b'0' * 1024).decode('utf-8')}),
             write_body=write_body)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -635,7 +635,7 @@ class BodyPartWriterTestCase(unittest.TestCase):
 
     def test_serialize_json(self):
         self.assertEqual(b'{"\\u043f\\u0440\\u0438\\u0432\\u0435\\u0442":'
-                         b' "\\u043c\\u0438\\u0440"}',
+                         b'"\\u043c\\u0438\\u0440"}',
                          next(self.part._serialize_json({'привет': 'мир'})))
 
     def test_serialize_form(self):
@@ -662,7 +662,7 @@ class BodyPartWriterTestCase(unittest.TestCase):
              b'--:\r\n',
              b'CONTENT-TYPE: application/json',
              b'\r\n\r\n',
-             b'{"test": "passed"}',
+             b'{"test":"passed"}',
              b'\r\n',
              b'--:--\r\n',
              b''],

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1,5 +1,5 @@
 import asyncio
-import json
+import ujson
 import os.path
 import socket
 import unittest
@@ -114,14 +114,14 @@ class TestWebFunctional(unittest.TestCase):
             self.assertEqual(data, data2)
             resp = web.Response()
             resp.content_type = 'application/json'
-            resp.body = json.dumps(data).encode('utf8')
+            resp.body = ujson.dumps(data).encode('utf8')
             return resp
 
         @asyncio.coroutine
         def go():
             _, _, url = yield from self.create_server('POST', '/', handler)
             headers = {'Content-Type': 'application/json'}
-            resp = yield from request('POST', url, data=json.dumps(dct),
+            resp = yield from request('POST', url, data=ujson.dumps(dct),
                                       headers=headers,
                                       loop=self.loop)
             self.assertEqual(200, resp.status)


### PR DESCRIPTION
There are various benchmarks that show ujson beats json in performance. I wrote a very simple one [here](https://gist.github.com/ttezel/4ee11f6c05c48a36fe3d) and posted the results there, it also showed ujson outperforming json. The tradeoff here is that ujson does not support `indent` and `sort_keys` functionality (for pretty-printing) but I think aiohttp should not worry about that since users can pretty-print  if they want.
