### PR TITLE
Add ws_connect to ClientSession.

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -174,11 +174,10 @@ class ClientSession:
         return resp
 
     @asyncio.coroutine
-    def ws_connect(self, url,
+    def ws_connect(self, url, *,
                    protocols=(),
                    timeout=10.0,
-                   connector=None,
-                   response_class=None,
+                   ws_response_class=None,
                    autoclose=True,
                    autoping=True):
         """Initiate websocket connection."""
@@ -230,17 +229,17 @@ class ClientSession:
         reader = resp.connection.reader.set_parser(WebSocketParser)
         writer = WebSocketWriter(resp.connection.writer, use_mask=True)
 
-        if response_class is None:
-            response_class = ClientWebSocketResponse
+        if ws_response_class is None:
+            ws_response_class = ClientWebSocketResponse
 
-        return response_class(reader,
-                              writer,
-                              protocol,
-                              resp,
-                              timeout,
-                              autoclose,
-                              autoping,
-                              self._loop)
+        return ws_response_class(reader,
+                                 writer,
+                                 protocol,
+                                 resp,
+                                 timeout,
+                                 autoclose,
+                                 autoping,
+                                 self._loop)
 
     def _update_cookies(self, cookies):
         """Update shared cookies."""

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1,19 +1,26 @@
 """HTTP Client for asyncio."""
 
 import asyncio
-import http.cookies
-import urllib.parse
-import warnings
+import base64
+import hashlib
+import os
 import sys
 import traceback
+import warnings
+import http.cookies
+import urllib.parse
 
 import aiohttp
 from .client_reqrep import ClientRequest, ClientResponse
+from .errors import WSServerHandshakeError
 from .multidict import MultiDictProxy, MultiDict, CIMultiDict
+from .websocket import WS_KEY, WebSocketParser, WebSocketWriter
+from .websocket_client import ClientWebSocketResponse
 from . import hdrs
 
 
 __all__ = ('request', 'ClientSession')
+
 
 PY_34 = sys.version_info >= (3, 4)
 
@@ -88,7 +95,6 @@ class ClientSession:
                 expect100=False,
                 read_until_eof=True):
         """Perform HTTP request."""
-
         if self.closed:
             raise RuntimeError('Session is closed')
 
@@ -166,6 +172,75 @@ class ClientSession:
             break
 
         return resp
+
+    @asyncio.coroutine
+    def ws_connect(self, url,
+                   protocols=(),
+                   timeout=10.0,
+                   connector=None,
+                   response_class=None,
+                   autoclose=True,
+                   autoping=True):
+        """Initiate websocket connection."""
+
+        sec_key = base64.b64encode(os.urandom(16))
+
+        headers = {
+            hdrs.UPGRADE: hdrs.WEBSOCKET,
+            hdrs.CONNECTION: hdrs.UPGRADE,
+            hdrs.SEC_WEBSOCKET_VERSION: '13',
+            hdrs.SEC_WEBSOCKET_KEY: sec_key.decode(),
+        }
+        if protocols:
+            headers[hdrs.SEC_WEBSOCKET_PROTOCOL] = ','.join(protocols)
+
+        # send request
+        resp = yield from self.request('get', url, headers=headers,
+                                       read_until_eof=False)
+
+        # check handshake
+        if resp.status != 101:
+            raise WSServerHandshakeError('Invalid response status')
+
+        if resp.headers.get(hdrs.UPGRADE, '').lower() != 'websocket':
+            raise WSServerHandshakeError('Invalid upgrade header')
+
+        if resp.headers.get(hdrs.CONNECTION, '').lower() != 'upgrade':
+            raise WSServerHandshakeError('Invalid connection header')
+
+        # key calculation
+        key = resp.headers.get(hdrs.SEC_WEBSOCKET_ACCEPT, '')
+        match = base64.b64encode(
+            hashlib.sha1(sec_key + WS_KEY).digest()).decode()
+        if key != match:
+            raise WSServerHandshakeError('Invalid challenge response')
+
+        # websocket protocol
+        protocol = None
+        if protocols and hdrs.SEC_WEBSOCKET_PROTOCOL in resp.headers:
+            resp_protocols = [
+                proto.strip() for proto in
+                resp.headers[hdrs.SEC_WEBSOCKET_PROTOCOL].split(',')]
+
+            for proto in resp_protocols:
+                if proto in protocols:
+                    protocol = proto
+                    break
+
+        reader = resp.connection.reader.set_parser(WebSocketParser)
+        writer = WebSocketWriter(resp.connection.writer, use_mask=True)
+
+        if response_class is None:
+            response_class = ClientWebSocketResponse
+
+        return response_class(reader,
+                              writer,
+                              protocol,
+                              resp,
+                              timeout,
+                              autoclose,
+                              autoping,
+                              self._loop)
 
     def _update_cookies(self, cookies):
         """Update shared cookies."""

