### PR TITLE
Avoid putting a new connection in the free list

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -291,12 +291,6 @@ class BaseConnector(object):
                 else:
                     transport, proto = yield from self._create_connection(req)
 
-                if not self._force_close:
-                    if self._conns.get(key, None) is None:
-                        self._conns[key] = []
-
-                    self._conns[key].append((transport, proto,
-                                            self._loop.time()))
             except asyncio.TimeoutError as exc:
                 raise ClientTimeoutError(
                     'Connection timeout to host %s:%s ssl:%s' % key) from exc


### PR DESCRIPTION
The invariant should be: a transport is either in the free list (_conns)
or in the active list (_acquired).

This fixes a bug that put every newly created connection in both lists