### PR TITLE
[StaticRoute] Add preliminary support for sendfile system call.

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -191,7 +191,7 @@ class StaticRoute(Route):
             fut.set_result(None)
 
     @asyncio.coroutine
-    def sendfile_system(self, req, resp, fobj, offset, count):
+    def _sendfile_system(self, req, resp, fobj, offset, count):
         """
         Write `count` bytes of `fobj` to `resp` starting from `offset` using
         the ``sendfile`` system call.
@@ -219,7 +219,7 @@ class StaticRoute(Route):
         yield from fut
 
     @asyncio.coroutine
-    def sendfile_fallback(self, req, resp, fobj, offset, count):
+    def _sendfile_fallback(self, req, resp, fobj, offset, count):
         """
         Mimic the :meth:`sendfile` method, but without using the ``sendfile``
         system call. This should be used on systems that don't support the
@@ -244,9 +244,9 @@ class StaticRoute(Route):
             yield from resp.drain()
 
     if hasattr(os, "sendfile"):
-        sendfile = sendfile_system
+        sendfile = _sendfile_system
     else:
-        sendfile = sendfile_fallback
+        sendfile = _sendfile_fallback
 
     @asyncio.coroutine
     def handle(self, request):

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -221,9 +221,9 @@ class StaticRoute(Route):
     @asyncio.coroutine
     def _sendfile_fallback(self, req, resp, fobj, offset, count):
         """
-        Mimic the :meth:`sendfile` method, but without using the ``sendfile``
-        system call. This should be used on systems that don't support the
-        ``sendfile`` system call.
+        Mimic the :meth:`_sendfile_system` method, but without using the
+        ``sendfile`` system call. This should be used on systems that don't
+        support the ``sendfile`` system call.
 
         To avoid blocking the event loop & to keep memory usage low, `fobj` is
         transferred in chunks controlled by the `chunk_size` argument to

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -219,7 +219,6 @@ class StaticRoute(Route):
         system call. This should be used on systems that don't support
         ``sendfile``.
         """
-        yield from resp.drain()
         chunk = fobj.read(self._chunk_size)
         while chunk:
             resp.write(chunk)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -193,8 +193,8 @@ class StaticRoute(Route):
     @asyncio.coroutine
     def sendfile_system(self, req, resp, fobj, offset, count):
         """
-        Write the content of `fobj` to `resp` using the ``sendfile`` system
-        call.
+        Write `count` bytes of `fobj` to `resp` starting from `offset` using
+        the ``sendfile`` system call.
 
         `req` should be a :obj:`aiohttp.web.Request` instance.
 
@@ -202,7 +202,9 @@ class StaticRoute(Route):
 
         `fobj` should be an open file object.
 
-        `offset` & `count` allow for partial writes.
+        `offset` should be an integer >= 0.
+
+        `count` should be an integer > 0.
         """
         yield from resp.drain()
 
@@ -220,8 +222,12 @@ class StaticRoute(Route):
     def sendfile_fallback(self, req, resp, fobj, offset, count):
         """
         Mimic the :meth:`sendfile` method, but without using the ``sendfile``
-        system call. This should be used on systems that don't support
-        ``sendfile``.
+        system call. This should be used on systems that don't support the
+        ``sendfile`` system call.
+
+        To avoid blocking the event loop & to keep memory usage low, `fobj` is
+        transferred in chunks controlled by the `chunk_size` argument to
+        :class:`StaticRoute`.
         """
         fobj.seek(offset)
         chunk_size = self._chunk_size

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -180,16 +180,14 @@ class StaticRoute(Route):
         return self._append_query(url, query)
 
     def _sendfile_cb(self, fut, out_fd, in_fd, offset, count, loop):
+        loop.remove_writer(out_fd)
         try:
             n = os.sendfile(out_fd, in_fd, offset, count)
         except (BlockingIOError, InterruptedError):
-            return
+            n = 0
         except Exception as exc:
-            loop.remove_writer(out_fd)
             fut.set_exception(exc)
             return
