### PR TITLE
Fixed ProxyConnector ignoring verify_ssl, ssl_context

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -690,7 +690,7 @@ class ProxyConnector(TCPConnector):
                         "Transport does not expose socket instance")
                 transport.pause_reading()
                 transport, proto = yield from self._loop.create_connection(
-                    self._factory, ssl=True, sock=rawsock,
+                    self._factory, ssl=self.ssl_context, sock=rawsock,
                     server_hostname=req.host)
 
         return transport, proto


### PR DESCRIPTION
The ProxyConnector calls loop.create_connection(ssl=True), where a new default ssl context is then created. This causes the exception "ClientOSError: Cannot connect to host ..." to be raised when connecting to websites with self signed certificates, even after passing verify_ssl=False to ProxyConnector.
Using this patch, the ProxyConnector passes the ssl context created in its superclass TCPConnector (in dependence of verify_ssl) to loop.create_connection().