### PR TITLE
Routes view

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -363,6 +363,23 @@ class _MethodNotAllowedMatchInfo(UrlMappingMatchInfo):
                         ', '.join(sorted(self._allowed_methods))))
 
 
+class RoutesView:
+
+    __slots__ = '_urls'
+
+    def __init__(self, urls):
+        self._urls = urls
+
+    def __len__(self):
+        return len(self._urls)
+
+    def __iter__(self):
+        yield from self._urls
+
+    def __contains__(self, route):
+        return route in self._urls
+
+
 class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
 
     DYN = re.compile(r'^\{(?P<var>[a-zA-Z][_a-zA-Z0-9]*)\}$')
@@ -416,6 +433,9 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
 
     def __getitem__(self, name):
         return self._routes[name]
+
+    def routes(self):
+        return RoutesView(self._urls)
 
     def register_route(self, route):
         assert isinstance(route, Route), 'Instance of Route class is required.'

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -179,6 +179,25 @@ so application developer can use classes if he wants::
    That means the handler for ``'/path'`` is applied for every HTTP method.
 
 
+Route views
+-----------
+
+.. versionadded:: 0.18
+
+For look on *all* routes in the router you may use
+:meth:`UrlDispatcher.routes` method.
+
+You can iterate over routes in the router table::
+
+   for route in app.router.routes():
+       print(route)
+
+or get router table size::
+
+   len(app.router.routes())
+
+
+
 Custom conditions for routes lookup
 -----------------------------------
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1085,6 +1085,26 @@ Router is any object that implements :class:`AbstractRouter` interface.
          The method don't raise :exc:`HTTPNotFound` and
          :exc:`HTTPMethodNotAllowed` anymore.
 
+   .. method:: routes()
+
+      The method returns a *view* for *all* registered routes.
+
+      The view is an object that allows to:
+
+      1. Get size of the router table::
+
+           len(app.router.routes())
+
+      2. Iterate over registered routes::
+
+           for route in app.router.routes():
+               print(route)
+
+      3. Make a check if the route is registered in the router table::
+
+           route in app.router.routes()
+
+      .. versionadded:: 0.18
 
 .. _aiohttp-web-route:
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -605,3 +605,24 @@ class TestUrlDispatcher(unittest.TestCase):
             self.assertIs(exc, fut.exception())
             self.assertFalse(loop.add_writer.called)
             self.assertFalse(loop.remove_writer.called)
+
+    def fill_routes(self):
+        route1 = self.router.add_route('GET', '/plain', self.make_handler())
+        route2 = self.router.add_route('GET', '/variable/{name}',
+                                       self.make_handler())
+        route3 = self.router.add_static('/static',
+                                        os.path.dirname(aiohttp.__file__))
+        return route1, route2, route3
+
+    def test_routes_view_len(self):
+        self.fill_routes()
+        self.assertEqual(3, len(self.router.routes()))
+
+    def test_routes_view_iter(self):
+        routes = self.fill_routes()
+        self.assertEqual(list(routes), list(self.router.routes()))
+
+    def test_routes_view_contains(self):
+        routes = self.fill_routes()
+        for route in routes:
+            self.assertIn(route, self.router.routes())


### PR DESCRIPTION
We need a view for *all* registered routes.

The questions are:

1. Should `app.router.routes()` to be a method or just property?
2. Do we need `app.router.named_routes()` also? We have implicit access to names routes but I think explicit method makes a value.