### PR TITLE
Fix #489 : properly parse URL's path

### DIFF
--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -173,7 +173,8 @@ class Request(dict, HeadersMixin):
 
     @reify
     def _splitted_path(self):
-        return urlsplit(self._path_qs)
+        url = '{}://{}{}'.format(self.scheme, self.host, self._path_qs)
+        return urlsplit(url)
 
     @property
     def raw_path(self):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -16,6 +16,7 @@ class TestWeb(unittest.TestCase):
     def tearDown(self):
         self.loop.close()
 
+    @unittest.skip('moved to test_web_functional')
     def test_handler_returns_not_response(self):
         app = web.Application(loop=self.loop)
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -66,6 +66,20 @@ class TestWebFunctional(unittest.TestCase):
 
         self.loop.run_until_complete(go())
 
+    def test_handler_returns_not_response(self):
+
+        @asyncio.coroutine
+        def handler(request):
+            return 'abc'
+
+        @asyncio.coroutine
+        def go():
+            _, _, url = yield from self.create_server('GET', '/', handler)
+            resp = yield from request('GET', url, loop=self.loop)
+            self.assertEqual(500, resp.status)
+
+        self.loop.run_until_complete(go())
+
     def test_post_form(self):
 
         @asyncio.coroutine

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -64,6 +64,10 @@ class TestWebRequest(unittest.TestCase):
         self.assertIs(self.transport, req.transport)
         self.assertTrue(req.keep_alive)
 
+    def test_doubleslashes(self):
+        req = self.make_request('GET', '//foo/')
+        self.assertEqual('//foo/', req.path)
+
     def test_POST(self):
         req = self.make_request('POST', '/')
         with self.assertRaises(RuntimeError):


### PR DESCRIPTION
This fix includes two tests and replace an old one (``test_handler_returns_not_response`` in ``test_web``).