### PR TITLE
Drain response after every chunk write in StaticRoute.

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -213,6 +213,7 @@ class StaticRoute(Route):
             else:
                 while chunk:
                     resp.write(chunk)
+                    yield from resp.drain()
                     chunk = f.read(self._chunk_size)
 
         return resp


### PR DESCRIPTION
Shouldn't the handler for `StaticRoute`s give control over to the event loop after writing each chunk, so that the event loop doesn't block? Or, am I missing something?