### PR TITLE
Add web.Request.scheme property

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -166,7 +166,8 @@ class Application(dict):
 
     def __init__(self, *, logger=web_logger, loop=None,
                  router=None, handler_factory=RequestHandlerFactory,
-                 middlewares=()):
+                 middlewares=(),
+                 secure_proxy_ssl_header=None):
         if loop is None:
             loop = asyncio.get_event_loop()
         if router is None:
@@ -182,6 +183,7 @@ class Application(dict):
         for factory in middlewares:
             assert asyncio.iscoroutinefunction(factory), factory
         self._middlewares = tuple(middlewares)
+        self._secure_proxy_ssl_header = secure_proxy_ssl_header
 
     @property
     def router(self):
@@ -194,6 +196,10 @@ class Application(dict):
     @property
     def middlewares(self):
         return self._middlewares
+
+    @property
+    def secure_proxy_ssl_header(self):
+        return self._secure_proxy_ssl_header
 
     def make_handler(self, **kwargs):
         return self._handler_factory(

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -29,13 +29,15 @@ class RequestHandler(ServerHttpProtocol):
     _meth = 'none'
     _path = 'none'
 
-    def __init__(self, manager, app, router, **kwargs):
+    def __init__(self, manager, app, router, *,
+                 secure_proxy_ssl_header=None, **kwargs):
         super().__init__(**kwargs)
 
         self._manager = manager
         self._app = app
         self._router = router
         self._middlewares = app.middlewares
+        self._secure_proxy_ssl_header = secure_proxy_ssl_header
 
     def __repr__(self):
         return "<{} {}:{} {}>".format(
@@ -58,8 +60,10 @@ class RequestHandler(ServerHttpProtocol):
             now = self._loop.time()
 
         app = self._app
-        request = Request(app, message, payload,
-                          self.transport, self.reader, self.writer)
+        request = Request(
+            app, message, payload,
+            self.transport, self.reader, self.writer,
+            secure_proxy_ssl_header=self._secure_proxy_ssl_header)
         self._meth = request.method
         self._path = request.path
         try:
@@ -105,14 +109,20 @@ class RequestHandler(ServerHttpProtocol):
 class RequestHandlerFactory:
 
     def __init__(self, app, router, *,
-                 handler=RequestHandler, loop=None, **kwargs):
+                 handler=RequestHandler, loop=None,
+                 secure_proxy_ssl_header=None, **kwargs):
         self._app = app
         self._router = router
         self._handler = handler
         self._loop = loop
         self._connections = {}
+        self._secure_proxy_ssl_header = secure_proxy_ssl_header
         self._kwargs = kwargs
         self._kwargs.setdefault('logger', app.logger)
+
+    @property
+    def secure_proxy_ssl_header(self):
+        return self._secure_proxy_ssl_header
 
     @property
     def connections(self):
@@ -159,15 +169,16 @@ class RequestHandlerFactory:
 
     def __call__(self):
         return self._handler(
-            self, self._app, self._router, loop=self._loop, **self._kwargs)
+            self, self._app, self._router, loop=self._loop,
+            secure_proxy_ssl_header=self._secure_proxy_ssl_header,
+            **self._kwargs)
 
 
 class Application(dict):
 
     def __init__(self, *, logger=web_logger, loop=None,
                  router=None, handler_factory=RequestHandlerFactory,
-                 middlewares=(),
-                 secure_proxy_ssl_header=None):
+                 middlewares=()):
         if loop is None:
             loop = asyncio.get_event_loop()
         if router is None:
@@ -183,7 +194,6 @@ class Application(dict):
         for factory in middlewares:
             assert asyncio.iscoroutinefunction(factory), factory
         self._middlewares = tuple(middlewares)
-        self._secure_proxy_ssl_header = secure_proxy_ssl_header
 
     @property
     def router(self):
@@ -196,10 +206,6 @@ class Application(dict):
     @property
     def middlewares(self):
         return self._middlewares
-
-    @property
-    def secure_proxy_ssl_header(self):
-        return self._secure_proxy_ssl_header
 
     def make_handler(self, **kwargs):
         return self._handler_factory(

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -80,7 +80,7 @@ class Request(dict, HeadersMixin):
                     hdrs.METH_TRACE, hdrs.METH_DELETE}
 
     def __init__(self, app, message, payload, transport, reader, writer, *,
-                 _HOST=hdrs.HOST):
+                 _HOST=hdrs.HOST, secure_proxy_ssl_header=None):
         self._app = app
         self._version = message.version
         self._transport = transport
