### PR TITLE
Fix deflate compression when writing a chunked response

### DIFF
--- a/aiohttp/protocol.py
+++ b/aiohttp/protocol.py
@@ -686,7 +686,8 @@ class HttpMessage:
         if self.filter:
             chunk = self.filter.send(chunk)
             while chunk not in (EOF_MARKER, EOL_MARKER):
-                self.writer.send(chunk)
+                if chunk:
+                    self.writer.send(chunk)
                 chunk = next(self.filter)
         else:
             if chunk is not EOF_MARKER:

--- a/tests/test_http_protocol.py
+++ b/tests/test_http_protocol.py
@@ -434,7 +434,9 @@ class TestHttpMessage(unittest.TestCase):
         msg.write(b'data')
         msg.write_eof()
 
-        content = b''.join([c[1][0] for c in list(write.mock_calls)])
+        chunks = [c[1][0] for c in list(write.mock_calls)]
+        self.assertTrue(all(chunks))
+        content = b''.join(chunks)
         self.assertEqual(
             self._COMPRESSED, content.split(b'\r\n\r\n', 1)[-1])
 
@@ -449,7 +451,9 @@ class TestHttpMessage(unittest.TestCase):
         msg.write(b'data')
         msg.write_eof()
 
-        content = b''.join([c[1][0] for c in list(write.mock_calls)])
+        chunks = [c[1][0] for c in list(write.mock_calls)]
+        self.assertTrue(all(chunks))
+        content = b''.join(chunks)
         self.assertEqual(
             b'2\r\nKI\r\n2\r\n,I\r\n2\r\n\x04\x00\r\n0\r\n\r\n',
             content.split(b'\r\n\r\n', 1)[-1])
@@ -466,7 +470,9 @@ class TestHttpMessage(unittest.TestCase):
         msg.write(b'data')
         msg.write_eof()
 
-        content = b''.join([c[1][0] for c in list(write.mock_calls)])
+        chunks = [c[1][0] for c in list(write.mock_calls)]
+        self.assertTrue(all(chunks))
+        content = b''.join(chunks)
         self.assertEqual(
             self._COMPRESSED, content.split(b'\r\n\r\n', 1)[-1])
 


### PR DESCRIPTION
Ensure all chunks have a size greater than 0, to avoid indicating end of
file prematurely.