--- a/aiohttp/websocket_client.py
+++ b/aiohttp/websocket_client.py
@@ -1,17 +1,14 @@
 """WebSocket client for asyncio."""
 
 import asyncio
-import base64
-import hashlib
-import os
 
-from aiohttp import client, hdrs
-from .errors import WSServerHandshakeError
-from .websocket import WS_KEY, Message
-from .websocket import WebSocketParser, WebSocketWriter, WebSocketError
+import aiohttp
+from .websocket import Message
+from .websocket import WebSocketError
 from .websocket import MSG_BINARY, MSG_TEXT, MSG_CLOSE, MSG_PING, MSG_PONG
 
-__all__ = ('ws_connect', 'MsgType')
+
+__all__ = ('MsgType', 'ws_connect')
 
 
 try:
@@ -33,65 +30,31 @@ class MsgType(IntEnum):
 closedMessage = Message(MsgType.closed, None, None)
 
 
-@asyncio.coroutine
 def ws_connect(url, protocols=(), timeout=10.0, connector=None,
-               response_class=None, autoclose=True, autoping=True, loop=None):
-    """Initiate websocket connection."""
+               response_class=None, autoclose=True, autoping=True,
+               loop=None):
+
     if loop is None:
-        loop = asyncio.get_event_loop()
+        asyncio.get_event_loop()
 
-    sec_key = base64.b64encode(os.urandom(16))
+    if connector is None:
+        connector = aiohttp.TCPConnector(loop=loop, force_close=True)
 
-    headers = {
-        hdrs.UPGRADE: hdrs.WEBSOCKET,
-        hdrs.CONNECTION: hdrs.UPGRADE,
-        hdrs.SEC_WEBSOCKET_VERSION: '13',
-        hdrs.SEC_WEBSOCKET_KEY: sec_key.decode(),
-    }
-    if protocols:
-        headers[hdrs.SEC_WEBSOCKET_PROTOCOL] = ','.join(protocols)
+    # May add more optional params for session.
+    session = aiohttp.ClientSession(loop=loop, connector=connector)
 
-    # send request
-    resp = yield from client.request(
-        'get', url, headers=headers,
-        read_until_eof=False,
-        connector=connector, loop=loop)
+    try:
+        resp = yield from session.ws_connect(url,
+                                             protocols=protocols,
+                                             timeout=timeout,
+                                             connector=connector,
+                                             response_class=response_class,
+                                             autoclose=autoclose,
+                                             autoping=autoping)
+        return resp
 
-    # check handshake
-    if resp.status != 101:
-        raise WSServerHandshakeError('Invalid response status')
-
-    if resp.headers.get(hdrs.UPGRADE, '').lower() != 'websocket':
-        raise WSServerHandshakeError('Invalid upgrade header')
-
-    if resp.headers.get(hdrs.CONNECTION, '').lower() != 'upgrade':
-        raise WSServerHandshakeError('Invalid connection header')
-
-    # key calculation
-    key = resp.headers.get(hdrs.SEC_WEBSOCKET_ACCEPT, '')
-    match = base64.b64encode(hashlib.sha1(sec_key + WS_KEY).digest()).decode()
-    if key != match:
-        raise WSServerHandshakeError('Invalid challenge response')
-
-    # websocket protocol
-    protocol = None
-    if protocols and hdrs.SEC_WEBSOCKET_PROTOCOL in resp.headers:
-        resp_protocols = [proto.strip() for proto in
-                          resp.headers[hdrs.SEC_WEBSOCKET_PROTOCOL].split(',')]
-
-        for proto in resp_protocols:
-            if proto in protocols:
-                protocol = proto
-                break
-
-    reader = resp.connection.reader.set_parser(WebSocketParser)
-    writer = WebSocketWriter(resp.connection.writer, use_mask=True)
-
-    if response_class is None:
-        response_class = ClientWebSocketResponse
-
-    return response_class(
-        reader, writer, protocol, resp, timeout, autoclose, autoping, loop)
+    finally:
+        session.detach()
 
 
 class ClientWebSocketResponse:

