### PR TITLE
Connection limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .DS_Store
 .Python
 .coverage
+.coverage.*
 .idea
 .installed.cfg
 .noseids

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -371,10 +371,7 @@ def request(method, url, *,
                                           read_until_eof=read_until_eof)
         return resp
     finally:
-        if connector is not None:
-            session.detach()
-        else:
-            session.close()
+        session.detach()
 
 
 class ClientRequest:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -227,7 +227,10 @@ class BaseConnector(object):
         return self._closed
 
     def update_cookies(self, cookies):
-        """Update shared cookies."""
+        """Update shared cookies.
+
+        Deprectated, use ClientSession instead.
+        """
         if isinstance(cookies, dict):
             cookies = cookies.items()
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -225,11 +225,7 @@ class BaseConnector(object):
     def update_cookies(self, cookies):
         """Update shared cookies.
 
-<<<<<<< HEAD
-        Deprectated, use ClientSession instead.
-=======
         Deprecated, use ClientSession instead.
->>>>>>> master
         """
         if isinstance(cookies, dict):
             cookies = cookies.items()

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -377,6 +377,18 @@ To tweek or change *transport* layer of requests you can pass a custom
     ...     'get', 'http://python.org', connector=conn)
 
 
+Limiting connection pool size
+-----------------------------
+
+To limit amount of simultaneously opened connection to the same
+endpoint (``(host, port, is_ssl)`` triple) you can pass *limit*
+parameter to **connector**::
+
+    >>> conn = aiohttp.TCPConnector(limit=30)
+
+The example limits amount of parallel connections to `30`.
+
+
 SSL control for tcp sockets
 ---------------------------
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -343,7 +343,7 @@ All connector classes should be derived from :class:`BaseConnector`.
 
    :param int limit: limit for simultaneous connections to the same
                      endpoint.  Endpoints are the same if they are
-                     have equal `(host, port, is_ssl)` triple.
+                     have equal ``(host, port, is_ssl)`` triple.
                      If *limit* is ``None`` connection pool has no limit.
 
    :param bool share_cookies: update :attr:`cookies` on connection

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -328,6 +328,7 @@ There are standard connectors:
 All connector classes should be derived from :class:`BaseConnector`.
 
 .. class:: BaseConnector(*, conn_timeout=None, keepalive_timeout=30, \
+                         limit=None, \
                          share_cookies=False, force_close=False, loop=None)
 
    Base class for all connectors.
@@ -339,6 +340,11 @@ All connector classes should be derived from :class:`BaseConnector`.
    :param float keepalive_timeout: timeout for connection reusing
                                    after releasing (optional). Values
                                    ``0`` or ``None`` mean no timeout.
+
+   :param int limit: limit for simultaneous connections to the same
+                     endpoint.  Endpoints are the same if they are
+                     have equal `(host, port, is_ssl)` triple.
+                     If *limit* is ``None`` connection pool has no limit.
 
    :param bool share_cookies: update :attr:`cookies` on connection
                               processing (optional, deprecated).
@@ -386,7 +392,7 @@ All connector classes should be derived from :class:`BaseConnector`.
 .. class:: TCPConnector(*, verify_ssl=True, resolve=False, \
                         family=socket.AF_INET, \
                         ssl_context=None, conn_timeout=None, \
-                        keepalive_timeout=30, share_cookies=False, \
+                        keepalive_timeout=30, limit=None, share_cookies=False, \
                         force_close=False, loop=None)
 
    Connector for working with *HTTP* and *HTTPS* via *TCP* sockets.
@@ -422,7 +428,8 @@ All connector classes should be derived from :class:`BaseConnector`.
 
 .. class:: ProxyConnector(proxy, *, proxy_auth=None, \
                           conn_timeout=None, \
-                          keepalive_timeout=30, share_cookies=False, \
+                          keepalive_timeout=30, limit=None, \
+                          share_cookies=False, \
                           force_close=False, loop=None)
 
    HTTP Proxy connector.
@@ -447,7 +454,11 @@ All connector classes should be derived from :class:`BaseConnector`.
       authenthication info used for proxies with authorization.
 
 
-.. class:: UnixConnector
+.. class:: UnixConnector(path, *, \
+                         conn_timeout=None, \
+                         keepalive_timeout=30, limit=None, \
+                         share_cookies=False, \
+                         force_close=False, loop=None)
 
    Unix socket connector.
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -173,7 +173,9 @@ class BaseConnectorTests(unittest.TestCase):
         resp.message.should_close = False
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
-        conn._release(1, req, tr, proto)
+        key = 1
+        conn._acquired[key].append(tr)
+        conn._release(key, req, tr, proto)
         self.assertEqual(conn._conns[1][0], (tr, proto, 10))
         self.assertTrue(conn._start_cleanup_task.called)
         conn.close()
@@ -191,7 +193,9 @@ class BaseConnectorTests(unittest.TestCase):
         cookies['c2'] = 'cookie2'
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
-        conn._release(1, req, tr, proto)
+        key = 1
+        conn._acquired[key].append(tr)
+        conn._release(key, req, tr, proto)
         self.assertFalse(conn._conns)
         self.assertTrue(tr.close.called)
 
@@ -208,6 +212,7 @@ class BaseConnectorTests(unittest.TestCase):
         conn._conns[key] = []
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
+        conn._acquired[key].append(tr)
         conn._release(key, req, tr, proto)
         self.assertEqual({}, conn._conns)
         self.assertTrue(tr.close.called)
@@ -225,6 +230,7 @@ class BaseConnectorTests(unittest.TestCase):
         req.response = resp
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
+        conn._acquired[key].append(tr)
         conn._release(key, req, tr, proto)
         self.assertEqual(conn._conns[key], [(tr1, proto1, 1)])
         self.assertTrue(tr.close.called)
@@ -238,7 +244,9 @@ class BaseConnectorTests(unittest.TestCase):
         req.response = None
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
-        conn._release(1, req, tr, proto)
+        key = 1
+        conn._acquired[key].append(tr)
+        conn._release(key, req, tr, proto)
         self.assertEqual(conn._conns, {1: [(tr, proto, 10)]})
         self.assertFalse(tr.close.called)
         conn.close()
@@ -250,7 +258,9 @@ class BaseConnectorTests(unittest.TestCase):
         req.response.message = None
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
-        conn._release(1, req, tr, proto)
+        key = 1
+        conn._acquired[key].append(tr)
+        conn._release(key, req, tr, proto)
         self.assertTrue(tr.close.called)
 
     def test_connect(self):


### PR DESCRIPTION
Add `limit` parameter to connector's constructor.

Wait on `connector.connect(...)` if limit exhausted.