### PR TITLE
'=' char is now safe in urls; wss:// protocol is now safe

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -129,7 +129,7 @@ class ClientRequest:
         self.netloc = netloc
 
         scheme = url_parsed.scheme
-        self.ssl = scheme == 'https'
+        self.ssl = scheme in ('https', 'wss')
 
         # set port number if it isn't already set
         if not port:
@@ -175,7 +175,7 @@ class ClientRequest:
                 query = params
 
         self.path = urllib.parse.urlunsplit(
-            ('', '', urllib.parse.quote(path, safe='/%:'), query, fragment))
+            ('', '', urllib.parse.quote(path, safe='/%:='), query, fragment))
         self.url = urllib.parse.urlunsplit(
             (scheme, netloc, self.path, '', ''))
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -73,6 +73,19 @@ class TestClientRequest(unittest.TestCase):
         self.assertTrue(req.ssl)
         self.loop.run_until_complete(req.close())
 
+    def test_websocket_host_port(self):
+        req = ClientRequest('get', 'ws://python.org/', loop=self.loop)
+        self.assertEqual(req.host, 'python.org')
+        self.assertEqual(req.port, 80)
+        self.assertFalse(req.ssl)
+        self.loop.run_until_complete(req.close())
+
+        req = ClientRequest('get', 'wss://python.org/', loop=self.loop)
+        self.assertEqual(req.host, 'python.org')
+        self.assertEqual(req.port, 443)
+        self.assertTrue(req.ssl)
+        self.loop.run_until_complete(req.close())
+
     def test_host_port_err(self):
         self.assertRaises(
             ValueError, ClientRequest, 'get', 'http://python.org:123e/',
@@ -228,6 +241,12 @@ class TestClientRequest(unittest.TestCase):
         req = ClientRequest('get', "http://0.0.0.0/get/test%20case",
                             loop=self.loop)
         self.assertEqual(req.path, "/get/test%20case")
+        self.loop.run_until_complete(req.close())
+
+    def test_path_safe_chars_preserved(self):
+        req = ClientRequest('get', "http://0.0.0.0/get/%:=",
+                            loop=self.loop)
+        self.assertEqual(req.path, "/get/%:=")
         self.loop.run_until_complete(req.close())
 
     def test_params_are_added_before_fragment(self):


### PR DESCRIPTION
The story behind this. I’m building a bot for Slack that communicates through websockets. Before switching to aiohttp websockets I used ‘websockets’ project and it was handling connections just fine.

Switching to aiohttp resulted in an issue with the initial websocket handshake (upgrade). Slack returns an URL which looks like this:

```
wss://ms309.slack-msgs.com/websocket/ElDcJnfq5Q7DBSEZFd4qxyDPkm3dup6vtkKfrUajWTj5ZcgeN68LdBMwspV9Jz5SDNLW8i_IgjWvgZ7Q4a7lVV2_a_ELfUc77cr4-RdI78s=
```

aiohttp had two major issues with handling the url above:

1. wss protocol was treated as non-ssl protocol, resulting effectively in a request to the port 80. Replacing ‘wss’ with ‘https’ fixed it, but that seem to be a hack to me.
2. the equals symbol at the end of querystring was not treated as ’safe’ which resulted in econding ‘=‘ as ‘%3D’. Slack API returned 400 Bad request.

This patch attempts to fix both of the issues. Not sure if the patch and the tests are fully correct. But my slack bot is now working fine :)