--- a/aiohttp/websocket_client.py
+++ b/aiohttp/websocket_client.py
@@ -40,7 +40,6 @@ def ws_connect(url, *, protocols=(), timeout=10.0, connector=None,
     if connector is None:
         connector = aiohttp.TCPConnector(loop=loop, force_close=True)
 
-    # May add more optional params for session.
     session = aiohttp.ClientSession(loop=loop, connector=connector)
 
     try:

--- a/aiohttp/websocket_client.py
+++ b/aiohttp/websocket_client.py
@@ -30,8 +30,8 @@ class MsgType(IntEnum):
 closedMessage = Message(MsgType.closed, None, None)
 
 
-def ws_connect(url, protocols=(), timeout=10.0, connector=None,
-               response_class=None, autoclose=True, autoping=True,
+def ws_connect(url, *, protocols=(), timeout=10.0, connector=None,
+               ws_response_class=None, autoclose=True, autoping=True,
                loop=None):
 
     if loop is None:
@@ -44,13 +44,13 @@ def ws_connect(url, protocols=(), timeout=10.0, connector=None,
     session = aiohttp.ClientSession(loop=loop, connector=connector)
 
     try:
-        resp = yield from session.ws_connect(url,
-                                             protocols=protocols,
-                                             timeout=timeout,
-                                             connector=connector,
-                                             response_class=response_class,
-                                             autoclose=autoclose,
-                                             autoping=autoping)
+        resp = yield from session.ws_connect(
+            url,
+            protocols=protocols,
+            timeout=timeout,
+            ws_response_class=ws_response_class,
+            autoclose=autoclose,
+            autoping=autoping)
         return resp
 
     finally:

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -223,6 +223,27 @@ Usage example::
       :param data: Dictionary, bytes, or file-like object to
                    send in the body of the request (optional)
 
+
+   .. coroutinemethod:: ws_connect(url, *, protocols=(), timeout=10.0\
+                                   ws_response_class=None, autoclose=True,\
+                                   autoping=True)
+
+      Create a websocket connection. Returns a :class:`ClientWebSocketResponse` object.
+
+      :param str url: Websocket server url
+
+      :param tuple protocols: Websocket protocols
+
+      :param float timeout: Timeout for websocket read. 10 seconds by default
+
+      :param ws_response_class: (optional) Custom Response class implementation
+
+      :param bool autoclose: Automatically close websocket connection on close
+                             message from server. If `autoclose` is False
+                             them close procedure has to be handled manually
+
+      :param bool autoping: automatically send `pong` on `ping` message from server
+
    .. method:: close()
 
       Close underlying connector.
@@ -250,8 +271,7 @@ request coroutine
                        read_until_eof=True, request_class=None,\
                        response_class=None)
 
-   Perform an asynchronous http request. Return a response object
-   (:class:`ClientResponse` or derived from).
+   Performs an asynchronous http request. Returns a response object.
 
    :param str method: HTTP method
 
@@ -319,7 +339,7 @@ Connectors
 
 .. module:: aiohttp.connector
 
-Connectors are transports for aiohttp client API.
+Connectors are transports for aiohttp clients.
 
 There are standard connectors:
 
@@ -331,7 +351,7 @@ There are standard connectors:
 
 All connector classes should be derived from :class:`BaseConnector`.
 
-By default all *connectors* except :class:`ProxyConnector` support
+By default all *connectors* except :class:`ProxyConnector` supports
 *keep-alive connections* (behavior controlled by *force_close*
 constructor's parameter).
 
@@ -407,9 +427,6 @@ constructor's parameter).
       Get a free connection from pool or create new one if connection
       is absent in the pool.
 
-      The call may be paused if :attr:`limit` is exhausted until used
-      connetions returns to pool.
-
       :param aiohttp.client.ClientRequest request: request object
                                                    which is connection
                                                    initiator.
@@ -457,49 +474,6 @@ constructor's parameter).
 
       *ssl_context* may be used for configuring certification
       authority channel, supported SSL options etc.
-
-   .. attribute:: verify_ssl
-
-      Check *ssl certifications* if ``True``.
-
-      Read-only :class:`bool` property.
-
-   .. attribute:: ssl_context
-
-      :class:`ssl.SSLContext` instance for *https* requests, read-only property.
-
-   .. attribute:: family
-
-      *TCP* socket family e.g. :const:`socket.AF_INET` or
-      :const:`socket.AF_INET6`
-
-      Read-only property.
-
-   .. attribute:: resolve
-
-      Use quick lookup in internal *DNS* cache for host names if ``True``.
-
-      Read-only :class:`bool` property.
-
-   .. attribute:: resolve
-
-      Use quick lookup in internal *DNS* cache for host names if ``True``.
-
-      Read-only :class:`bool` property.
-
-   .. attribute:: resolved_hosts
-
-      The cache of resolved hosts if :attr:`resolve` is enabled.
-
-      Read-only :class:`types.MappingProxyType` property.
-
-   .. method:: clear_resolved_hosts(self, host=None, port=None)
-
-      Clear internal *DNS* cache.
-
-      Remove specific entry if both *host* and *port* are specified,
-      clear all cache otherwise.
-
 
 .. class:: ProxyConnector(proxy, *, proxy_auth=None, \
                           conn_timeout=None, \

--- a/docs/client_websockets.rst
+++ b/docs/client_websockets.rst
@@ -46,7 +46,7 @@ ClientWebSocketResponse
 To connect to a websocket server you have to use the `aiohttp.ws_connect()` function,
 do not create an instance of class :class:`ClientWebSocketResponse` manually.
 
-.. py:function:: ws_connect(url, protocols=(), connector=None, ws_response_class=None, autoclose=True, autoping=True, loop=None)
+.. py:function:: ws_connect(url, *, protocols=(), connector=None, ws_response_class=None, autoclose=True, autoping=True, loop=None)
 
    This function creates a websocket connection, checks the response and
    returns a :class:`ClientWebSocketResponse` object. In case of failure

--- a/docs/client_websockets.rst
+++ b/docs/client_websockets.rst
@@ -46,7 +46,7 @@ ClientWebSocketResponse
 To connect to a websocket server you have to use the `aiohttp.ws_connect()` function,
 do not create an instance of class :class:`ClientWebSocketResponse` manually.
 
-.. py:function:: ws_connect(url, protocols=(), connector=None, response_class=None, autoclose=True, autoping=True, loop=None)
+.. py:function:: ws_connect(url, protocols=(), connector=None, ws_response_class=None, autoclose=True, autoping=True, loop=None)
 
    This function creates a websocket connection, checks the response and
    returns a :class:`ClientWebSocketResponse` object. In case of failure
@@ -58,7 +58,7 @@ do not create an instance of class :class:`ClientWebSocketResponse` manually.
 
    :param obj connector: object :class:`TCPConnector`
 
-   :param response_class: (optional) Custom Response class implementation.
+   :param ws_response_class: (optional) Custom Response class implementation.
 
    :param bool autoclose: automatically close websocket connection
                           on close message from server. if `autoclose` is

--- a/docs/client_websockets.rst
+++ b/docs/client_websockets.rst
@@ -46,25 +46,29 @@ ClientWebSocketResponse
 To connect to a websocket server you have to use the `aiohttp.ws_connect()` function,
 do not create an instance of class :class:`ClientWebSocketResponse` manually.
 
-.. py:function:: ws_connect(url, *, protocols=(), connector=None, ws_response_class=None, autoclose=True, autoping=True, loop=None)
+.. py:function:: ws_connect(url, *, protocols=(), timeout=10.0,\
+                            connector=None, ws_response_class=None,\
+                            autoclose=True, autoping=True, loop=None)
 
    This function creates a websocket connection, checks the response and
    returns a :class:`ClientWebSocketResponse` object. In case of failure
    it may raise a :exc:`~aiohttp.errors.WSServerHandshakeError` exception.
 
-   :param str url: websocket server url
+   :param str url: Websocket server url
 
-   :param tuple protocols: websocket protocols
+   :param tuple protocols: Websocket protocols
+
+   :param float timeout: Timeout for websocket read. 10 seconds by default
 
    :param obj connector: object :class:`TCPConnector`
 
    :param ws_response_class: (optional) Custom Response class implementation.
 
-   :param bool autoclose: automatically close websocket connection
-                          on close message from server. if `autoclose` is
+   :param bool autoclose: Automatically close websocket connection
+                          on close message from server. If `autoclose` is
                           False them close procedure has to be handled manually
 
-   :param bool autoping: automatically send `pong` on `ping` message from server
+   :param bool autoping: Automatically send `pong` on `ping` message from server
 
    :param loop: :ref:`event loop<asyncio-event-loop>` used
                 for processing HTTP requests.

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -70,7 +70,7 @@ class TestWebSocketClient(unittest.TestCase):
         res = self.loop.run_until_complete(
             websocket_client.ws_connect(
                 'http://test.org',
-                response_class=CustomResponse,
+                ws_response_class=CustomResponse,
                 loop=self.loop))
 
         self.assertEqual(res.read(), 'customized!')


### PR DESCRIPTION
Added `ClientSession.ws_connect` method. Pretty much a copy paste of old `websocket_client.ws_connect`. The `websocket_client.ws_connect` now is very similar to `client.request` in that it creates a `ClientSession` with a `TCPConnector(force_close=True)` and calls that session's `ws_connect` method.

Had to change the mocks in the websocket client tests a bit.

As @asvetlov mentioned in #367, the params for the `ws_connect` method and function may need some fine tuning.

If this is to be merged I will be happy to do docs and doc strings. Thanks in advance for any feedback or suggestions.

(sorry about that extra merge commit)