### PR TITLE
routing subsystem refactoring

### DIFF
--- a/aiohttp/hdrs.py
+++ b/aiohttp/hdrs.py
@@ -11,6 +11,7 @@ METH_PATCH = upstr('PATCH')
 METH_POST = upstr('POST')
 METH_PUT = upstr('PUT')
 METH_TRACE = upstr('TRACE')
+METH_PURGE = upstr('PURGE')
 
 ACCEPT = upstr('ACCEPT')
 ACCEPT_CHARSET = upstr('ACCEPT-CHARSET')

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -89,7 +89,11 @@ class RequestHandler(ServerHttpProtocol):
                  "got {!r} [middlewares {!r}]").format(
                      match_info.handler, type(resp), self._middlewares)
         except HTTPException as exc:
-            resp = exc
+            route = self._router.get_system_route(exc.status_code)
+            try:
+                resp = yield from route.handler(request, exc)
+            except:
+                resp = exc
 
         resp_msg = resp.start(request)
         yield from resp.write_eof()

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -278,6 +278,11 @@ class StaticRoute(Route):
 class View(metaclass=abc.ABCMeta):
 
     def __init__(self, handler, name='', method=hdrs.METH_ANY):
+        assert callable(handler), handler
+        if (not asyncio.iscoroutinefunction(handler) and
+                not inspect.isgeneratorfunction(handler)):
+            handler = asyncio.coroutine(handler)
+
         self._name = name
         self._method = upstr(method)
         self._handler = handler
@@ -402,12 +407,6 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         self._urls.append(route)
 
     def add_view(self, method, handler, *, name='', route=None):
-
-        assert callable(handler), handler
-        if (not asyncio.iscoroutinefunction(handler) and
-                not inspect.isgeneratorfunction(handler)):
-            handler = asyncio.coroutine(handler)
-
         if route is None:
             raise ValueError('Route name is required')
 
@@ -418,7 +417,6 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         route.add_view(method, handler, name=name)
 
     def add_route(self, name, path, *, expect_handler=None):
-
         if not path.startswith('/'):
             raise ValueError("path should be started with /")
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -172,7 +172,7 @@ class SystemRoute(ViewableRoute):
 
     def handler(self, request, exc):
         request.match_info['exception'] = exc
-        if self._view or not None:
+        if self._view is not None:
             return (yield from self._view(request))
         else:
             return exc

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -412,7 +412,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
             raise ValueError('Route name is required')
 
         if route not in self._routes:
-            raise ValueError('Route is not found {}', route)
+            raise ValueError('Route is not found {}'.format(route))
 
         route = self._routes[route]
         route.add_view(method, handler, name=name)

--- a/tests/test_client_functional_newstyle.py
+++ b/tests/test_client_functional_newstyle.py
@@ -31,7 +31,8 @@ class TestHttpClientFunctionalNewStyle(unittest.TestCase):
     def create_server(self, method, path, handler=None):
         app = web.Application(loop=self.loop)
         if handler:
