### PR TITLE
Allow custom route attributes to be set

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -338,7 +338,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         self._urls.append(route)
 
     def add_route(self, method, path, handler,
-                  *, name=None, expect_handler=None):
+                  *, name=None, expect_handler=None, **kwargs):
 
         assert callable(handler), handler
         if (not asyncio.iscoroutinefunction(handler) and
@@ -383,6 +383,10 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         route = DynamicRoute(
             method, handler, name, compiled,
             formatter, expect_handler=expect_handler)
+
+        for attr, value in kwargs.items():
+            setattr(route, attr, value)
+
         self.register_route(route)
         return route
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -391,6 +391,12 @@ class TestUrlDispatcher(unittest.TestCase):
             "Bad pattern '\/handler\/(?P<to>+++)': nothing to repeat"), s)
         self.assertIsNone(ctx.exception.__cause__)
 
+    def test_add_route_with_custom_attr(self):
+        handler = self.make_handler()
+        self.router.add_route('GET', '/path', handler, schema='foo')
+        route = yield from self.router.resolve('/path')
+        self.assertTrue(hasattr(route, 'schema'))
+
     def test_route_dynamic_with_regex_spec(self):
         handler = self.make_handler()
         route = self.router.add_route('GET', '/get/{num:^\d+}', handler,


### PR DESCRIPTION
Hi,

I needed to add some custom attributes to a route when using add_route (to use them later in a middleware). My fist reflex was to create a custom router, but since this is something i had to do multiple times, i figured it would be nice to generalise it.

This would allow something like this:

    self.router.add_route('GET', '/path', handler, schema='foo')
    route = yield from self.router.resolve('/path')
    schema = route.schema

Maybe letting ANY attribute to be set this way is not the best idea.
What do you think?