### PR TITLE
support new param 'response_class' in websocket_client.ws_connect.

### DIFF
--- a/aiohttp/websocket_client.py
+++ b/aiohttp/websocket_client.py
@@ -35,7 +35,7 @@ closedMessage = Message(MsgType.closed, None, None)
 
 @asyncio.coroutine
 def ws_connect(url, protocols=(), timeout=10.0, connector=None,
-               autoclose=True, autoping=True, loop=None):
+               response_class=None, autoclose=True, autoping=True, loop=None):
     """Initiate websocket connection."""
     if loop is None:
         loop = asyncio.get_event_loop()
@@ -87,7 +87,9 @@ def ws_connect(url, protocols=(), timeout=10.0, connector=None,
     reader = resp.connection.reader.set_parser(WebSocketParser)
     writer = WebSocketWriter(resp.connection.writer, use_mask=True)
 
-    return ClientWebSocketResponse(
+    response_class = response_class or ClientWebSocketResponse
+
+    return response_class(
         reader, writer, protocol, resp, timeout, autoclose, autoping, loop)
 
 

--- a/aiohttp/websocket_client.py
+++ b/aiohttp/websocket_client.py
@@ -87,7 +87,8 @@ def ws_connect(url, protocols=(), timeout=10.0, connector=None,
     reader = resp.connection.reader.set_parser(WebSocketParser)
     writer = WebSocketWriter(resp.connection.writer, use_mask=True)
 
-    response_class = response_class or ClientWebSocketResponse
+    if response_class is None:
+        response_class = ClientWebSocketResponse
 
     return response_class(
         reader, writer, protocol, resp, timeout, autoclose, autoping, loop)

--- a/docs/client_websockets.rst
+++ b/docs/client_websockets.rst
@@ -46,7 +46,7 @@ ClientWebSocketResponse
 To connect to a websocket server you have to use the `aiohttp.ws_connect()` function,
 do not create an instance of class :class:`ClientWebSocketResponse` manually.
 
-.. py:function:: ws_connect(url, protocols=(), connector=None, autoclose=True, autoping=True, response_class=None, loop=None)
+.. py:function:: ws_connect(url, protocols=(), connector=None, response_class=None, autoclose=True, autoping=True, loop=None)
 
    This function creates a websocket connection, checks the response and
    returns a :class:`ClientWebSocketResponse` object. In case of failure

--- a/docs/client_websockets.rst
+++ b/docs/client_websockets.rst
@@ -64,6 +64,8 @@ do not create an instance of class :class:`ClientWebSocketResponse` manually.
 
    :param bool autoping: automatically send `pong` on `ping` message from server
 
+   :param response_class: (optional) Custom Response class implementation.
+
    :param loop: :ref:`event loop<asyncio-event-loop>` used
                 for processing HTTP requests.
 

--- a/docs/client_websockets.rst
+++ b/docs/client_websockets.rst
@@ -58,13 +58,13 @@ do not create an instance of class :class:`ClientWebSocketResponse` manually.
 
    :param obj connector: object :class:`TCPConnector`
 
+   :param response_class: (optional) Custom Response class implementation.
+
    :param bool autoclose: automatically close websocket connection
                           on close message from server. if `autoclose` is
                           False them close procedure has to be handled manually
 
    :param bool autoping: automatically send `pong` on `ping` message from server
-
-   :param response_class: (optional) Custom Response class implementation.
 
    :param loop: :ref:`event loop<asyncio-event-loop>` used
                 for processing HTTP requests.

--- a/docs/client_websockets.rst
+++ b/docs/client_websockets.rst
@@ -46,7 +46,7 @@ ClientWebSocketResponse
 To connect to a websocket server you have to use the `aiohttp.ws_connect()` function,
 do not create an instance of class :class:`ClientWebSocketResponse` manually.
 
-.. py:function:: ws_connect(url, protocols=(), connector=None, autoclose=True, autoping=True, loop=None)
+.. py:function:: ws_connect(url, protocols=(), connector=None, autoclose=True, autoping=True, response_class=None, loop=None)
 
    This function creates a websocket connection, checks the response and
    returns a :class:`ClientWebSocketResponse` object. In case of failure


### PR DESCRIPTION
Adds a 'response_class' parameter to `websocket_client.ws_connect` that allows user to implement a custom `ClientWebSocketResponse` style class and pass it to the `ws_connect` coroutine. Similar to 'response_class' param for `aiohttp.client.request`.