### PR TITLE
document pypy3 incompatibility

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,6 +98,7 @@ Dependencies
 
 - Python 3.3 and :term:`asyncio` or Python 3.4+
 - *chardet* library
+- Due to a bug in PyPy3, PyPy is not currently supported.
 
 Contributing
 ------------


### PR DESCRIPTION
```
> pypy3 -c 'import aiohttp'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/Cellar/pypy3/2.4.0/libexec/site-packages/aiohttp/__init__.py", line 6, in <module>
    from . import hdrs  # noqa
  File "/usr/local/Cellar/pypy3/2.4.0/libexec/site-packages/aiohttp/hdrs.py", line 2, in <module>
    from .multidict import upstr
  File "/usr/local/Cellar/pypy3/2.4.0/libexec/site-packages/aiohttp/multidict.py", line 317
    yield from self._items
         ^
SyntaxError: invalid syntax
```
This is using the latest pypy3 homebrew package (stable 2.4.0) and latest aiohttp release (0.15.3).