### PR TITLE
Adding connections to the pool after creation

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -282,6 +282,7 @@ class BaseConnector(object):
                 yield from fut
 
         transport, proto = self._get(key)
+
         if transport is None:
             try:
                 if self._conn_timeout:
@@ -290,6 +291,11 @@ class BaseConnector(object):
                         self._conn_timeout, loop=self._loop)
                 else:
                     transport, proto = yield from self._create_connection(req)
+
+                if self._conns.get(key, None) is None:
+                    self._conns[key] = []
+
+                self._conns[key].append((transport, proto, self._loop.time()))
             except asyncio.TimeoutError as exc:
                 raise ClientTimeoutError(
                     'Connection timeout to host %s:%s ssl:%s' % key) from exc


### PR DESCRIPTION
The current implementation does not add the newly created connection to the connection pool, thus breaking the keep-alive functionality by always creating a new connection for every request.