### PR TITLE
Skip auto-generation of Content-Type header.

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -291,8 +291,7 @@ class ClientRequest:
             if not self.chunked and isinstance(data, io.BytesIO):
                 # Not chunking if content-length can be determined
                 size = len(data.getbuffer())
-                if hdrs.CONTENT_LENGTH not in skip_auto_headers:
-                    self.headers[hdrs.CONTENT_LENGTH] = str(size)
+                self.headers[hdrs.CONTENT_LENGTH] = str(size)
                 self.chunked = False
             elif not self.chunked and isinstance(data, io.BufferedReader):
                 # Not chunking if content-length can be determined

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -97,7 +97,7 @@ class ClientRequest:
                     'not supported at the same time.')
             data = files
 
-        self.update_body_from_data(data)
+        self.update_body_from_data(data, skip_auto_headers)
         self.update_transfer_encoding()
         self.update_expect_continue(expect100)
 
@@ -260,7 +260,7 @@ class ClientRequest:
 
         self.headers[hdrs.AUTHORIZATION] = auth.encode()
 
-    def update_body_from_data(self, data):
+    def update_body_from_data(self, data, skip_auto_headers):
         if not data:
             return
 
@@ -269,7 +269,8 @@ class ClientRequest:
 
         if isinstance(data, (bytes, bytearray)):
             self.body = data
-            if hdrs.CONTENT_TYPE not in self.headers:
+            if (hdrs.CONTENT_TYPE not in self.headers and
+                    hdrs.CONTENT_TYPE not in skip_auto_headers):
                 self.headers[hdrs.CONTENT_TYPE] = 'application/octet-stream'
             if hdrs.CONTENT_LENGTH not in self.headers and not self.chunked:
                 self.headers[hdrs.CONTENT_LENGTH] = str(len(self.body))
@@ -290,7 +291,8 @@ class ClientRequest:
             if not self.chunked and isinstance(data, io.BytesIO):
                 # Not chunking if content-length can be determined
                 size = len(data.getbuffer())
-                self.headers[hdrs.CONTENT_LENGTH] = str(size)
+                if hdrs.CONTENT_LENGTH not in skip_auto_headers:
+                    self.headers[hdrs.CONTENT_LENGTH] = str(size)
                 self.chunked = False
             elif not self.chunked and isinstance(data, io.BufferedReader):
                 # Not chunking if content-length can be determined
@@ -310,6 +312,7 @@ class ClientRequest:
                     raise ValueError('file {!r} should be open in binary mode'
                                      ''.format(data))
             if (hdrs.CONTENT_TYPE not in self.headers and
+                hdrs.CONTENT_TYPE not in skip_auto_headers and
                     hasattr(data, 'name')):
                 mime = mimetypes.guess_type(data.name)[0]
                 mime = 'application/octet-stream' if mime is None else mime
@@ -326,7 +329,8 @@ class ClientRequest:
 
             self.body = data(self.encoding)
 
-            if hdrs.CONTENT_TYPE not in self.headers:
+            if (hdrs.CONTENT_TYPE not in self.headers and
+                    hdrs.CONTENT_TYPE not in skip_auto_headers):
                 self.headers[hdrs.CONTENT_TYPE] = data.content_type
 
             if data.is_multipart:

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -76,7 +76,8 @@ The client session supports context manager protocol for self closing::
       *aiohttp* autogenerates headers like ``User-Agent`` or
       ``Content-Type`` if these headers are not explicitly
       passed. Using ``skip_auto_headers`` parameter allows to skip
-      that generation.
+      that generation. Note that ``Content-Length`` autogeneration can't
+      be skipped.
 
       Iterable of :class:`str` or :class:`~aiohttp.multidict.upstr` (optional)
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 import asyncio
 import gc
 import unittest
@@ -251,6 +253,38 @@ class TestClientRequest(unittest.TestCase):
         self.loop.run_until_complete(req.close())
         resp.close()
 
+    def test_content_type_auto_header_get(self):
+        req = ClientRequest('get', 'http://python.org', loop=self.loop)
+        req.send(self.transport, self.protocol)
+        self.assertNotIn('CONTENT-TYPE', req.headers)
+
+    def test_content_type_auto_header_form(self):
+        req = ClientRequest('get', 'http://python.org', data={'hey': 'you'},
+                            loop=self.loop)
+        req.send(self.transport, self.protocol)
+        self.assertEqual('application/x-www-form-urlencoded',
+                         req.headers.get('CONTENT-TYPE'))
+
+    def test_content_type_auto_header_bytes(self):
+        req = ClientRequest('post', 'http://python.org', data=b'hey you',
+                            loop=self.loop)
+        req.send(self.transport, self.protocol)
+        self.assertEqual('application/octet-stream',
+                         req.headers.get('CONTENT-TYPE'))
+
+    def test_content_type_skip_auto_header_bytes(self):
+        req = ClientRequest('post', 'http://python.org', data=b'hey you',
+                            skip_auto_headers=set('CONTENT-TYPE'),
+                            loop=self.loop)
+        req.send(self.transport, self.protocol)
+        self.assertNotIn('application/octet-stream', req.headers)
+
+    def test_content_type_skip_auto_header_form(self):
+        req = ClientRequest('post', 'http://python.org', data={'hey': 'you'},
+                            loop=self.loop, skip_auto_headers={'CONTENT-TYPE'})
+        req.send(self.transport, self.protocol)
+        self.assertNotIn('CONTENT-TYPE', req.headers)
+
     def test_path_is_not_double_encoded(self):
         req = ClientRequest('get', "http://0.0.0.0/get/test case",
                             loop=self.loop)
@@ -367,7 +401,7 @@ class TestClientRequest(unittest.TestCase):
         req = ClientRequest(
             'post', 'http://python.org/',
             data={}, loop=self.loop)
-        req.update_body_from_data.assert_called_once_with({})
+        req.update_body_from_data.assert_called_once_with({}, frozenset())
         self.loop.run_until_complete(req.close())
 
     def test_get_with_data(self):

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -259,7 +259,7 @@ class TestClientRequest(unittest.TestCase):
         self.assertNotIn('CONTENT-TYPE', req.headers)
 
     def test_content_type_auto_header_form(self):
-        req = ClientRequest('get', 'http://python.org', data={'hey': 'you'},
+        req = ClientRequest('post', 'http://python.org', data={'hey': 'you'},
                             loop=self.loop)
         req.send(self.transport, self.protocol)
         self.assertEqual('application/x-www-form-urlencoded',
@@ -284,6 +284,14 @@ class TestClientRequest(unittest.TestCase):
                             loop=self.loop, skip_auto_headers={'CONTENT-TYPE'})
         req.send(self.transport, self.protocol)
         self.assertNotIn('CONTENT-TYPE', req.headers)
+
+    def test_content_type_auto_header_content_length_no_skip(self):
+        req = ClientRequest('get', 'http://python.org',
+                            data=io.BytesIO(b'hey'),
+                            skip_auto_headers={'CONTENT-LENGTH'},
+                            loop=self.loop)
+        req.send(self.transport, self.protocol)
+        self.assertEqual(req.headers.get('CONTENT-LENGTH'), '3')
 
     def test_path_is_not_double_encoded(self):
         req = ClientRequest('get', "http://0.0.0.0/get/test case",


### PR DESCRIPTION
Content-Type header automatic generation did not honor
the documented `skip_auto_headers` param.

With this patch we correctly skip generation of this header
while documenting that it is not possible to do so for the
`Content-Length` header.

See Issue #379 for details.