### PR TITLE
Make StaticRoute support Last-Modified and If-Modified-Since headers

### DIFF
--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -69,34 +69,6 @@ class HeadersMixin:
         else:
             return int(l)
 
-    @property
-    def if_modified_since(self, _IF_MODIFIED_SINCE=hdrs.IF_MODIFIED_SINCE):
-        """The value of If-Modified-Since HTTP header, or None.
-
-        This header is represented as a `datetime` object.
-        """
-        httpdate = self.headers.get(_IF_MODIFIED_SINCE)
-        if httpdate is not None:
-            timetuple = parsedate(httpdate)
-            if timetuple is not None:
-                return datetime.datetime(*timetuple[:6],
-                                         tzinfo=datetime.timezone.utc)
-        return None
-
-    @property
-    def last_modified(self, _LAST_MODIFIED=hdrs.LAST_MODIFIED):
-        """The value of Last-Modified HTTP header, or None.
-
-        This header is represented as a `datetime` object.
-        """
-        httpdate = self.headers.get(_LAST_MODIFIED)
-        if httpdate is not None:
-            timetuple = parsedate(httpdate)
-            if timetuple is not None:
-                return datetime.datetime(*timetuple[:6],
-                                         tzinfo=datetime.timezone.utc)
-        return None
-
 FileField = collections.namedtuple('Field', 'name filename file content_type')
 
 
@@ -228,6 +200,20 @@ class Request(dict, HeadersMixin):
     def headers(self):
         """A case-insensitive multidict proxy with all headers."""
         return self._headers
+
+    @property
+    def if_modified_since(self, _IF_MODIFIED_SINCE=hdrs.IF_MODIFIED_SINCE):
+        """The value of If-Modified-Since HTTP header, or None.
+
+        This header is represented as a `datetime` object.
+        """
+        httpdate = self.headers.get(_IF_MODIFIED_SINCE)
+        if httpdate is not None:
+            timetuple = parsedate(httpdate)
+            if timetuple is not None:
+                return datetime.datetime(*timetuple[:6],
+                                         tzinfo=datetime.timezone.utc)
+        return None
 
     @property
     def keep_alive(self):
@@ -545,9 +531,18 @@ class StreamResponse(HeadersMixin):
         self._generate_content_type_header()
 
     @property
-    def last_modified(self):
-        # Just a placeholder for adding setter
-        return super().last_modified
+    def last_modified(self, _LAST_MODIFIED=hdrs.LAST_MODIFIED):
+        """The value of Last-Modified HTTP header, or None.
+
+        This header is represented as a `datetime` object.
+        """
+        httpdate = self.headers.get(_LAST_MODIFIED)
+        if httpdate is not None:
+            timetuple = parsedate(httpdate)
+            if timetuple is not None:
+                return datetime.datetime(*timetuple[:6],
+                                         tzinfo=datetime.timezone.utc)
+        return None
 
     @last_modified.setter
     def last_modified(self, value):

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -4,13 +4,17 @@ import asyncio
 import binascii
 import cgi
 import collections
+import datetime
 import http.cookies
 import io
 import json
+import math
+import time
 import warnings
 
-from urllib.parse import urlsplit, parse_qsl, unquote
+from email.utils import parsedate
 from types import MappingProxyType
+from urllib.parse import urlsplit, parse_qsl, unquote
 
 from . import hdrs
 from .helpers import reify
@@ -65,6 +69,33 @@ class HeadersMixin:
         else:
             return int(l)
 
+    @property
+    def if_modified_since(self, _IF_MODIFIED_SINCE=hdrs.IF_MODIFIED_SINCE):
+        """The value of If-Modified-Since HTTP header, or None.
+
+        This header is represented as a `datetime` object.
+        """
+        httpdate = self.headers.get(_IF_MODIFIED_SINCE)
+        if httpdate is not None:
+            timetuple = parsedate(httpdate)
+            if timetuple is not None:
+                return datetime.datetime(*timetuple[:6],
+                                         tzinfo=datetime.timezone.utc)
+        return None
+
+    @property
+    def last_modified(self, _LAST_MODIFIED=hdrs.LAST_MODIFIED):
+        """The value of Last-Modified HTTP header, or None.
+
+        This header is represented as a `datetime` object.
+        """
+        httpdate = self.headers.get(_LAST_MODIFIED)
+        if httpdate is not None:
+            timetuple = parsedate(httpdate)
+            if timetuple is not None:
+                return datetime.datetime(*timetuple[:6],
+                                         tzinfo=datetime.timezone.utc)
+        return None
 
 FileField = collections.namedtuple('Field', 'name filename file content_type')
 
