### PR TITLE
#454: Don't append CRLF for the last read line

### DIFF
--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -116,14 +116,14 @@ class PartReaderTestCase(TestCase):
         obj = aiohttp.multipart.BodyPartReader(
             self.boundary, {}, Stream(b'Hello, world!\r\n--:'))
         result = yield from obj.next()
-        self.assertEqual(b'Hello, world!\r\n', result)
+        self.assertEqual(b'Hello, world!', result)
         self.assertTrue(obj.at_eof())
 
     def test_next_next(self):
         obj = aiohttp.multipart.BodyPartReader(
             self.boundary, {}, Stream(b'Hello, world!\r\n--:'))
         result = yield from obj.next()
-        self.assertEqual(b'Hello, world!\r\n', result)
+        self.assertEqual(b'Hello, world!', result)
         self.assertTrue(obj.at_eof())
         result = yield from obj.next()
         self.assertIsNone(result)
@@ -132,7 +132,7 @@ class PartReaderTestCase(TestCase):
         obj = aiohttp.multipart.BodyPartReader(
             self.boundary, {}, Stream(b'Hello, world!\r\n--:'))
         result = yield from obj.read()
-        self.assertEqual(b'Hello, world!\r\n', result)
+        self.assertEqual(b'Hello, world!', result)
         self.assertTrue(obj.at_eof())
 
     def test_read_chunk_at_eof(self):
@@ -153,15 +153,15 @@ class PartReaderTestCase(TestCase):
         obj = aiohttp.multipart.BodyPartReader(
             self.boundary, {}, stream)
         result = yield from obj.read()
-        self.assertEqual(b'Hello, world!\r\n', result)
+        self.assertEqual(b'Hello, world!', result)
         self.assertEqual(b'', (yield from stream.read()))
-        self.assertEqual([b'--:'], obj._unread)
+        self.assertEqual([b'--:'], list(obj._unread))
 
     def test_multiread(self):
         obj = aiohttp.multipart.BodyPartReader(
             self.boundary, {}, Stream(b'Hello,\r\n--:\r\n\r\nworld!\r\n--:--'))
         result = yield from obj.read()
-        self.assertEqual(b'Hello,\r\n', result)
+        self.assertEqual(b'Hello,', result)
         result = yield from obj.read()
         self.assertEqual(b'', result)
         self.assertTrue(obj.at_eof())
@@ -170,7 +170,7 @@ class PartReaderTestCase(TestCase):
         obj = aiohttp.multipart.BodyPartReader(
             self.boundary, {}, Stream(b'Hello\n,\r\nworld!\r\n--:--'))
         result = yield from obj.read()
-        self.assertEqual(b'Hello\n,\r\nworld!\r\n', result)
+        self.assertEqual(b'Hello\n,\r\nworld!', result)
         result = yield from obj.read()
         self.assertEqual(b'', result)
         self.assertTrue(obj.at_eof())
@@ -207,7 +207,7 @@ class PartReaderTestCase(TestCase):
             self.boundary, {CONTENT_ENCODING: 'identity'},
             Stream(thing + b'--:--'))
         result = yield from obj.read(decode=True)
-        self.assertEqual(thing, result)
+        self.assertEqual(thing[:-2], result)
 
     def test_read_with_content_encoding_unknown(self):
         obj = aiohttp.multipart.BodyPartReader(
@@ -230,7 +230,7 @@ class PartReaderTestCase(TestCase):
                    b' =D0=BC=D0=B8=D1=80!\r\n--:--'))
         result = yield from obj.read(decode=True)
         self.assertEqual(b'\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82,'
-                         b' \xd0\xbc\xd0\xb8\xd1\x80!\r\n', result)
+                         b' \xd0\xbc\xd0\xb8\xd1\x80!', result)
 
     def test_read_with_content_transfer_encoding_unknown(self):
         obj = aiohttp.multipart.BodyPartReader(
@@ -243,21 +243,21 @@ class PartReaderTestCase(TestCase):
         obj = aiohttp.multipart.BodyPartReader(
             self.boundary, {}, Stream(b'Hello, world!\r\n--:--'))
         result = yield from obj.text()
-        self.assertEqual('Hello, world!\r\n', result)
+        self.assertEqual('Hello, world!', result)
 
     def test_read_text_encoding(self):
         obj = aiohttp.multipart.BodyPartReader(
             self.boundary, {},
             Stream('Привет, Мир!\r\n--:--'.encode('cp1251')))
         result = yield from obj.text(encoding='cp1251')
-        self.assertEqual('Привет, Мир!\r\n', result)
+        self.assertEqual('Привет, Мир!', result)
 
     def test_read_text_guess_encoding(self):
         obj = aiohttp.multipart.BodyPartReader(
             self.boundary, {CONTENT_TYPE: 'text/plain;charset=cp1251'},
             Stream('Привет, Мир!\r\n--:--'.encode('cp1251')))
         result = yield from obj.text()
-        self.assertEqual('Привет, Мир!\r\n', result)
+        self.assertEqual('Привет, Мир!', result)
 
     def test_read_text_compressed(self):
         obj = aiohttp.multipart.BodyPartReader(
@@ -352,7 +352,7 @@ class PartReaderTestCase(TestCase):
         yield from obj.release()
         self.assertTrue(obj.at_eof())
         self.assertEqual(b'\r\nworld!\r\n--:--', stream.content.read())
-        self.assertEqual([b'--:\r\n'], obj._unread)
+        self.assertEqual([b'--:\r\n'], list(obj._unread))
 
     def test_release_respects_content_length(self):
         obj = aiohttp.multipart.BodyPartReader(
@@ -369,7 +369,7 @@ class PartReaderTestCase(TestCase):
         yield from obj.release()
         yield from obj.release()
         self.assertEqual(b'\r\nworld!\r\n--:--', stream.content.read())
-        self.assertEqual([b'--:\r\n'], obj._unread)
+        self.assertEqual([b'--:\r\n'], list(obj._unread))
 
     def test_filename(self):
         part = aiohttp.multipart.BodyPartReader(


### PR DESCRIPTION
The RFC http://www.w3.org/Protocols/rfc1341/7_2_Multipart.html says:
"NOTE: The CRLF preceding the encapsulation line is considered part of
the boundary so that it is possible to have a part that does not end
with a CRLF (line break). Body parts that must be considered to end
with line breaks, therefore, should have two CRLFs preceding
the encapsulation line, the first of which is part of the preceding
body part, and the second of which is part of the encapsulation
boundary."