### PR TITLE
Add response factory to StaticRoute.

### DIFF
--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1014,7 +1014,7 @@ Router is any object that implements :class:`AbstractRouter` interface.
       :returns: new :class:`PlainRoute` or :class:`DynamicRoute` instance.
 
    .. method:: add_static(prefix, path, *, name=None, expect_handler=None, \
-                          chunk_size=256*1024)
+                          chunk_size=256*1024, response_factory=None)
 
       Adds router for returning static files.
 
@@ -1043,6 +1043,13 @@ Router is any object that implements :class:`AbstractRouter` interface.
                              speed but consumes more memory.
 
                              .. versionadded:: 0.16
+
+      :param callable response_factory: factory to use to generate a new
+                                        response, defaults to
+                                        :class:`StreamResponse` and should
+                                        expose a compatible API.
+
+                                        .. versionadded:: 0.17
 
    :returns: new :class:`StaticRoute` instance.
 


### PR DESCRIPTION
Allow specifying a response factory (defaults to StreamResponse) when adding a static route. This allows you to, for example, add extra headers or change default behaviour.