-        else:
-            loop.remove_writer(out_fd)
 
         if n < count:
             loop.add_writer(out_fd, self._sendfile_cb, fut, out_fd, in_fd,

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -196,9 +196,13 @@ class StaticRoute(Route):
         Write the content of `fobj` to `resp` using the ``sendfile`` system
         call.
 
-        `fobj` should be an open file object.
+        `req` should be a :obj:`aiohttp.web.Request` instance.
 
         `resp` should be a :obj:`aiohttp.web.StreamResponse` instance.
+
+        `fobj` should be an open file object.
+
+        `offset` & `count` allow for partial writes.
         """
         yield from resp.drain()
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -734,7 +734,7 @@ class TestStaticFileSendfileFallback(WebFunctionalSetupMixin):
     def patch_sendfile(self, add_static):
         def f(*args, **kwargs):
             route = add_static(*args, **kwargs)
-            route.sendfile = route.sendfile_fallback
+            route.sendfile = route._sendfile_fallback
             return route
         return f
 
@@ -956,6 +956,6 @@ class TestStaticFileSendfile(TestStaticFileSendfileFallback):
     def patch_sendfile(self, add_static):
         def f(*args, **kwargs):
             route = add_static(*args, **kwargs)
-            route.sendfile = route.sendfile_system
+            route.sendfile = route._sendfile_system
             return route
         return f

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -11,7 +11,7 @@ from aiohttp.protocol import HttpVersion, HttpVersion10, HttpVersion11
 from aiohttp.streams import EOF_MARKER
 
 
-class TestWebFunctional(unittest.TestCase):
+class WebFunctionalSetupMixin(unittest.TestCase):
 
     def setUp(self):
         self.handler = None
@@ -48,6 +48,9 @@ class TestWebFunctional(unittest.TestCase):
         url = "http://127.0.0.1:{}".format(port) + path
         self.addCleanup(srv.close)
         return app, srv, url
+
+
+class TestWebFunctional(WebFunctionalSetupMixin):
 
     def test_simple_get(self):
 
@@ -312,215 +315,6 @@ class TestWebFunctional(unittest.TestCase):
             resp.close()
 
         self.loop.run_until_complete(go())
-
-    @unittest.skipUnless(hasattr(os, "sendfile"),
-                         "system does not support 'sendfile' system call")
-    def test_static_file_sendfile(self):
-        self.test_static_file(False)
-
-    def test_static_file(self, sendfile_fallback=True):
-
-        @asyncio.coroutine
-        def go(dirname, filename):
-            app, _, url = yield from self.create_server(
-                'GET', '/static/' + filename
-            )
-            app.router.add_static('/static', dirname,
-                                  sendfile_fallback=sendfile_fallback)
-
-            resp = yield from request('GET', url, loop=self.loop)
-            self.assertEqual(200, resp.status)
-            txt = yield from resp.text()
-            self.assertEqual('file content', txt.rstrip())
-            ct = resp.headers['CONTENT-TYPE']
-            self.assertEqual('application/octet-stream', ct)
-            self.assertEqual(resp.headers.get('CONTENT-ENCODING'), None)
-            resp.close()
-
-            resp = yield from request('GET', url + 'fake', loop=self.loop)
-            self.assertEqual(404, resp.status)
-            resp.close()
-
-            resp = yield from request('GET', url + '/../../', loop=self.loop)
-            self.assertEqual(404, resp.status)
-            resp.close()
-
-        here = os.path.dirname(__file__)
-        filename = 'data.unknown_mime_type'
-        self.loop.run_until_complete(go(here, filename))
-
-    def test_static_file_with_content_type(self):
-
-        @asyncio.coroutine
-        def go(dirname, filename):
-            app, _, url = yield from self.create_server(
-                'GET', '/static/' + filename
-            )
-            app.router.add_static('/static', dirname, chunk_size=16)
-
-            resp = yield from request('GET', url, loop=self.loop)
-            self.assertEqual(200, resp.status)
-            body = yield from resp.read()
-            with open(os.path.join(dirname, filename), 'rb') as f:
-                content = f.read()
-                self.assertEqual(content, body)
-            ct = resp.headers['CONTENT-TYPE']
-            self.assertEqual('image/jpeg', ct)
-            self.assertEqual(resp.headers.get('CONTENT-ENCODING'), None)
-            resp.close()
-
-            resp = yield from request('GET', url + 'fake', loop=self.loop)
-            self.assertEqual(404, resp.status)
-            resp.close()
-
-            resp = yield from request('GET', url + '/../../', loop=self.loop)
-            self.assertEqual(404, resp.status)
-            resp.close()
-
-        here = os.path.dirname(__file__)
-        filename = 'software_development_in_picture.jpg'
-        self.loop.run_until_complete(go(here, filename))
-
-    def test_static_file_with_content_encoding(self):
-
-        @asyncio.coroutine
-        def go(dirname, filename):
-            app, _, url = yield from self.create_server(
-                'GET', '/static/' + filename
-            )
-            app.router.add_static('/static', dirname)
-
-            resp = yield from request('GET', url, loop=self.loop)
-            self.assertEqual(200, resp.status)
-            body = yield from resp.read()
-            self.assertEqual(b'hello aiohttp\n', body)
-            ct = resp.headers['CONTENT-TYPE']
-            self.assertEqual('text/plain', ct)
-            encoding = resp.headers['CONTENT-ENCODING']
-            self.assertEqual('gzip', encoding)
-            resp.close()
-
-        here = os.path.dirname(__file__)
-        filename = 'hello.txt.gz'
-        self.loop.run_until_complete(go(here, filename))
-
-    def test_static_file_directory_traversal_attack(self):
-
-        @asyncio.coroutine
-        def go(dirname, relpath):
-            self.assertTrue(os.path.isfile(os.path.join(dirname, relpath)))
-
-            app, _, url = yield from self.create_server('GET', '/static/')
-            app.router.add_static('/static', dirname)
-
-            url_relpath = url + relpath
-            resp = yield from request('GET', url_relpath, loop=self.loop)
-            self.assertEqual(404, resp.status)
-            resp.close()
-
-            url_relpath2 = url + 'dir/../' + filename
-            resp = yield from request('GET', url_relpath2, loop=self.loop)
-            self.assertEqual(404, resp.status)
-            resp.close()
-
-            url_abspath = \
-                url + os.path.abspath(os.path.join(dirname, filename))
-            resp = yield from request('GET', url_abspath, loop=self.loop)
-            self.assertEqual(404, resp.status)
-            resp.close()
-
-        here = os.path.dirname(__file__)
-        filename = '../README.rst'
-        self.loop.run_until_complete(go(here, filename))
-
-    def test_static_file_if_modified_since(self):
-
-        @asyncio.coroutine
-        def go(dirname, filename):
-            app, _, url = yield from self.create_server(
-                'GET', '/static/' + filename
-            )
-            app.router.add_static('/static', dirname)
-
-            resp = yield from request('GET', url, loop=self.loop)
-            self.assertEqual(200, resp.status)
-            lastmod = resp.headers.get('Last-Modified')
-            self.assertIsNotNone(lastmod)
-            resp.close()
-
-            resp = yield from request('GET', url, loop=self.loop,
-                                      headers={'If-Modified-Since': lastmod})
-            self.assertEqual(304, resp.status)
-            resp.close()
-
-        here = os.path.dirname(__file__)
-        filename = 'data.unknown_mime_type'
-        self.loop.run_until_complete(go(here, filename))
-
-    def test_static_file_if_modified_since_past_date(self):
-
-        @asyncio.coroutine
-        def go(dirname, filename):
-            app, _, url = yield from self.create_server(
-                'GET', '/static/' + filename
-            )
-            app.router.add_static('/static', dirname)
-
-            lastmod = 'Mon, 1 Jan 1990 01:01:01 GMT'
-            resp = yield from request('GET', url, loop=self.loop,
-                                      headers={'If-Modified-Since': lastmod})
-            self.assertEqual(200, resp.status)
-            resp.close()
-
-        here = os.path.dirname(__file__)
-        filename = 'data.unknown_mime_type'
-        self.loop.run_until_complete(go(here, filename))
-
-    def test_static_file_if_modified_since_future_date(self):
-
-        @asyncio.coroutine
-        def go(dirname, filename):
-            app, _, url = yield from self.create_server(
-                'GET', '/static/' + filename
-            )
-            app.router.add_static('/static', dirname)
-
-            lastmod = 'Fri, 31 Dec 9999 23:59:59 GMT'
-            resp = yield from request('GET', url, loop=self.loop,
-                                      headers={'If-Modified-Since': lastmod})
-            self.assertEqual(304, resp.status)
-            resp.close()
-
-        here = os.path.dirname(__file__)
-        filename = 'data.unknown_mime_type'
-        self.loop.run_until_complete(go(here, filename))
-
-    def test_static_file_if_modified_since_invalid_date(self):
-
-        @asyncio.coroutine
-        def go(dirname, filename):
-            app, _, url = yield from self.create_server(
-                'GET', '/static/' + filename
-            )
-            app.router.add_static('/static', dirname)
-
-            lastmod = 'not a valid HTTP-date'
-            resp = yield from request('GET', url, loop=self.loop,
-                                      headers={'If-Modified-Since': lastmod})
-            self.assertEqual(200, resp.status)
-            resp.close()
-
-        here = os.path.dirname(__file__)
-        filename = 'data.unknown_mime_type'
-        self.loop.run_until_complete(go(here, filename))
-
-    def test_static_route_path_existence_check(self):
-        directory = os.path.dirname(__file__)
-        web.StaticRoute(None, "/", directory)
-
-        nodirectory = os.path.join(directory, "nonexistent-uPNiOEAg5d")
-        with self.assertRaises(ValueError):
-            web.StaticRoute(None, "/", nodirectory)
 
     def test_post_form_with_duplicate_keys(self):
 
@@ -933,3 +727,235 @@ class TestWebFunctional(unittest.TestCase):
             client.close()
 
         self.loop.run_until_complete(go())
+
+
+class TestStaticFileSendfileFallback(WebFunctionalSetupMixin):
+
+    def patch_sendfile(self, add_static):
+        def f(*args, **kwargs):
+            route = add_static(*args, **kwargs)
+            route.sendfile = route.sendfile_fallback
+            return route
+        return f
+
+    @asyncio.coroutine
+    def create_server(self, method, path):
+        app, srv, url = yield from super().create_server(method, path)
+        app.router.add_static = self.patch_sendfile(app.router.add_static)
+
+        return app, srv, url
+
+    def test_static_file(self):
+
+        @asyncio.coroutine
+        def go(dirname, filename):
+            app, _, url = yield from self.create_server(
+                'GET', '/static/' + filename
+            )
+            app.router.add_static('/static', dirname)
+
+            resp = yield from request('GET', url, loop=self.loop)
+            self.assertEqual(200, resp.status)
+            txt = yield from resp.text()
+            self.assertEqual('file content', txt.rstrip())
+            ct = resp.headers['CONTENT-TYPE']
+            self.assertEqual('application/octet-stream', ct)
+            self.assertEqual(resp.headers.get('CONTENT-ENCODING'), None)
+            resp.close()
+
+            resp = yield from request('GET', url + 'fake', loop=self.loop)
+            self.assertEqual(404, resp.status)
+            resp.close()
+
+            resp = yield from request('GET', url + '/../../', loop=self.loop)
+            self.assertEqual(404, resp.status)
+            resp.close()
+
+        here = os.path.dirname(__file__)
+        filename = 'data.unknown_mime_type'
+        self.loop.run_until_complete(go(here, filename))
+
+    def test_static_file_with_content_type(self):
+
+        @asyncio.coroutine
+        def go(dirname, filename):
+            app, _, url = yield from self.create_server(
+                'GET', '/static/' + filename
+            )
+            app.router.add_static('/static', dirname, chunk_size=16)
+
+            resp = yield from request('GET', url, loop=self.loop)
+            self.assertEqual(200, resp.status)
+            body = yield from resp.read()
+            with open(os.path.join(dirname, filename), 'rb') as f:
+                content = f.read()
+                self.assertEqual(content, body)
+            ct = resp.headers['CONTENT-TYPE']
+            self.assertEqual('image/jpeg', ct)
+            self.assertEqual(resp.headers.get('CONTENT-ENCODING'), None)
+            resp.close()
+
+            resp = yield from request('GET', url + 'fake', loop=self.loop)
+            self.assertEqual(404, resp.status)
+            resp.close()
+
+            resp = yield from request('GET', url + '/../../', loop=self.loop)
+            self.assertEqual(404, resp.status)
+            resp.close()
+
+        here = os.path.dirname(__file__)
+        filename = 'software_development_in_picture.jpg'
+        self.loop.run_until_complete(go(here, filename))
+
+    def test_static_file_with_content_encoding(self):
+
+        @asyncio.coroutine
+        def go(dirname, filename):
+            app, _, url = yield from self.create_server(
+                'GET', '/static/' + filename
+            )
+            app.router.add_static('/static', dirname)
+
+            resp = yield from request('GET', url, loop=self.loop)
+            self.assertEqual(200, resp.status)
+            body = yield from resp.read()
+            self.assertEqual(b'hello aiohttp\n', body)
+            ct = resp.headers['CONTENT-TYPE']
+            self.assertEqual('text/plain', ct)
+            encoding = resp.headers['CONTENT-ENCODING']
+            self.assertEqual('gzip', encoding)
+            resp.close()
+
+        here = os.path.dirname(__file__)
+        filename = 'hello.txt.gz'
+        self.loop.run_until_complete(go(here, filename))
+
+    def test_static_file_directory_traversal_attack(self):
+
+        @asyncio.coroutine
+        def go(dirname, relpath):
+            self.assertTrue(os.path.isfile(os.path.join(dirname, relpath)))
+
+            app, _, url = yield from self.create_server('GET', '/static/')
+            app.router.add_static('/static', dirname)
+
+            url_relpath = url + relpath
+            resp = yield from request('GET', url_relpath, loop=self.loop)
+            self.assertEqual(404, resp.status)
+            resp.close()
+
+            url_relpath2 = url + 'dir/../' + filename
+            resp = yield from request('GET', url_relpath2, loop=self.loop)
+            self.assertEqual(404, resp.status)
+            resp.close()
+
+            url_abspath = \
+                url + os.path.abspath(os.path.join(dirname, filename))
+            resp = yield from request('GET', url_abspath, loop=self.loop)
+            self.assertEqual(404, resp.status)
+            resp.close()
+
+        here = os.path.dirname(__file__)
+        filename = '../README.rst'
+        self.loop.run_until_complete(go(here, filename))
+
+    def test_static_file_if_modified_since(self):
+
+        @asyncio.coroutine
+        def go(dirname, filename):
+            app, _, url = yield from self.create_server(
+                'GET', '/static/' + filename
+            )
+            app.router.add_static('/static', dirname)
+
+            resp = yield from request('GET', url, loop=self.loop)
+            self.assertEqual(200, resp.status)
+            lastmod = resp.headers.get('Last-Modified')
+            self.assertIsNotNone(lastmod)
+            resp.close()
+
+            resp = yield from request('GET', url, loop=self.loop,
+                                      headers={'If-Modified-Since': lastmod})
+            self.assertEqual(304, resp.status)
+            resp.close()
+
+        here = os.path.dirname(__file__)
+        filename = 'data.unknown_mime_type'
+        self.loop.run_until_complete(go(here, filename))
+
+    def test_static_file_if_modified_since_past_date(self):
+
+        @asyncio.coroutine
+        def go(dirname, filename):
+            app, _, url = yield from self.create_server(
+                'GET', '/static/' + filename
+            )
+            app.router.add_static('/static', dirname)
+
+            lastmod = 'Mon, 1 Jan 1990 01:01:01 GMT'
+            resp = yield from request('GET', url, loop=self.loop,
+                                      headers={'If-Modified-Since': lastmod})
+            self.assertEqual(200, resp.status)
+            resp.close()
+
+        here = os.path.dirname(__file__)
+        filename = 'data.unknown_mime_type'
+        self.loop.run_until_complete(go(here, filename))
+
+    def test_static_file_if_modified_since_future_date(self):
+
+        @asyncio.coroutine
+        def go(dirname, filename):
+            app, _, url = yield from self.create_server(
+                'GET', '/static/' + filename
+            )
+            app.router.add_static('/static', dirname)
+
+            lastmod = 'Fri, 31 Dec 9999 23:59:59 GMT'
+            resp = yield from request('GET', url, loop=self.loop,
+                                      headers={'If-Modified-Since': lastmod})
+            self.assertEqual(304, resp.status)
+            resp.close()
+
+        here = os.path.dirname(__file__)
+        filename = 'data.unknown_mime_type'
+        self.loop.run_until_complete(go(here, filename))
+
+    def test_static_file_if_modified_since_invalid_date(self):
+
+        @asyncio.coroutine
+        def go(dirname, filename):
+            app, _, url = yield from self.create_server(
+                'GET', '/static/' + filename
+            )
+            app.router.add_static('/static', dirname)
+
+            lastmod = 'not a valid HTTP-date'
+            resp = yield from request('GET', url, loop=self.loop,
+                                      headers={'If-Modified-Since': lastmod})
+            self.assertEqual(200, resp.status)
+            resp.close()
+
+        here = os.path.dirname(__file__)
+        filename = 'data.unknown_mime_type'
+        self.loop.run_until_complete(go(here, filename))
+
+    def test_static_route_path_existence_check(self):
+        directory = os.path.dirname(__file__)
+        web.StaticRoute(None, "/", directory)
+
+        nodirectory = os.path.join(directory, "nonexistent-uPNiOEAg5d")
+        with self.assertRaises(ValueError):
+            web.StaticRoute(None, "/", nodirectory)
+
+
+@unittest.skipUnless(hasattr(os, "sendfile"),
+                     "sendfile system call not supported")
+class TestStaticFileSendfile(TestStaticFileSendfileFallback):
+
+    def patch_sendfile(self, add_static):
+        def f(*args, **kwargs):
+            route = add_static(*args, **kwargs)
+            route.sendfile = route.sendfile_system
+            return route
+        return f


### PR DESCRIPTION
This is a first draft of `sendfile` support. Not merge ready, yet. Please critique.

The tests probably need some work. Should we test every static file test with both `sendfile` and `sendfile_fallback`?

https://github.com/KeepSafe/aiohttp/issues/398