### PR TITLE
Test and fix for multidicts' .items(), .keys() and .values() repr

### DIFF
--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -1,7 +1,7 @@
 import sys
 from collections import abc
 from collections.abc import Iterable, Set
-from operators import itemgetter
+from operator import itemgetter
 
 
 _marker = object()

--- a/aiohttp/_multidict.pyx
+++ b/aiohttp/_multidict.pyx
@@ -368,6 +368,9 @@ cdef class _ViewBase:
     def __len__(self):
         return len(self._items)
 
+    def __repr__(self):
+        return '{}({!r})'.format(self.__class__.__name__, self._items)
+
 
 cdef class _ViewBaseSet(_ViewBase):
 

--- a/aiohttp/multidict.py
+++ b/aiohttp/multidict.py
@@ -305,6 +305,9 @@ class _ViewBase:
     def __len__(self):
         return len(self._items)
 
+    def __repr__(self):
+        return '{0.__class__.__name__}({0._items!r})'.format(self)
+
 
 class _ItemsView(_ViewBase, abc.ItemsView):
 

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -300,6 +300,21 @@ class _MultiDictTests(_BaseTest):
         d = self.make_dict([('a', 1), ('a', 2)])
         self.assertEqual(1, d['a'])
 
+    def test_items__repr__(self):
+        d = self.make_dict([('key', 'value1')], key='value2')
+        self.assertEqual(repr(d.items()),
+                         "_ItemsView([('key', 'value1'), ('key', 'value2')])")
+
+    def test_keys__repr__(self):
+        d = self.make_dict([('key', 'value1')], key='value2')
+        self.assertEqual(repr(d.keys()),
+                         "_KeysView([('key', 'value1'), ('key', 'value2')])")
+
+    def test_values__repr__(self):
+        d = self.make_dict([('key', 'value1')], key='value2')
+        self.assertEqual(repr(d.values()),
+                         "_ValuesView([('key', 'value1'), ('key', 'value2')])")
+
 
 class _CIMultiDictTests(_Root):
 
@@ -330,6 +345,21 @@ class _CIMultiDictTests(_Root):
     def test_get(self):
         d = self.make_dict([('A', 1), ('a', 2)])
         self.assertEqual(1, d['a'])
+
+    def test_items__repr__(self):
+        d = self.make_dict([('KEY', 'value1')], key='value2')
+        self.assertEqual(repr(d.items()),
+                         "_ItemsView([('KEY', 'value1'), ('KEY', 'value2')])")
+
+    def test_keys__repr__(self):
+        d = self.make_dict([('KEY', 'value1')], key='value2')
+        self.assertEqual(repr(d.keys()),
+                         "_KeysView([('KEY', 'value1'), ('KEY', 'value2')])")
+
+    def test_values__repr__(self):
+        d = self.make_dict([('KEY', 'value1')], key='value2')
+        self.assertEqual(repr(d.values()),
+                         "_ValuesView([('KEY', 'value1'), ('KEY', 'value2')])")
 
 
 class _NonProxyCIMultiDict(_CIMultiDictTests):


### PR DESCRIPTION
`abc.ItemsView / KeysView / ValuesView` has `__repr__` method but it expects that data is stored in `._mapping` attribute.

First commit is failing test, second -- the fix.