### PR TITLE
Allow gzip compression in high-level server response interface

### DIFF
--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -382,14 +382,15 @@ StreamResponse
 
       .. seealso:: :meth:`enable_compression`
 
-   .. method:: enable_compression(force=False)
+   .. method:: enable_compression(force=None)
 
       Enable compression.
 
-      When *force* is ``False`` (default) compression is used only
-      when *deflate* is in *Accept-Encoding* request's header.
+      When *force* is unset compression encoding is selected based on
+      the request's *Accept-Encoding* header.
 
-      *Accept-Encoding* is not checked if *force* is ``True``.
+      *Accept-Encoding* is not checked if *force* is set to a
+      :class:`ContentCoding`.
 
       .. versionadded:: 0.14
 
@@ -1217,3 +1218,17 @@ Utilities
       *MIME type* of uploaded file, ``'text/plain'`` by default.
 
    .. seealso:: :ref:`aiohttp-web-file-upload`
+
+
+Constants
+---------
+
+.. class:: ContentCoding
+
+   An :class:`enum.Enum` class of available Content Codings.
+
+   .. attribute:: deflate
+
+   .. attribute:: gzip
+
+   .. attribute:: identity

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ with codecs.open(os.path.join(os.path.abspath(os.path.dirname(
 install_requires = ['chardet']
 
 if sys.version_info < (3, 4):
-    install_requires += ['asyncio']
+    install_requires += ['asyncio', 'flufl.enum']
 
 tests_require = install_requires + ['nose', 'gunicorn']
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -4,7 +4,7 @@ import unittest
 from unittest import mock
 from aiohttp import hdrs
 from aiohttp.multidict import CIMultiDict
-from aiohttp.web import Request, StreamResponse, Response
+from aiohttp.web import ContentCoding, Request, StreamResponse, Response
 from aiohttp.protocol import HttpVersion, HttpVersion11, HttpVersion10
 from aiohttp.protocol import RawRequestMessage
 
@@ -197,7 +197,7 @@ class TestStreamResponse(unittest.TestCase):
         self.assertFalse(msg.add_compression_filter.called)
 
     @mock.patch('aiohttp.web_reqrep.ResponseImpl')
-    def test_force_compression_no_accept(self, ResponseImpl):
+    def test_force_compression_no_accept_backwards_compat(self, ResponseImpl):
         req = self.make_request('GET', '/')
         resp = StreamResponse()
         self.assertFalse(resp.chunked)
@@ -211,7 +211,19 @@ class TestStreamResponse(unittest.TestCase):
         self.assertIsNotNone(msg.filter)
 
     @mock.patch('aiohttp.web_reqrep.ResponseImpl')
-    def test_compression(self, ResponseImpl):
+    def test_force_compression_false_backwards_compat(self, ResponseImpl):
+        req = self.make_request('GET', '/')
+        resp = StreamResponse()
+
+        self.assertFalse(resp.compression)
+        resp.enable_compression(force=False)
+        self.assertTrue(resp.compression)
+
+        msg = resp.start(req)
+        self.assertFalse(msg.add_compression_filter.called)
+
+    @mock.patch('aiohttp.web_reqrep.ResponseImpl')
+    def test_compression_default_coding(self, ResponseImpl):
         req = self.make_request(
             'GET', '/',
             headers=CIMultiDict({hdrs.ACCEPT_ENCODING: 'gzip, deflate'}))
@@ -223,8 +235,61 @@ class TestStreamResponse(unittest.TestCase):
         self.assertTrue(resp.compression)
 
         msg = resp.start(req)
-        self.assertTrue(msg.add_compression_filter.called)
+        msg.add_compression_filter.assert_called_with('deflate')
+        self.assertEqual('deflate', resp.headers.get(hdrs.CONTENT_ENCODING))
         self.assertIsNotNone(msg.filter)
+
+    @mock.patch('aiohttp.web_reqrep.ResponseImpl')
+    def test_force_compression_deflate(self, ResponseImpl):
+        req = self.make_request(
+            'GET', '/',
+            headers=CIMultiDict({hdrs.ACCEPT_ENCODING: 'gzip, deflate'}))
+        resp = StreamResponse()
+
+        resp.enable_compression(ContentCoding.deflate)
+        self.assertTrue(resp.compression)
+
+        msg = resp.start(req)
+        msg.add_compression_filter.assert_called_with('deflate')
+        self.assertEqual('deflate', resp.headers.get(hdrs.CONTENT_ENCODING))
+
+    @mock.patch('aiohttp.web_reqrep.ResponseImpl')
+    def test_force_compression_no_accept_deflate(self, ResponseImpl):
+        req = self.make_request('GET', '/')
+        resp = StreamResponse()
+
+        resp.enable_compression(ContentCoding.deflate)
+        self.assertTrue(resp.compression)
+
+        msg = resp.start(req)
+        msg.add_compression_filter.assert_called_with('deflate')
+        self.assertEqual('deflate', resp.headers.get(hdrs.CONTENT_ENCODING))
+
+    @mock.patch('aiohttp.web_reqrep.ResponseImpl')
+    def test_force_compression_gzip(self, ResponseImpl):
+        req = self.make_request(
+            'GET', '/',
+            headers=CIMultiDict({hdrs.ACCEPT_ENCODING: 'gzip, deflate'}))
+        resp = StreamResponse()
+
+        resp.enable_compression(ContentCoding.gzip)
+        self.assertTrue(resp.compression)
+
+        msg = resp.start(req)
+        msg.add_compression_filter.assert_called_with('gzip')
+        self.assertEqual('gzip', resp.headers.get(hdrs.CONTENT_ENCODING))
+
+    @mock.patch('aiohttp.web_reqrep.ResponseImpl')
+    def test_force_compression_no_accept_gzip(self, ResponseImpl):
+        req = self.make_request('GET', '/')
+        resp = StreamResponse()
+
+        resp.enable_compression(ContentCoding.gzip)
+        self.assertTrue(resp.compression)
+
+        msg = resp.start(req)
+        msg.add_compression_filter.assert_called_with('gzip')
+        self.assertEqual('gzip', resp.headers.get(hdrs.CONTENT_ENCODING))
 
     def test_write_non_byteish(self):
         resp = StreamResponse()


### PR DESCRIPTION
Add encoding kwarg to enable_compression to select gzip or deflate and
set Content-Encoding header.

This is for issue #396.

I have a few concerns about this code:

I think that when using a high level interface one would generally want to simply enable all types of compression that are supported by the library, with selection automatically made based on the Accept-Encoding header.  Potentially one may want to optionally specify a subset of the available encoding types, such as if we had compress support, maybe one would want to allow *gzip* and *compress* but not *deflate*.

I considered changing the signature to accept a sequence of encodings, however if we do this it is no longer intuitive to me how the `force` argument behaves.

Let me know how you think it would best to proceed.