-            app.router.add_route(method, path, handler)
+            app.router.add_route('r', path)
+            app.router.add_view(method, handler, route='r')
 
         port = self.find_unused_port()
         self.handler = app.make_handler(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -22,7 +22,8 @@ class TestWeb(unittest.TestCase):
         def handler(request):
             return 'abc'
 
-        app.router.add_route('GET', '/', handler)
+        app.router.add_route('r', '/')
+        app.router.add_view('GET', handler, route='r')
         h = app.make_handler()()
         message = RawRequestMessage('GET', '/', HttpVersion11,
                                     CIMultiDict(), False, False)

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -32,7 +32,8 @@ class TestWebFunctional(unittest.TestCase):
     def create_server(self, method, path, handler=None):
         app = web.Application(loop=self.loop)
         if handler:
-            app.router.add_route(method, path, handler)
+            app.router.add_route('r', path)
+            app.router.add_view(method, handler, route='r')
 
         port = self.find_unused_port()
         self.handler = app.make_handler(
@@ -576,7 +577,9 @@ class TestWebFunctional(unittest.TestCase):
 
             app, _, url = yield from self.create_server('POST', '/')
             app.router.add_route(
-                'POST', '/', handler, expect_handler=expect_handler)
+                'r', '/', expect_handler=expect_handler)
+            app.router.add_view(
+                'POST', handler, route='r')
 
             form = FormData()
             form.add_field('name', b'123',
@@ -617,7 +620,9 @@ class TestWebFunctional(unittest.TestCase):
 
             app, _, url = yield from self.create_server('POST', '/')
             app.router.add_route(
-                'POST', '/', handler, expect_handler=expect_handler)
+                'r', '/', expect_handler=expect_handler)
+            app.router.add_view(
+                'POST', handler, route='r')
 
             form = FormData()
             form.add_field('name', b'123',
@@ -650,7 +655,8 @@ class TestWebFunctional(unittest.TestCase):
         @asyncio.coroutine
         def go():
             app, _, url = yield from self.create_server('POST', '/')
-            app.router.add_route('POST', '/', handler)
+            app.router.add_route('r', '/')
+            app.router.add_view('POST', handler, route='r')
 
             form = FormData()
             form.add_field('name', b'123',
@@ -675,7 +681,8 @@ class TestWebFunctional(unittest.TestCase):
         @asyncio.coroutine
         def go():
             app, _, url = yield from self.create_server('POST', '/')
-            app.router.add_route('POST', '/', handler)
+            app.router.add_route('r', '/')
+            app.router.add_view('POST', handler, route='r')
 
             form = FormData()
             form.add_field('name', b'123',

--- a/tests/test_web_middleware.py
+++ b/tests/test_web_middleware.py
@@ -26,7 +26,8 @@ class TestWebMiddlewareFunctional(unittest.TestCase):
     @asyncio.coroutine
     def create_server(self, method, path, handler, *middlewares):
         app = web.Application(loop=self.loop, middlewares=middlewares)
-        app.router.add_route(method, path, handler)
+        app.router.add_route('r', path)
+        app.router.add_view(method, handler, route='r')
 
         port = self.find_unused_port()
         self.handler = app.make_handler(debug=True)

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -31,7 +31,8 @@ class TestWebWebSocketFunctional(unittest.TestCase):
     @asyncio.coroutine
     def create_server(self, method, path, handler):
         app = web.Application(loop=self.loop)
-        app.router.add_route(method, path, handler)
+        app.router.add_route('r', path)
+        app.router.add_view(method, handler, route='r')
 
         port = self.find_unused_port()
         srv = yield from self.loop.create_server(

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -380,6 +380,7 @@ class TestWebSocketClient(unittest.TestCase):
 class TestWebSocketClientFunctional(unittest.TestCase):
 
     def setUp(self):
+        self.handler = None
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(None)
 
@@ -399,7 +400,8 @@ class TestWebSocketClientFunctional(unittest.TestCase):
     @asyncio.coroutine
     def create_server(self, method, path, handler):
         app = web.Application(loop=self.loop)
-        app.router.add_route(method, path, handler)
+        app.router.add_route('r', path)
+        app.router.add_view(method, handler, route='r')
 
         port = self.find_unused_port()
         self.handler = app.make_handler()


### PR DESCRIPTION
routing subsystem refactoring

1. Route object is responsible for path only (endpoint)
2. handler moved to View object. we can add more matching checks to View, like specific headers, cookies, etc. right now we match only on method.
3. added system routes that match HTTPException, so we can register view for specific system route, i.e. HTTPNotFound, or HTTPForbidden, etc.

this is first version, for discussion
it is not backward compatible, we can make it backward compatible later when we decide if we want to use this changes.


@asvetlov @kxepal  thoughts, ides, etc
