### PR TITLE
Make the rule: path for add_route should start with slash

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -356,15 +356,17 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
     def add_route(self, method, path, handler,
                   *, name=None, expect_handler=None):
 
-        assert callable(handler), handler
         if not path.startswith('/'):
             raise ValueError("path should be started with /")
+
+        assert callable(handler), handler
         if (not asyncio.iscoroutinefunction(handler) and
                 not inspect.isgeneratorfunction(handler)):
             handler = asyncio.coroutine(handler)
 
         method = upstr(method)
-        assert method in self.METHODS, method
+        if method not in self.METHODS:
+            raise ValueError("{} is not allowed HTTP method".format(method))
 
         if not ('{' in path or '}' in path or self.ROUTE_RE.search(path)):
             route = PlainRoute(

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -357,6 +357,8 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
                   *, name=None, expect_handler=None):
 
         assert callable(handler), handler
+        if not path.startswith('/'):
+            raise ValueError("path should be started with /")
         if (not asyncio.iscoroutinefunction(handler) and
                 not inspect.isgeneratorfunction(handler)):
             handler = asyncio.coroutine(handler)

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1000,9 +1000,9 @@ Router is any object that implements :class:`AbstractRouter` interface.
                          The parameter is case-insensitive, e.g. you
                          can push ``'get'`` as well as ``'GET'``.
 
-      :param str path: route path
+      :param str path: route path. Should be started with slash (``'/'``).
 
-      :param callable handler: route handler
+      :param callable handler: route handler.
 
       :param str name: optional route name.
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -550,3 +550,8 @@ class TestUrlDispatcher(unittest.TestCase):
         with self.assertRaises(ValueError):
             handler = self.make_handler()
             self.router.add_route('GET', 'invalid_path', handler)
+
+    def test_add_route_invalid_method(self):
+        with self.assertRaises(ValueError):
+            handler = self.make_handler()
+            self.router.add_route('INVALID_METHOD', '/path', handler)

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -545,3 +545,8 @@ class TestUrlDispatcher(unittest.TestCase):
             })
 
         self.loop.run_until_complete(go())
+
+    def test_add_route_not_started_with_slash(self):
+        with self.assertRaises(ValueError):
+            handler = self.make_handler()
+            self.router.add_route('GET', 'invalid_path', handler)


### PR DESCRIPTION
I believe paths not started with slash are invalid in our system.
Let's force the rule on making route stage.