### PR TITLE
Add web.Request.has_body property

### DIFF
--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -108,6 +108,7 @@ class Request(dict, HeadersMixin):
         self._cookies = None
 
         self._read_bytes = None
+        self._has_body = not payload.at_eof()
 
     @property
     def method(self):
@@ -223,6 +224,11 @@ class Request(dict, HeadersMixin):
     def content(self):
         """Return raw payload stream."""
         return self._payload
+
+    @property
+    def has_body(self):
+        """Return True if request has HTTP BODY, False otherwise."""
+        return self._has_body
 
     @asyncio.coroutine
     def release(self):

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -139,6 +139,14 @@ first positional parameter.
 
       .. versionadded:: 0.15
 
+   .. attribute:: has_body
+
+      Return ``True`` if request has no *HTTP BODY*, ``False`` otherwise.
+
+      Read-only :class:`bool` property.
+
+      .. versionadded:: 0.16
+
    .. attribute:: payload
 
       A :class:`~aiohttp.streams.FlowControlStreamReader` instance,


### PR DESCRIPTION
I need a way to figure out is there HTTP BODY in request or not without calling `request.read()`.