@@ -512,6 +543,25 @@ class StreamResponse(HeadersMixin):
         else:
             self._content_dict['charset'] = str(value).lower()
         self._generate_content_type_header()
+
+    @property
+    def last_modified(self):
+        # Just a placeholder for adding setter
+        return super().last_modified
+
+    @last_modified.setter
+    def last_modified(self, value):
+        if value is None:
+            if hdrs.LAST_MODIFIED in self.headers:
+                del self.headers[hdrs.LAST_MODIFIED]
+        elif isinstance(value, (int, float)):
+            self.headers[hdrs.LAST_MODIFIED] = time.strftime(
+                "%a, %d %b %Y %H:%M:%S GMT", time.gmtime(math.ceil(value)))
+        elif isinstance(value, datetime.datetime):
+            self.headers[hdrs.LAST_MODIFIED] = time.strftime(
+                "%a, %d %b %Y %H:%M:%S GMT", value.utctimetuple())
+        elif isinstance(value, str):
+            self.headers[hdrs.LAST_MODIFIED] = value
 
     def _generate_content_type_header(self, CONTENT_TYPE=hdrs.CONTENT_TYPE):
         params = '; '.join("%s=%s" % i for i in self._content_dict.items())

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -198,6 +198,15 @@ first positional parameter.
 
       Returns :class:`int` or ``None`` if *Content-Length* is absent.
 
+   .. attribute:: if_modified_since
+
+      Read-only property that returns the date specified in the
+      *If-Modified-Since* header.
+
+      Returns :class:`datetime.datetime` or ``None`` if
+      *If-Modified-Since* header is absent or is not a valid
+      HTTP date.
+
    .. coroutinemethod:: read()
 
       Read request body, returns :class:`bytes` object with body content.
@@ -502,6 +511,15 @@ StreamResponse
       *Charset* aka *encoding* part of *Content-Type* for outgoing response.
 
       The value converted to lower-case on attribute assigning.
+
+   .. attribute:: last_modified
+
+      *Last-Modified* header for outgoing response.
+
+      This property accepts raw :class:`str` values,
+      :class:`datetime.datetime` objects, Unix timestamps specified
+      as an :class:`int` or a :class:`float` object, and the
+      value ``None`` to unset the header.
 
    .. method:: start(request)
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -394,11 +394,37 @@ class TestWebFunctional(unittest.TestCase):
             self.assertEqual(304, resp.status)
             resp.close()
 
+        here = os.path.dirname(__file__)
+        filename = 'data.unknown_mime_type'
+        self.loop.run_until_complete(go(here, filename))
+
+    def test_static_file_if_modified_since_past_date(self):
+
+        @asyncio.coroutine
+        def go(dirname, filename):
+            app, _, url = yield from self.create_server(
+                'GET', '/static/' + filename
+            )
+            app.router.add_static('/static', dirname)
+
             lastmod = 'Mon, 1 Jan 1990 01:01:01 GMT'
             resp = yield from request('GET', url, loop=self.loop,
                                       headers={'If-Modified-Since': lastmod})
             self.assertIn(resp.status, (200, 304))
             resp.close()
