### PR TITLE
Reminder to release response in Client doc

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -162,6 +162,18 @@ It is not possible to use ``read()``, ``json()`` and ``text()`` after
 reading the file with ``chunk_size``.
 
 
+Releasing Response
+--------------------------
+
+Don't forget to release response after use. This will ensure explicit 
+behavior and proper connection pooling.
+
+    >>> yield from r.release()
+
+But it's not necessary if you use ``read()``, ``json()`` and ``text()`` methods. 
+They do release connection internally.
+
+
 Custom Headers
 --------------
 


### PR DESCRIPTION
Its not clearly understandable that you have to release your ClientResponse after use. There is call to release method from read, json and text. But if you use response just to see its headers you can get 'Unclosed response' error when GC kills it.