### PR TITLE
multiple file upload with same key

### DIFF
--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -360,6 +360,7 @@ class Request(dict, HeadersMixin):
         }
 
         out = MultiDict()
+        _count = 1
         for field in fs.list or ():
             transfer_encoding = field.headers.get(
                 hdrs.CONTENT_TRANSFER_ENCODING, None)
@@ -370,7 +371,8 @@ class Request(dict, HeadersMixin):
                                field.type)
                 if self._post_files_cache is None:
                     self._post_files_cache = {}
-                self._post_files_cache[field.name] = field
+                self._post_files_cache[field.name+str(_count)] = field
+                _count += 1
                 out.add(field.name, ff)
             else:
                 value = field.value

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -186,8 +186,15 @@ class TestWebFunctional(unittest.TestCase):
         def handler(request):
             data = yield from request.post()
             files = data.getall('file')
+            _file_names = []
             for _file in files:
-                self.assertEqual(_file.file.closed, False)
+                self.assertFalse(_file.file.closed)
+                if _file.filename == 'test1.jpeg':
+                    self.assertEqual(_file.file.read(), b'binary data 1')
+                if _file.filename == 'test2.jpeg':
+                    self.assertEqual(_file.file.read(), b'binary data 2')
+                _file_names.append(_file.filename)
+            self.assertCountEqual(_file_names, ['test1.jpeg', 'test2.jpeg'])
             resp = web.Response(body=b'OK')
             return resp
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -181,6 +181,33 @@ class TestWebFunctional(unittest.TestCase):
 
         self.loop.run_until_complete(go())
 
+    def test_files_upload_with_same_key(self):
+        @asyncio.coroutine
+        def handler(request):
+            data = yield from request.post()
+            files = data.getall('file')
+            for _file in files:
+                self.assertEqual(_file.file.closed, False)
+            resp = web.Response(body=b'OK')
+            return resp
+
+        @asyncio.coroutine
+        def go():
+            _, _, url = yield from self.create_server('POST', '/', handler)
+            _data = FormData()
+            _data.add_field('file', b'binary data 1',
+                            content_type='image/jpeg',
+                            filename='test1.jpeg')
+            _data.add_field('file', b'binary data 2',
+                            content_type='image/jpeg',
+                            filename='test2.jpeg')
+            resp = yield from request('POST', url, data=_data,
+                                      loop=self.loop)
+            self.assertEqual(200, resp.status)
+            resp.close()
+
+        self.loop.run_until_complete(go())
+
     def test_post_files(self):
 
         here = os.path.dirname(__file__)


### PR DESCRIPTION
if multiple files are uploaded with same key , only last file descriptor is open and rest is closed