### PR TITLE
Process bytes io

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -288,6 +288,7 @@ class ClientRequest:
                 'attempt to send text data instead of binary'
             self.body = data
             if not self.chunked and isinstance(data, io.BytesIO):
+                # Not chunking if content-length can be determined
                 size = len(data.getbuffer())
                 self.headers[hdrs.CONTENT_LENGTH] = str(size)
                 self.chunked = False

--- a/tests/test_client_functional2.py
+++ b/tests/test_client_functional2.py
@@ -116,7 +116,7 @@ class TestClientFunctional2(unittest.TestCase):
 
         self.loop.run_until_complete(go())
 
-    def test_raw_post_data(self):
+    def test_post_data_bytesio(self):
         data = b'some buffer'
 
         @asyncio.coroutine
@@ -133,6 +133,28 @@ class TestClientFunctional2(unittest.TestCase):
             resp = yield from self.client.post(
                 url+'/',
                 data=io.BytesIO(data))
+            self.assertEqual(200, resp.status)
+            yield from resp.release()
+
+        self.loop.run_until_complete(go())
+
+    def test_post_data_with_bytesio_file(self):
+        data = b'some buffer'
+
+        @asyncio.coroutine
+        def handler(request):
+            post_data = yield from request.post()
+            self.assertEqual(['file'], list(post_data.keys()))
+            self.assertEqual(data, post_data['file'].file.read())
+            return web.Response()
+
+        @asyncio.coroutine
+        def go():
+            app, srv, url = yield from self.create_server()
+            app.router.add_route('post', '/', handler)
+            resp = yield from self.client.post(
+                url+'/',
+                data={'file': io.BytesIO(data)})
             self.assertEqual(200, resp.status)
             yield from resp.release()
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -559,7 +559,8 @@ class TestClientRequest(unittest.TestCase):
 
     def test_data_file(self):
         req = ClientRequest(
-            'POST', 'http://python.org/', data=io.BytesIO(b'*' * 2),
+            'POST', 'http://python.org/',
+            data=io.BufferedReader(io.BytesIO(b'*' * 2)),
             loop=self.loop)
         self.assertTrue(req.chunked)
         self.assertTrue(isinstance(req.body, io.IOBase))


### PR DESCRIPTION
Fixes the problem when `data=io.BytesIO(...)`