### PR TITLE
request.json() now returns empty dict when no data

### DIFF
--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -284,6 +284,8 @@ class Request(dict, HeadersMixin):
     def json(self, *, loader=json.loads):
         """Return BODY as JSON."""
         body = yield from self.text()
+        if not body:
+            return loader('{}')
         return loader(body)
 
     @asyncio.coroutine

--- a/examples/json_data.py
+++ b/examples/json_data.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+__author__ = 'Most Wanted'
+
+
+import asyncio
+from aiohttp import web
+
+
+@asyncio.coroutine
+def get_json(request):
+    data = yield from request.json()
+    # Now all is ok when there are no json-data
+    return web.Response(body='The response'.encode('utf-8'))
+
+
+@asyncio.coroutine
+def init(loop):
+    app = web.Application(loop=loop)
+    app.router.add_route('POST', '/', get_json)
+
+    srv = yield from loop.create_server(app.make_handler(),
+                                        '127.0.0.1', 8080)
+    print("Server started at http://127.0.0.1:8080")
+    return srv
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(init(loop))
+try:
+    loop.run_forever()
+except KeyboardInterrupt:
+    pass


### PR DESCRIPTION
There was ValueError raising when trying to access request.json() is there is no data. I think that this is incorrect behavior and empty dict (or something else) must be returned in this case.