@@ -109,11 +109,13 @@ class Request(dict, HeadersMixin):
 
         self._read_bytes = None
 
+        self._secure_proxy_ssl_header = secure_proxy_ssl_header
+
     @property
     def scheme(self):
         if self._transport.get_extra_info('sslcontext'):
             return 'https'
-        secure_proxy_ssl_header = self._app.secure_proxy_ssl_header
+        secure_proxy_ssl_header = self._secure_proxy_ssl_header
         if secure_proxy_ssl_header is not None:
             header, value = secure_proxy_ssl_header
             if self._headers.get(header) == value:

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -110,6 +110,17 @@ class Request(dict, HeadersMixin):
         self._read_bytes = None
 
     @property
+    def scheme(self):
+        if self._transport.get_extra_info('sslcontext'):
+            return 'https'
+        secure_proxy_ssl_header = self._app.secure_proxy_ssl_header
+        if secure_proxy_ssl_header is not None:
+            header, value = secure_proxy_ssl_header
+            if self._headers.get(header) == value:
+                return 'https'
+        return 'http'
+
+    @property
     def method(self):
         """Read only property for getting HTTP method.
 

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -23,7 +23,6 @@ class TestWebRequest(unittest.TestCase):
         if version < HttpVersion(1, 1):
             closing = True
         self.app = mock.Mock()
-        self.app.secure_proxy_ssl_header = secure_proxy_ssl_header
         message = RawRequestMessage(method, path, version, headers, closing,
                                     False)
         self.payload = mock.Mock()
@@ -39,7 +38,8 @@ class TestWebRequest(unittest.TestCase):
         self.writer = mock.Mock()
         self.reader = mock.Mock()
         req = Request(self.app, message, self.payload,
-                      self.transport, self.reader, self.writer)
+                      self.transport, self.reader, self.writer,
+                      secure_proxy_ssl_header=secure_proxy_ssl_header)
         return req
 
     def test_ctor(self):

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -17,14 +17,25 @@ class TestWebRequest(unittest.TestCase):
         self.loop.close()
 
     def make_request(self, method, path, headers=CIMultiDict(), *,
-                     version=HttpVersion(1, 1), closing=False):
+                     version=HttpVersion(1, 1), closing=False,
+                     sslcontext=None,
+                     secure_proxy_ssl_header=None):
         if version < HttpVersion(1, 1):
             closing = True
         self.app = mock.Mock()
+        self.app.secure_proxy_ssl_header = secure_proxy_ssl_header
         message = RawRequestMessage(method, path, version, headers, closing,
                                     False)
         self.payload = mock.Mock()
         self.transport = mock.Mock()
+
+        def get_extra_info(key):
+            if key == 'sslcontext':
+                return sslcontext
+            else:
+                return None
+
+        self.transport.get_extra_info.side_effect = get_extra_info
         self.writer = mock.Mock()
         self.reader = mock.Mock()
         req = Request(self.app, message, self.payload,
@@ -175,3 +186,23 @@ class TestWebRequest(unittest.TestCase):
     def test___repr__(self):
         req = self.make_request('GET', '/path/to')
         self.assertEqual("<Request GET /path/to >", repr(req))
+
+    def test_http_scheme(self):
+        req = self.make_request('GET', '/')
+        self.assertEqual("http", req.scheme)
+
+    def test_https_scheme_by_ssl_transport(self):
+        req = self.make_request('GET', '/', sslcontext=True)
+        self.assertEqual("https", req.scheme)
+
+    def test_https_scheme_by_secure_proxy_ssl_header(self):
+        req = self.make_request('GET', '/',
+                                secure_proxy_ssl_header=('X-HEADER', '1'),
+                                headers=CIMultiDict({'X-HEADER': '1'}))
+        self.assertEqual("https", req.scheme)
+
+    def test_https_scheme_by_secure_proxy_ssl_header_false_test(self):
+        req = self.make_request('GET', '/',
+                                secure_proxy_ssl_header=('X-HEADER', '1'),
+                                headers=CIMultiDict({'X-HEADER': '0'}))
+        self.assertEqual("http", req.scheme)


### PR DESCRIPTION
request.scheme (not schema, according to rfc 3986) is `'http'` or `'https`' string.
`'https'` is for ssl transports and regular transports with specific HTTP HEADER set by proxy.
`'http'` otherwise.

I'll update docs and add strict check for `secure_proxy_ssl_header` in `web.Application` (it should be tuple of header name and value) when will get preliminary agreement.