### PR TITLE
Change the behavior of url dispatching with quote characters.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,10 @@ CHANGES
 
 - Allow gzip compression in high-level server response interface #403
 
+- Make UrlDispatcher ignore quoted characters during url matching #414
+Backward-compatibility warning: this may change the url matched by your queries
+if they send quoted characted (like %2F for /).
+
 
 0.16.5 (06-13-2015)
 -------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -14,6 +14,7 @@ Anton Kasyanov
 Arthur Darcet
 Ben Bader
 Brian C. Lane
+Boris Feld
 Chris Laws
 Daniel Nelson
 David Michael Brown

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -179,12 +179,21 @@ class Request(dict, HeadersMixin):
         return urlsplit(self._path_qs)
 
     @property
+    def raw_path(self):
+        """ The URL including raw *PATH INFO* without the host or scheme.
+        Warning, the path is unquoted and may contains non valid URL characters
+
+        E.g., ``/my%2Fpath%7Cwith%21some%25strange%24characters``
+        """
+        return self._splitted_path.path
+
+    @reify
     def path(self):
         """The URL including *PATH INFO* without the host or scheme.
 
         E.g., ``/app/blog``
         """
-        return unquote(self._splitted_path.path)
+        return unquote(self.raw_path)
 
     @reify
     def query_string(self):

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -10,7 +10,7 @@ import re
 import os
 import inspect
 
-from urllib.parse import urlencode
+from urllib.parse import urlencode, unquote
 
 from . import hdrs
 from .abc import AbstractRouter, AbstractMatchInfo
@@ -304,7 +304,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
 
     @asyncio.coroutine
     def resolve(self, request):
-        path = request.path
+        path = request.raw_path
         method = request.method
         allowed_methods = set()
 
@@ -315,6 +315,9 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
 
             route_method = route.method
             if route_method == method or route_method == hdrs.METH_ANY:
+                # Unquote separate matching parts
+                match_dict = {key: unquote(value) for key, value in
+                              match_dict.items()}
                 return UrlMappingMatchInfo(match_dict, route)
 
             allowed_methods.add(route_method)

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -72,6 +72,15 @@ first positional parameter.
 
       Read-only :class:`str` property.
 
+   .. attribute:: raw_path
+
+      The URL including raw *PATH INFO* without the host or scheme.
+      Warning, the path is unquoted and may contains non valid URL characters.
+      e.g.,
+      ``/my%2Fpath%7Cwith%21some%25strange%24characters``
+
+      Read-only :class:`str` property.
+
    .. attribute:: query_string
 
       The query string in the URL, e.g., ``id=10``
@@ -965,6 +974,11 @@ Router is any object that implements :class:`AbstractRouter` interface.
 
    *Named route* can be retrieved by ``app.router[name]`` call, checked for
    existence by ``name in app.router`` etc.
+
+   You can tell UrlDispatcher to use unquoted_path for dispatching instead
+   of quoted path by passing ``unquoted_path=true``. It's necessary if you try
+   to call the server with paths including ``/`` as they may interfere with
+   normal route matching. You will be then responsible for unquoting the path.
 
    .. seealso:: :ref:`Route classes <aiohttp-web-route>`
 


### PR DESCRIPTION
The quoted characters of the URL will not be significant during url dispatching
but will be decoded after the matching.

For example, with this route:

```
@asyncio.coroutine
def handler(request):
    return web.Response(body=repr(request.match_info))

app = Application(loop=loop)
app.router.add_route('GET', '/{route}', handler)
```

The following query will generate this match_info:

```
curl -I http://127.0.0.1:8080/route%2Fslash
HTTP/1.1 200 OK
...
<MatchInfo {'route': 'route/slash'}: <DynamicRoute [*] /{route} -> <function handler at 0x10b888158>>
```