### PR TITLE
Allow middleware to set response headers in a dependable way

### DIFF
--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -95,6 +95,9 @@ cdef class _Base:
     def __len__(self):
         return len(self._items)
 
+    def __bool__(self):
+        return bool(self._items)
+
     cpdef keys(self):
         """Return a new view of the dictionary's keys."""
         return _KeysView.__new__(_KeysView, self._items)

--- a/aiohttp/multidict.py
+++ b/aiohttp/multidict.py
@@ -73,6 +73,9 @@ class _Base:
     def __len__(self):
         return len(self._items)
 
+    def __bool__(self):
+        return bool(self._items)
+
     def keys(self):
         """Return a new view of the dictionary's keys."""
         return _KeysView(self._items)


### PR DESCRIPTION
I'd like to write middleware that can add response headers in all circumstances, including on streamed responses. The example at 57ebeae doesn't work in such a case as the response has already started.

This PR adds a `response_headers` attribute to `Request`, which are then added to the response headers when `StreamResponse.start(…)` is called. Each header is only added if the key doesn't already exist in `headers`, so that handlers can override any defaults that might have been set by middleware. I suspect that in most cases conflicts won't be an issue, and can be handled by having the request handler check `request.response_headers` before attempting to set headers on the response directly.

If this seems reasonable, I'll add more commits to the PR to document this functionality (on the `Request` ref docs, and in the middleware section).