### PR TITLE
fix response.text property

### DIFF
--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -740,6 +740,8 @@ class Response(StreamResponse):
 
     @property
     def text(self):
+        if self._body is None:
+            return None
         return self._body.decode(self.charset or 'utf-8')
 
     @text.setter

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -680,3 +680,8 @@ class TestResponse(unittest.TestCase):
         self.assertEqual('текст'.encode('koi8-r'), resp.body)
         self.assertEqual('text/html', resp.content_type)
         self.assertEqual('koi8-r', resp.charset)
+
+    def test_text_with_empty_payload(self):
+        resp = Response(status=200)
+        self.assertEqual(resp.body, None)
+        self.assertEqual(resp.text, None)


### PR DESCRIPTION
``response.text`` has unexpected behavior:
``` python
response = Rresponse(status=200)
print(response.text)
```
results in:
```python
File "/home/nick/sources/python/aiohttp/aiohttp/web_reqrep.py", line 743, in text
    return self._body.decode(self.charset or 'utf-8')
nose.proxy.AttributeError: 'NoneType' object has no attribute 'decode '
```
here tiny fix.
