### PR TITLE
Streams optimization

### DIFF
--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -171,18 +171,14 @@ class StreamReader(asyncio.StreamReader):
             # This used to just loop creating a new waiter hoping to
             # collect everything in self._buffer, but that would
             # deadlock if the subprocess sends more than self.limit
-            # bytes.  So just call self.read(self._limit) until EOF.
+            # bytes.  So just call self.readany() until EOF.
             blocks = []
             while True:
-                block = yield from self.read(self._limit)
+                block = yield from self.readany()
                 if not block:
                     break
                 blocks.append(block)
-            data = b''.join(blocks)
-            if data:
-                return data
-            else:
-                return EOF_MARKER
+            return b''.join(blocks)
 
         if not self._buffer and not self._eof:
             self._waiter = self._create_waiter('read')

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -395,9 +395,8 @@ def maybe_resume(func):
     def wrapper(self, *args, **kw):
         result = yield from func(self, *args, **kw)
 
-        size = len(self._buffer)
         if self._stream.paused:
-            if size < self._b_limit:
+            if self._buffer_size < self._b_limit:
                 try:
                     self._stream.transport.resume_reading()
                 except (AttributeError, NotImplementedError):
@@ -405,7 +404,7 @@ def maybe_resume(func):
                 else:
                     self._stream.paused = False
         else:
-            if size > self._b_limit:
+            if self._buffer_size > self._b_limit:
                 try:
                     self._stream.transport.pause_reading()
                 except (AttributeError, NotImplementedError):
@@ -439,7 +438,7 @@ class FlowControlStreamReader(StreamReader):
         super().feed_data(data)
 
         if (not self._stream.paused and
-                not has_waiter and len(self._buffer) > self._b_limit):
+                not has_waiter and self._buffer_size > self._b_limit):
             try:
                 self._stream.transport.pause_reading()
             except (AttributeError, NotImplementedError):

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -188,7 +188,7 @@ class StreamReader(asyncio.StreamReader):
                 finally:
                     self._waiter = None
 
-        if n < 0 or len(self._buffer) <= n:
+        if len(self._buffer) <= n:
             data = bytes(self._buffer)
             self._buffer.clear()
         else:

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -119,8 +119,10 @@ class StreamReader(asyncio.StreamReader):
 
         while not_enough:
             while self._buffer and not_enough:
-                ichar = self._buffer[0].find(b'\n', self._buffer_offset) + 1
-                data = self._read_nowait(ichar)
+                offset = self._buffer_offset
+                ichar = self._buffer[0].find(b'\n', offset) + 1
+                # Read from current offset to found b'\n' or to the end.
+                data = self._read_nowait(ichar - offset if ichar else 0)
                 line.append(data)
                 line_size += len(data)
                 if ichar:

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -114,18 +114,20 @@ class StreamReader(asyncio.StreamReader):
             raise self._exception
 
         line = []
+        line_size = 0
         not_enough = True
 
         while not_enough:
             while self._buffer and not_enough:
-                offset = self._buffer_offset
-                ichar = self._buffer[0].find(b'\n', offset) + 1
-                line.append(self._read_nowait(ichar))
+                ichar = self._buffer[0].find(b'\n', self._buffer_offset) + 1
+                data = self._read_nowait(ichar)
+                line.append(data)
+                line_size += len(data)
                 if ichar:
                     not_enough = False
 
-                # if len(line) > self._limit:
-                #     raise ValueError('Line is too long')
+                if line_size > self._limit:
+                    raise ValueError('Line is too long')
 
             if self._eof:
                 break


### PR DESCRIPTION
This is proof of concept of significant `StreamReader` speedup. The main idea is avoiding memory copying and reallocations. The `collections.deque` is used instead of the `bytearray`, but unlike for `DataQueue`, no reading limitations are applied.

## Performance

My benchmarks: https://gist.github.com/homm/3b9c2909905f76668bf9

Test | old time | new time | speedup
-----|-----|-----|--------
Large chunk |
test_stream_feed | 0.0298 | 0.00001 | 2450x
test_stream_read_all | 0.2127 | 0.00005 | 3948x
test_stream_read_less | 0.2433 | 0.0506 | 4.8x
test_stream_read_any | 0.0608 | 0.00005 | 1128x
test_stream_read_exactly | 0.2005 | 0.0173 | 11.5x
Small chunks |
test_stream_feed | 0.0674 | 0.0094 | 7.1x
test_stream_read_all | 0.2633 | 0.0508 | 5.2x
test_stream_read_less | 0.2165 | 0.0556 | 3.9x
test_stream_read_any | 0.1022 | 0.0237 | 4.3x
test_stream_read_exactly | 0.1825 | 0.0371 | 4.9x

## Memory

As a result of removing relocations, the memory consumption and fragmentation is also greatly reduced. I've got following result for the benchmark:

* Without `test_stream_read_all` test.
  * Old: mostly 350-450MB, up to 550MB
  * New: 92MB
* With `test_stream_read_all` test.
  * Old: mostly 350-450MB, up to 550MB
  * New: 170MB

## Distinct

The main difference is how `read(BIG_LIMIT)` and `readany()` produce the result when the buffer is full: In the old implementation, the whole buffer is returned at once. In the new implementation, only the first chunk is returned.