### PR TITLE
fix request content-length header erasing after post redirect

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -155,6 +155,8 @@ class ClientSession:
                 if resp.status != 307:
                     method = hdrs.METH_GET
                     data = None
+                    if headers.get(hdrs.CONTENT_LENGTH):
+                        headers.pop(hdrs.CONTENT_LENGTH)
 
                 r_url = (resp.headers.get(hdrs.LOCATION) or
                          resp.headers.get(hdrs.URI))

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -153,6 +153,22 @@ class TestHttpClientFunctional(unittest.TestCase):
             self.assertEqual(2, httpd['redirects'])
             r.close()
 
+    def test_HTTP_302_REDIRECT_POST_with_content_length_header(self):
+        data = json.dumps({'some': 'data'})
+        with test_utils.run_server(self.loop, router=Functional) as httpd:
+            r = self.loop.run_until_complete(
+                client.request('post', httpd.url('redirect', 2),
+                               data=data,
+                               headers={'Content-Length': str(len(data))},
+                               loop=self.loop))
+            content = self.loop.run_until_complete(r.content.read())
+            content = content.decode()
+
+            self.assertEqual(r.status, 200)
+            self.assertIn('"method": "GET"', content)
+            self.assertEqual(2, httpd['redirects'])
+            r.close()
+
     def test_HTTP_307_REDIRECT_POST(self):
         with test_utils.run_server(self.loop, router=Functional) as httpd:
             r = self.loop.run_until_complete(


### PR DESCRIPTION
When performing a POST request with some data to server and it answers with redirect 303 See other with location of resource.
So when we are trying to handle redirect to that resource, we still have a Content-Length header left from POST. It cause ```send_headers``` method to try to write payload with no data but with length

```python
    def send_headers(self, _sep=': ', _end='\r\n'):
        """Writes headers to a stream. Constructs payload writer."""
        ...
        elif self.length is not None:
            self.writer = self._write_length_payload(self.length)
        ...
```

Maybe this fix just fixing the symptom, but what I want is to pay attention at POST with data redirect problem 