+
+        here = os.path.dirname(__file__)
+        filename = 'data.unknown_mime_type'
+        self.loop.run_until_complete(go(here, filename))
+
+    def test_static_file_not_modified_since(self):
+
+        @asyncio.coroutine
+        def go(dirname, filename):
+            app, _, url = yield from self.create_server(
+                'GET', '/static/' + filename
+            )
+            app.router.add_static('/static', dirname)
 
             lastmod = 'Fri, 31 Dec 9999 23:59:59 GMT'
             resp = yield from request('GET', url, loop=self.loop,

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -374,6 +374,48 @@ class TestWebFunctional(unittest.TestCase):
         filename = '../README.rst'
         self.loop.run_until_complete(go(here, filename))
 
+    def test_static_file_if_modified_since(self):
+
+        @asyncio.coroutine
+        def go(dirname, filename):
+            app, _, url = yield from self.create_server(
+                'GET', '/static/' + filename
+            )
+            app.router.add_static('/static', dirname)
+
+            resp = yield from request('GET', url, loop=self.loop)
+            self.assertEqual(200, resp.status)
+            lastmod = resp.headers.get('Last-Modified')
+            self.assertIsNotNone(lastmod)
+            resp.close()
+
+            resp = yield from request('GET', url, loop=self.loop,
+                                      headers={'If-Modified-Since': lastmod})
+            self.assertEqual(304, resp.status)
+            resp.close()
+
+            lastmod = 'Mon, 1 Jan 1990 01:01:01 GMT'
+            resp = yield from request('GET', url, loop=self.loop,
+                                      headers={'If-Modified-Since': lastmod})
+            self.assertIn(resp.status, (200, 304))
+            resp.close()
+
+            lastmod = 'Fri, 31 Dec 9999 23:59:59 GMT'
+            resp = yield from request('GET', url, loop=self.loop,
+                                      headers={'If-Modified-Since': lastmod})
+            self.assertEqual(200, resp.status)
+            resp.close()
+
+            lastmod = 'not a valid HTTP-date'
+            resp = yield from request('GET', url, loop=self.loop,
+                                      headers={'If-Modified-Since': lastmod})
+            self.assertEqual(200, resp.status)
+            resp.close()
+
+        here = os.path.dirname(__file__)
+        filename = 'data.unknown_mime_type'
+        self.loop.run_until_complete(go(here, filename))
+
     def test_static_route_path_existence_check(self):
         directory = os.path.dirname(__file__)
         web.StaticRoute(None, "/", directory)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import unittest
 from unittest import mock
 from aiohttp import hdrs
@@ -102,6 +103,42 @@ class TestStreamResponse(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             resp.charset = 'koi8-r'
+
+    def test_last_modified_initial(self):
+        resp = StreamResponse()
+        self.assertIsNone(resp.last_modified)
+
+    def test_last_modified_string(self):
+        resp = StreamResponse()
+
+        dt = datetime.datetime(1990, 1, 2, 3, 4, 5, 0, datetime.timezone.utc)
+        resp.last_modified = 'Mon, 2 Jan 1990 03:04:05 GMT'
+        self.assertEqual(resp.last_modified, dt)
+
+    def test_last_modified_timestamp(self):
+        resp = StreamResponse()
+
+        dt = datetime.datetime(1970, 1, 1, 0, 0, 0, 0, datetime.timezone.utc)
+
+        resp.last_modified = 0
+        self.assertEqual(resp.last_modified, dt)
+
+        resp.last_modified = 0.0
+        self.assertEqual(resp.last_modified, dt)
+
+    def test_last_modified_datetime(self):
+        resp = StreamResponse()
+
+        dt = datetime.datetime(2001, 2, 3, 4, 5, 6, 0, datetime.timezone.utc)
+        resp.last_modified = dt
+        self.assertEqual(resp.last_modified, dt)
+
+    def test_last_modified_reset(self):
+        resp = StreamResponse()
+
+        resp.last_modified = 0
+        resp.last_modified = None
+        self.assertEqual(resp.last_modified, None)
 
     @mock.patch('aiohttp.web_reqrep.ResponseImpl')
     def test_start(self, ResponseImpl):


### PR DESCRIPTION
This change makes `StaticRoute` add `Last-Modified` headers to the responses and recognize `If-Modified-Since` headers in the requests. If `If-Modified-Since` header is present and is equal to the modification time of the file being served, `StaticRoute` will now respond with a 304 "Not Modified" response.

This is a small feature, but rather useful if you hit "Refresh" button often.