### PR TITLE
Handling of FileNotFoundError in setup.py for build_ext.run

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ class ve_build_ext(build_ext):
     def run(self):
         try:
             build_ext.run(self)
-        except DistutilsPlatformError:
+        except (DistutilsPlatformError, FileNotFoundError):
             raise BuildFailed()
 
     def build_extension(self, ext):


### PR DESCRIPTION
Installation from the pypi repository was failing during the build of extensions so I've fixed it by "handling" `FileNotFoundError`.

This is the traceback I had:
```
    Traceback (most recent call last):
      File "C:\Users\PROST_~1\AppData\Local\Temp\pip-ts3utdkg-build\setup.py", line 36, in run
        build_ext.run(self)
      File "C:\Program Files\Python 3.5\lib\distutils\command\build_ext.py", line 338, in run
        self.build_extensions()
      File "C:\Program Files\Python 3.5\lib\distutils\command\build_ext.py", line 447, in build_extensions
        self._build_extensions_serial()
      File "C:\Program Files\Python 3.5\lib\distutils\command\build_ext.py", line 472, in _build_extensions_serial
        self.build_extension(ext)
      File "C:\Users\PROST_~1\AppData\Local\Temp\pip-ts3utdkg-build\setup.py", line 45, in build_extension
        build_ext.build_extension(self, ext)
      File "C:\Program Files\Python 3.5\lib\distutils\command\build_ext.py", line 532, in build_extension
        depends=ext.depends)
      File "C:\Program Files\Python 3.5\lib\distutils\_msvccompiler.py", line 259, in compile
        self.initialize()
      File "C:\Program Files\Python 3.5\lib\distutils\_msvccompiler.py", line 180, in initialize
        vc_env = _get_vc_env(plat_spec)
      File "C:\Program Files\Python 3.5\lib\distutils\_msvccompiler.py", line 71, in _get_vc_env
        vcvarsall = _find_vcvarsall()
      File "C:\Program Files\Python 3.5\lib\distutils\_msvccompiler.py", line 33, in _find_vcvarsall
        access=winreg.KEY_READ | winreg.KEY_WOW64_32KEY
    FileNotFoundError: [WinError 2] The system cannot find the file specified
```
