### PR TITLE
Fix read bytes count

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -247,7 +247,7 @@ class BodyPartReader(object):
             'Content-Length required for chunked read'
         chunk_size = min(size, self._length - self._read_bytes)
         chunk = yield from self._content.read(chunk_size)
-        self._read_bytes += chunk_size
+        self._read_bytes += len(chunk)
         if self._read_bytes == self._length:
             self._at_eof = True
             assert b'\r\n' == (yield from self._content.readline()), \

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -163,17 +163,17 @@ class PartReaderTestCase(TestCase):
             yield from obj.read_chunk()
 
     def test_read_chunk_properly_counts_read_bytes(self):
-        size = aiohttp.multipart.BodyPartReader.chunk_size * 10
+        expected = b'.' * 10
+        size = len(expected)
         obj = aiohttp.multipart.BodyPartReader(
             self.boundary, {'CONTENT-LENGTH': size},
-            StreamWithShortenRead(b'.' * size + b'\r\n--:--'))
-        chunks = []
+            StreamWithShortenRead(expected + b'\r\n--:--'))
+        result = bytearray()
         while True:
             chunk = yield from obj.read_chunk()
             if not chunk:
                 break
-            chunks.append(chunk)
-        result = b''.join(chunks)
+            result.extend(chunk)
         self.assertEqual(size, len(result))
         self.assertEqual(b'.' * size, result)
         self.assertTrue(obj.at_eof())

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -2,6 +2,7 @@ import asyncio
 import functools
 import io
 import os
+import random
 import unittest
 import unittest.mock as mock
 import zlib
@@ -67,6 +68,8 @@ class Stream(object):
 
     @asyncio.coroutine
     def read(self, size=None):
+        if size is not None:
+            size = random.randint(size // 2, size)
         return self.content.read(size)
 
     @asyncio.coroutine


### PR DESCRIPTION
`read` attempts to read **up to** `chunk_size` bytes. So real chunk length can be less than `chunk_size`.