### PR TITLE
Validate full file path in the static file handler

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -152,6 +152,10 @@ class StaticRoute(Route):
         self._directory = os.path.abspath(directory) + os.sep
         self._chunk_size = chunk_size
 
+        if not os.path.isdir(self._directory):
+            raise ValueError(
+                "No directory exists at '{}'".format(self._directory))
+
     def match(self, path):
         if not path.startswith(self._prefix):
             return None
@@ -394,7 +398,6 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         :param path - folder with files
         """
         assert prefix.startswith('/')
-        assert os.path.isdir(path), 'Path is not a directory: %s' % path
         if not prefix.endswith('/'):
             prefix += '/'
         route = StaticRoute(name, prefix, path,

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -168,7 +168,7 @@ class StaticRoute(Route):
         resp = StreamResponse()
         filename = request.match_info['filename']
         filepath = os.path.abspath(os.path.join(self._directory, filename))
-        if not filename.startswith(self._directory):
+        if not filepath.startswith(self._directory):
             raise HTTPNotFound()
         if not os.path.exists(filepath) or not os.path.isfile(filepath):
             raise HTTPNotFound()

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -374,6 +374,14 @@ class TestWebFunctional(unittest.TestCase):
         filename = '../README.rst'
         self.loop.run_until_complete(go(here, filename))
 
+    def test_static_route_path_existence_check(self):
+        directory = os.path.dirname(__file__)
+        web.StaticRoute(None, "/", directory)
+
+        nodirectory = os.path.join(directory, "nonexistent-uPNiOEAg5d")
+        with self.assertRaises(ValueError):
+            web.StaticRoute(None, "/", nodirectory)
+
     def test_post_form_with_duplicate_keys(self):
 
         @asyncio.coroutine

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -364,7 +364,8 @@ class TestWebFunctional(unittest.TestCase):
             self.assertEqual(404, resp.status)
             resp.close()
 
-            url_abspath = url + os.path.abspath(os.path.join(dirname, filename))
+            url_abspath = \
+                url + os.path.abspath(os.path.join(dirname, filename))
             resp = yield from request('GET', url_abspath, loop=self.loop)
             self.assertEqual(404, resp.status)
             resp.close()

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -287,7 +287,7 @@ class TestWebFunctional(unittest.TestCase):
             resp.close()
 
         here = os.path.dirname(__file__)
-        filename = os.path.join(here, 'data.unknown_mime_type')
+        filename = 'data.unknown_mime_type'
         self.loop.run_until_complete(go(here, filename))
 
     def test_static_file_with_content_type(self):
@@ -319,7 +319,7 @@ class TestWebFunctional(unittest.TestCase):
             resp.close()
 
         here = os.path.dirname(__file__)
-        filename = os.path.join(here, 'software_development_in_picture.jpg')
+        filename = 'software_development_in_picture.jpg'
         self.loop.run_until_complete(go(here, filename))
 
     def test_static_file_with_content_encoding(self):
@@ -342,7 +342,7 @@ class TestWebFunctional(unittest.TestCase):
             resp.close()
 
         here = os.path.dirname(__file__)
-        filename = os.path.join(here, 'hello.txt.gz')
+        filename = 'hello.txt.gz'
         self.loop.run_until_complete(go(here, filename))
 
     def test_static_file_directory_traversal_attack(self):


### PR DESCRIPTION
Hopefully prevent directory traversal attacks; as discussed in issue #380.