### PR TITLE
Resp prepare

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,7 +2,7 @@ CHANGES
 =======
 
 0.18.0a0 (XX-XX-XXXX)
--------------------
+---------------------
 
 - Use errors.HttpProcessingError.message as HTTP error reason and
   message #459

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -92,7 +92,7 @@ class RequestHandler(ServerHttpProtocol):
         except HTTPException as exc:
             resp = exc
 
-        resp_msg = resp.start(request)
+        resp_msg = yield from resp.prepare(request)
         yield from resp.write_eof()
 
         # notify server about keep-alive

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -617,20 +617,20 @@ class StreamResponse(HeadersMixin):
             return None
 
     def _start_compression(self, request):
-        def start(coding):
+        def _start(coding):
             if coding != ContentCoding.identity:
                 self.headers[hdrs.CONTENT_ENCODING] = coding.value
                 self._resp_impl.add_compression_filter(coding.value)
                 self.content_length = None
 
         if self._compression_force:
-            start(self._compression_force)
+            _start(self._compression_force)
         else:
             accept_encoding = request.headers.get(
                 hdrs.ACCEPT_ENCODING, '').lower()
             for coding in ContentCoding:
                 if coding.value in accept_encoding:
-                    start(coding)
+                    _start(coding)
                     return
 
     def start(self, request):

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -425,8 +425,13 @@ class StreamResponse(HeadersMixin):
             self.headers.add(hdrs.SET_COOKIE, value)
 
     @property
-    def started(self):
+    def prepared(self):
         return self._resp_impl is not None
+
+    @property
+    def started(self):
+        warnings.warn('use Response.prepared instead', DeprecationWarning)
+        return self.prepared
 
     @property
     def status(self):
@@ -629,10 +634,22 @@ class StreamResponse(HeadersMixin):
                     return
 
     def start(self, request):
+        warnings.warn('use .prepare(request) instead', DeprecationWarning)
         resp_impl = self._start_pre_check(request)
         if resp_impl is not None:
             return resp_impl
 
+        return self._start(request)
+
+    @asyncio.coroutine
+    def prepare(self, request):
+        resp_impl = self._start_pre_check(request)
+        if resp_impl is not None:
+            return resp_impl
+
+        return self._start(request)
+
+    def _start(self, request):
         self._req = request
         keep_alive = self._keep_alive
         if keep_alive is None:

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -281,7 +281,7 @@ class StaticRoute(Route):
         file_size = st.st_size
 
         resp.content_length = file_size
-        resp.start(request)
+        yield from resp.prepare(request)
 
         with open(filepath, 'rb') as f:
             yield from self._sendfile(request, resp, f, file_size)

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -86,7 +86,7 @@ class WebSocketResponse(StreamResponse):
         self._post_start(request, parser, protocol, writer)
         return resp_impl
 
-    def can_start(self, request):
+    def can_prepare(self, request):
         if self._writer is not None:
             raise RuntimeError('Already started')
         try:
@@ -97,6 +97,10 @@ class WebSocketResponse(StreamResponse):
             return False, None
         else:
             return True, protocol
+
+    def can_start(self, request):
+        warnings.warn('use .can_prepare(request) instead', DeprecationWarning)
+        return self.can_prepare(request)
 
     @property
     def closed(self):
@@ -256,7 +260,7 @@ class WebSocketResponse(StreamResponse):
             self._waiting = False
 
     @asyncio.coroutine
-    def receive_msg(self):  # pragma: no cover
+    def receive_msg(self):
         warnings.warn(
             'receive_msg() coroutine is deprecated. use receive() instead',
             DeprecationWarning)

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -35,6 +35,7 @@ class WebSocketResponse(StreamResponse):
         self._autoclose = autoclose
         self._autoping = autoping
 
+    @asyncio.coroutine
     def prepare(self, request):
         # make pre-check to don't hide it by do_handshake() exceptions
         resp_impl = self._start_pre_check(request)

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -35,12 +35,18 @@ class WebSocketResponse(StreamResponse):
         self._autoclose = autoclose
         self._autoping = autoping
 
-    def start(self, request):
+    def prepare(self, request):
         # make pre-check to don't hide it by do_handshake() exceptions
         resp_impl = self._start_pre_check(request)
         if resp_impl is not None:
             return resp_impl
 
+        parser, protocol, writer = self._pre_start(request)
+        resp_impl = yield from super().prepare(request)
+        self._post_start(request, parser, protocol, writer)
+        return resp_impl
+
+    def _pre_start(self, request):
         try:
             status, headers, parser, writer, protocol = do_handshake(
                 request.method, request.headers, request.transport,
@@ -59,14 +65,24 @@ class WebSocketResponse(StreamResponse):
         for k, v in headers:
             self.headers[k] = v
         self.force_close()
+        return parser, protocol, writer
 
-        resp_impl = super().start(request)
-
+    def _post_start(self, request, parser, protocol, writer):
         self._reader = request._reader.set_parser(parser)
         self._writer = writer
         self._protocol = protocol
         self._loop = request.app.loop
 
+    def start(self, request):
+        warnings.warn('use .prepare(request) instead', DeprecationWarning)
+        # make pre-check to don't hide it by do_handshake() exceptions
+        resp_impl = self._start_pre_check(request)
+        if resp_impl is not None:
+            return resp_impl
+
+        parser, protocol, writer = self._pre_start(request)
+        resp_impl = super().start(request)
+        self._post_start(request, parser, protocol, writer)
         return resp_impl
 
     def can_start(self, request):
@@ -98,7 +114,7 @@ class WebSocketResponse(StreamResponse):
 
     def ping(self, message='b'):
         if self._writer is None:
-            raise RuntimeError('Call .start() first')
+            raise RuntimeError('Call .prepare() first')
         if self._closed:
             raise RuntimeError('websocket connection is closing')
         self._writer.ping(message)
@@ -106,14 +122,14 @@ class WebSocketResponse(StreamResponse):
     def pong(self, message='b'):
         # unsolicited pong
         if self._writer is None:
-            raise RuntimeError('Call .start() first')
+            raise RuntimeError('Call .prepare() first')
         if self._closed:
             raise RuntimeError('websocket connection is closing')
         self._writer.pong(message)
 
     def send_str(self, data):
         if self._writer is None:
-            raise RuntimeError('Call .start() first')
+            raise RuntimeError('Call .prepare() first')
         if self._closed:
             raise RuntimeError('websocket connection is closing')
         if not isinstance(data, str):
@@ -122,7 +138,7 @@ class WebSocketResponse(StreamResponse):
 
     def send_bytes(self, data):
         if self._writer is None:
-            raise RuntimeError('Call .start() first')
+            raise RuntimeError('Call .prepare() first')
         if self._closed:
             raise RuntimeError('websocket connection is closing')
         if not isinstance(data, (bytes, bytearray, memoryview)):
@@ -151,7 +167,7 @@ class WebSocketResponse(StreamResponse):
     @asyncio.coroutine
     def close(self, *, code=1000, message=b''):
         if self._writer is None:
-            raise RuntimeError('Call .start() first')
+            raise RuntimeError('Call .prepare() first')
 
         if not self._closed:
             self._closed = True
@@ -190,7 +206,7 @@ class WebSocketResponse(StreamResponse):
     @asyncio.coroutine
     def receive(self):
         if self._reader is None:
-            raise RuntimeError('Call .start() first')
+            raise RuntimeError('Call .prepare() first')
         if self._waiting:
             raise RuntimeError('Concurrent call to receive() is not allowed')
 

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -407,7 +407,7 @@ using response's methods:
     def websocket_handler(request):
 
         ws = web.WebSocketResponse()
-        ws.start(request)
+        yield from ws.prepare(request)
 
         while True:
             msg = yield from ws.receive()

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -339,11 +339,10 @@ StreamResponse
    The most important thing you should know about *response* --- it
    is *Finite State Machine*.
 
-   That means you can do any manipulations with *headers*,
-   *cookies* and *status code* only before :meth:`start`
-   called.
+   That means you can do any manipulations with *headers*, *cookies*
+   and *status code* only before :meth:`prepare` coroutine is called.
 
-   Once you call :meth:`start` any change of
+   Once you call :meth:`prepare` any change of
    the *HTTP header* part will raise :exc:`RuntimeError` exception.
 
    Any :meth:`write` call after :meth:`write_eof` is also forbidden.
@@ -355,10 +354,18 @@ StreamResponse
                       parameter. Otherwise pass :class:`str` with
                       arbitrary *status* explanation..
 
+   .. attribute:: prepared
+
+      Read-only :class:`bool` property, ``True`` if :meth:`prepare` has
+      been called, ``False`` otherwise.
+
+      .. versionadded:: 0.18
+
    .. attribute:: started
 
-      Read-only :class:`bool` property, ``True`` if :meth:`start` has
-      been called, ``False`` otherwise.
+      Deprecated alias for :attr:`prepared`.
+
+      .. deprecated:: 0.18
 
    .. attribute:: status
 
@@ -550,16 +557,30 @@ StreamResponse
       Send *HTTP header*. You should not change any header data after
       calling this method.
 
+      .. deprecated:: 0.18
+
+         Use :meth:`prepare` instead.
+
+   .. coroutinemethod:: prepare(request)
+
+      :param aiohttp.web.Request request: HTTP request object, that the
+                                          response answers.
+
+      Send *HTTP header*. You should not change any header data after
+      calling this method.
+
+      .. versionadded:: 0.18
+
    .. method:: write(data)
 
       Send byte-ish data as the part of *response BODY*.
 
-      :meth:`start` must be called before.
+      :meth:`prepare` must be called before.
 
       Raises :exc:`TypeError` if data is not :class:`bytes`,
       :class:`bytearray` or :class:`memoryview` instance.
 
-      Raises :exc:`RuntimeError` if :meth:`start` has not been called.
+      Raises :exc:`RuntimeError` if :meth:`prepare` has not been called.
 
       Raises :exc:`RuntimeError` if :meth:`write_eof` has been called.
 
@@ -651,10 +672,22 @@ WebSocketResponse
 
    Class for handling server-side websockets.
 
-   After starting (by :meth:`start` call) the response you
+   After starting (by :meth:`prepare` call) the response you
    cannot use :meth:`~StreamResponse.write` method but should to
    communicate with websocket client by :meth:`send_str`,
    :meth:`receive` and others.
+
+   .. coroutinemethod:: prepare(request)
+
+      Starts websocket. After the call you can use websocket methods.
+
+      :param aiohttp.web.Request request: HTTP request object, that the
+                                          response answers.
+
+
+      :raises HTTPException: if websocket handshake has failed.
+
+      .. versionadded:: 0.18
 
    .. method:: start(request)
 
@@ -666,12 +699,17 @@ WebSocketResponse
 
       :raises HTTPException: if websocket handshake has failed.
 
-   .. method:: can_start(request)
+      .. deprecated:: 0.18
+
+         Use :meth:`prepare` instead.
+
+   .. method:: can_prepare(request)
 
       Performs checks for *request* data to figure out if websocket
       can be started on the request.
 
-      If :meth:`can_start` call is success then :meth:`start` will success too.
+      If :meth:`can_prepare` call is success then :meth:`prepare` will
+      success too.
 
       :param aiohttp.web.Request request: HTTP request object, that the
                                           response answers.
@@ -683,6 +721,12 @@ WebSocketResponse
                ``None`` if client and server subprotocols are nit overlapping.
 
       .. note:: The method never raises exception.
+
+   .. method:: can_start(request)
+
+      Deprecated alias for :meth:`can_prepare`
+
+      .. deprecated:: 0.18
 
    .. attribute:: closed
 

--- a/examples/web_srv.py
+++ b/examples/web_srv.py
@@ -15,7 +15,7 @@ def intro(request):
     binary = txt.encode('utf8')
     resp = StreamResponse()
     resp.content_length = len(binary)
-    resp.start(request)
+    yield from resp.prepare(request)
     resp.write(binary)
     return resp
 
@@ -36,7 +36,7 @@ def hello(request):
     name = request.match_info.get('name', 'Anonymous')
     answer = ('Hello, ' + name).encode('utf8')
     resp.content_length = len(answer)
-    resp.start(request)
+    yield from resp.prepare(request)
     resp.write(answer)
     yield from resp.write_eof()
     return resp

--- a/examples/web_ws.py
+++ b/examples/web_ws.py
@@ -17,7 +17,7 @@ def wshandler(request):
         with open(WS_FILE, 'rb') as fp:
             return Response(body=fp.read(), content_type='text/html')
 
-    resp.start(request)
+    yield from resp.prepare(request)
     print('Someone joined.')
     for ws in request.app['sockets']:
         ws.send_str('Someone joined')

--- a/tests/autobahn/server.py
+++ b/tests/autobahn/server.py
@@ -12,7 +12,7 @@ def wshandler(request):
     if not ok:
         return web.HTTPBadRequest()
 
-    ws.start(request)
+    yield from ws.prepare(request)
 
     while True:
         msg = yield from ws.receive()

--- a/tests/test_web_exceptions.py
+++ b/tests/test_web_exceptions.py
@@ -50,7 +50,7 @@ class TestHTTPExceptions(unittest.TestCase):
     def test_HTTPOk(self):
         req = self.make_request()
         resp = web.HTTPOk()
-        resp.start(req)
+        self.loop.run_until_complete(resp.prepare(req))
         self.loop.run_until_complete(resp.write_eof())
         txt = self.buf.decode('utf8')
         self.assertRegex(txt, ('HTTP/1.1 200 OK\r\n'
@@ -85,7 +85,7 @@ class TestHTTPExceptions(unittest.TestCase):
         resp = web.HTTPFound(location='/redirect')
         self.assertEqual('/redirect', resp.location)
         self.assertEqual('/redirect', resp.headers['location'])
-        resp.start(req)
+        self.loop.run_until_complete(resp.prepare(req))
         self.loop.run_until_complete(resp.write_eof())
         txt = self.buf.decode('utf8')
         self.assertRegex(txt, ('HTTP/1.1 302 Found\r\n'
@@ -110,7 +110,7 @@ class TestHTTPExceptions(unittest.TestCase):
         self.assertEqual('GET', resp.method)
         self.assertEqual(['POST', 'PUT'], resp.allowed_methods)
         self.assertEqual('POST,PUT', resp.headers['allow'])
-        resp.start(req)
+        self.loop.run_until_complete(resp.prepare(req))
         self.loop.run_until_complete(resp.write_eof())
         txt = self.buf.decode('utf8')
         self.assertRegex(txt, ('HTTP/1.1 405 Method Not Allowed\r\n'

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -715,7 +715,7 @@ class TestWebFunctional(WebFunctionalSetupMixin, unittest.TestCase):
         def handler(request):
             resp = web.StreamResponse()
             resp.enable_chunked_encoding()
-            resp.start(request)
+            yield from resp.prepare(request)
             resp.write(b'x')
             resp.write(b'y')
             resp.write(b'z')

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -147,16 +147,16 @@ class TestStreamResponse(unittest.TestCase):
         resp = StreamResponse()
         self.assertIsNone(resp.keep_alive)
 
-        msg = resp.start(req)
+        msg = self.loop.run_until_complete(resp.prepare(req))
 
         self.assertTrue(msg.send_headers.called)
-        self.assertIs(msg, resp.start(req))
+        self.assertIs(msg, self.loop.run_until_complete(resp.prepare(req)))
 
         self.assertTrue(resp.keep_alive)
 
         req2 = self.make_request('GET', '/')
         with self.assertRaises(RuntimeError):
-            resp.start(req2)
+            self.loop.run_until_complete(resp.prepare(req2))
 
     @mock.patch('aiohttp.web_reqrep.ResponseImpl')
     def test_chunked_encoding(self, ResponseImpl):
@@ -167,7 +167,7 @@ class TestStreamResponse(unittest.TestCase):
         resp.enable_chunked_encoding()
         self.assertTrue(resp.chunked)
 
-        msg = resp.start(req)
+        msg = self.loop.run_until_complete(resp.prepare(req))
         self.assertTrue(msg.chunked)
 
     @mock.patch('aiohttp.web_reqrep.ResponseImpl')
@@ -179,7 +179,7 @@ class TestStreamResponse(unittest.TestCase):
         resp.enable_chunked_encoding(chunk_size=8192)
         self.assertTrue(resp.chunked)
 
-        msg = resp.start(req)
+        msg = self.loop.run_until_complete(resp.prepare(req))
         self.assertTrue(msg.chunked)
         msg.add_chunking_filter.assert_called_with(8192)
         self.assertIsNotNone(msg.filter)
@@ -192,7 +192,7 @@ class TestStreamResponse(unittest.TestCase):
         with self.assertRaisesRegex(
                 RuntimeError,
                 "Using chunked encoding is forbidden for HTTP/1.0"):
-            resp.start(req)
+            self.loop.run_until_complete(resp.prepare(req))
 
     @mock.patch('aiohttp.web_reqrep.ResponseImpl')
     def test_compression_no_accept(self, ResponseImpl):
@@ -204,7 +204,7 @@ class TestStreamResponse(unittest.TestCase):
         resp.enable_compression()
         self.assertTrue(resp.compression)
 
-        msg = resp.start(req)
+        msg = self.loop.run_until_complete(resp.prepare(req))
         self.assertFalse(msg.add_compression_filter.called)
 
     @mock.patch('aiohttp.web_reqrep.ResponseImpl')
@@ -217,7 +217,7 @@ class TestStreamResponse(unittest.TestCase):
         resp.enable_compression(force=True)
         self.assertTrue(resp.compression)
 
-        msg = resp.start(req)
+        msg = self.loop.run_until_complete(resp.prepare(req))
         self.assertTrue(msg.add_compression_filter.called)
         self.assertIsNotNone(msg.filter)
 
@@ -230,7 +230,7 @@ class TestStreamResponse(unittest.TestCase):
         resp.enable_compression(force=False)
         self.assertTrue(resp.compression)
 
-        msg = resp.start(req)
+        msg = self.loop.run_until_complete(resp.prepare(req))
         self.assertFalse(msg.add_compression_filter.called)
 
     @mock.patch('aiohttp.web_reqrep.ResponseImpl')
@@ -245,7 +245,7 @@ class TestStreamResponse(unittest.TestCase):
         resp.enable_compression()
         self.assertTrue(resp.compression)
 
-        msg = resp.start(req)
+        msg = self.loop.run_until_complete(resp.prepare(req))
         msg.add_compression_filter.assert_called_with('deflate')
         self.assertEqual('deflate', resp.headers.get(hdrs.CONTENT_ENCODING))
         self.assertIsNotNone(msg.filter)
@@ -260,7 +260,7 @@ class TestStreamResponse(unittest.TestCase):
         resp.enable_compression(ContentCoding.deflate)
         self.assertTrue(resp.compression)
 
-        msg = resp.start(req)
+        msg = self.loop.run_until_complete(resp.prepare(req))
         msg.add_compression_filter.assert_called_with('deflate')
         self.assertEqual('deflate', resp.headers.get(hdrs.CONTENT_ENCODING))
 
@@ -272,7 +272,7 @@ class TestStreamResponse(unittest.TestCase):
         resp.enable_compression(ContentCoding.deflate)
         self.assertTrue(resp.compression)
 
-        msg = resp.start(req)
+        msg = self.loop.run_until_complete(resp.prepare(req))
         msg.add_compression_filter.assert_called_with('deflate')
         self.assertEqual('deflate', resp.headers.get(hdrs.CONTENT_ENCODING))
 
@@ -286,7 +286,7 @@ class TestStreamResponse(unittest.TestCase):
         resp.enable_compression(ContentCoding.gzip)
         self.assertTrue(resp.compression)
 
-        msg = resp.start(req)
+        msg = self.loop.run_until_complete(resp.prepare(req))
         msg.add_compression_filter.assert_called_with('gzip')
         self.assertEqual('gzip', resp.headers.get(hdrs.CONTENT_ENCODING))
 
@@ -298,7 +298,7 @@ class TestStreamResponse(unittest.TestCase):
         resp.enable_compression(ContentCoding.gzip)
         self.assertTrue(resp.compression)
 
-        msg = resp.start(req)
+        msg = self.loop.run_until_complete(resp.prepare(req))
         msg.add_compression_filter.assert_called_with('gzip')
         self.assertEqual('gzip', resp.headers.get(hdrs.CONTENT_ENCODING))
 
@@ -310,12 +310,13 @@ class TestStreamResponse(unittest.TestCase):
 
         resp.enable_compression(ContentCoding.gzip)
 
-        resp.start(req)
+        self.loop.run_until_complete(resp.prepare(req))
         self.assertIsNone(resp.content_length)
 
     def test_write_non_byteish(self):
         resp = StreamResponse()
-        resp.start(self.make_request('GET', '/'))
+        self.loop.run_until_complete(
+            resp.prepare(self.make_request('GET', '/')))
 
         with self.assertRaises(AssertionError):
             resp.write(123)
@@ -328,7 +329,8 @@ class TestStreamResponse(unittest.TestCase):
 
     def test_cannot_write_after_eof(self):
         resp = StreamResponse()
-        resp.start(self.make_request('GET', '/'))
+        self.loop.run_until_complete(
+            resp.prepare(self.make_request('GET', '/')))
 
         resp.write(b'data')
         self.writer.drain.return_value = ()
@@ -347,7 +349,8 @@ class TestStreamResponse(unittest.TestCase):
 
     def test_cannot_write_eof_twice(self):
         resp = StreamResponse()
-        resp.start(self.make_request('GET', '/'))
+        self.loop.run_until_complete(
+            resp.prepare(self.make_request('GET', '/')))
 
         resp.write(b'data')
         self.writer.drain.return_value = ()
@@ -360,13 +363,15 @@ class TestStreamResponse(unittest.TestCase):
 
     def test_write_returns_drain(self):
         resp = StreamResponse()
-        resp.start(self.make_request('GET', '/'))
+        self.loop.run_until_complete(
+            resp.prepare(self.make_request('GET', '/')))
 
         self.assertEqual((), resp.write(b'data'))
 
     def test_write_returns_empty_tuple_on_empty_data(self):
         resp = StreamResponse()
-        resp.start(self.make_request('GET', '/'))
+        self.loop.run_until_complete(
+            resp.prepare(self.make_request('GET', '/')))
 
         self.assertEqual((), resp.write(b''))
 
@@ -460,14 +465,14 @@ class TestStreamResponse(unittest.TestCase):
         resp.force_close()
         self.assertFalse(resp.keep_alive)
 
-        msg = resp.start(req)
+        msg = self.loop.run_until_complete(resp.prepare(req))
         self.assertFalse(resp.keep_alive)
         self.assertTrue(msg.closing)
 
     def test___repr__(self):
         req = self.make_request('GET', '/path/to')
         resp = StreamResponse(reason=301)
-        resp.start(req)
+        self.loop.run_until_complete(resp.prepare(req))
         self.assertEqual("<StreamResponse 301 GET /path/to >", repr(resp))
 
     def test___repr__not_started(self):
@@ -479,7 +484,7 @@ class TestStreamResponse(unittest.TestCase):
                                     True, False)
         req = self.request_from_message(message)
         resp = StreamResponse()
-        resp.start(req)
+        self.loop.run_until_complete(resp.prepare(req))
         self.assertFalse(resp.keep_alive)
 
         headers = CIMultiDict(Connection='keep-alive')
@@ -487,7 +492,7 @@ class TestStreamResponse(unittest.TestCase):
                                     False, False)
         req = self.request_from_message(message)
         resp = StreamResponse()
-        resp.start(req)
+        self.loop.run_until_complete(resp.prepare(req))
         self.assertEqual(resp.keep_alive, True)
 
     def test_keep_alive_http09(self):
@@ -496,7 +501,7 @@ class TestStreamResponse(unittest.TestCase):
                                     False, False)
         req = self.request_from_message(message)
         resp = StreamResponse()
-        resp.start(req)
+        self.loop.run_until_complete(resp.prepare(req))
         self.assertFalse(resp.keep_alive)
 
 
@@ -599,7 +604,7 @@ class TestResponse(unittest.TestCase):
 
         self.writer.write.side_effect = append
 
-        resp.start(req)
+        self.loop.run_until_complete(resp.prepare(req))
         self.loop.run_until_complete(resp.write_eof())
         txt = buf.decode('utf8')
         self.assertRegex(txt, 'HTTP/1.1 200 OK\r\nCONTENT-LENGTH: 0\r\n'
@@ -619,7 +624,7 @@ class TestResponse(unittest.TestCase):
 
         self.writer.write.side_effect = append
 
-        resp.start(req)
+        self.loop.run_until_complete(resp.prepare(req))
         self.loop.run_until_complete(resp.write_eof())
         txt = buf.decode('utf8')
         self.assertRegex(txt, 'HTTP/1.1 200 OK\r\nCONTENT-LENGTH: 4\r\n'
@@ -640,7 +645,7 @@ class TestResponse(unittest.TestCase):
 
         self.writer.write.side_effect = append
 
-        resp.start(req)
+        self.loop.run_until_complete(resp.prepare(req))
         self.loop.run_until_complete(resp.write_eof())
         txt = buf.decode('utf8')
         self.assertRegex(txt, 'HTTP/1.1 200 OK\r\nCONTENT-LENGTH: 0\r\n'
@@ -669,12 +674,13 @@ class TestResponse(unittest.TestCase):
 
     def test_started_when_not_started(self):
         resp = StreamResponse()
-        self.assertFalse(resp.started)
+        self.assertFalse(resp.prepared)
 
     def test_started_when_started(self):
         resp = StreamResponse()
-        resp.start(self.make_request('GET', '/'))
-        self.assertTrue(resp.started)
+        self.loop.run_until_complete(
+            resp.prepare(self.make_request('GET', '/')))
+        self.assertTrue(resp.prepared)
 
     def test_drain_before_start(self):
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -504,6 +504,16 @@ class TestStreamResponse(unittest.TestCase):
         self.loop.run_until_complete(resp.prepare(req))
         self.assertFalse(resp.keep_alive)
 
+    @mock.patch('aiohttp.web_reqrep.ResponseImpl')
+    def test_start_twice(self, ResponseImpl):
+        req = self.make_request('GET', '/')
+        resp = StreamResponse()
+
+        with self.assertWarns(DeprecationWarning):
+            impl1 = resp.start(req)
+            impl2 = resp.start(req)
+            self.assertIs(impl1, impl2)
+
 
 class TestResponse(unittest.TestCase):
 

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -90,7 +90,7 @@ class TestWebWebSocket(unittest.TestCase):
         def go():
             req = self.make_request('GET', '/')
             ws = WebSocketResponse()
-            ws.start(req)
+            yield from ws.prepare(req)
 
             @asyncio.coroutine
             def receive():
@@ -109,7 +109,7 @@ class TestWebWebSocket(unittest.TestCase):
         def go():
             req = self.make_request('GET', '/')
             ws = WebSocketResponse()
-            ws.start(req)
+            yield from ws.prepare(req)
 
             @asyncio.coroutine
             def receive():
@@ -125,14 +125,14 @@ class TestWebWebSocket(unittest.TestCase):
     def test_send_str_nonstring(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
         with self.assertRaises(TypeError):
             ws.send_str(b'bytes')
 
     def test_send_bytes_nonbytes(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
         with self.assertRaises(TypeError):
             ws.send_bytes('string')
 
@@ -165,7 +165,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_can_start_started(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
         with self.assertRaisesRegex(RuntimeError, 'Already started'):
             ws.can_start(req)
 
@@ -177,7 +177,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_send_str_closed(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
         self.loop.run_until_complete(ws.close())
         with self.assertRaises(RuntimeError):
             ws.send_str('string')
@@ -185,7 +185,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_send_bytes_closed(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
         self.loop.run_until_complete(ws.close())
         with self.assertRaises(RuntimeError):
             ws.send_bytes(b'bytes')
@@ -193,7 +193,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_ping_closed(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
         self.loop.run_until_complete(ws.close())
         with self.assertRaises(RuntimeError):
             ws.ping()
@@ -201,7 +201,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_pong_closed(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
         self.loop.run_until_complete(ws.close())
         with self.assertRaises(RuntimeError):
             ws.pong()
@@ -209,7 +209,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_close_idempotent(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
         writer = mock.Mock()
         ws._writer = writer
         self.assertTrue(
@@ -222,14 +222,14 @@ class TestWebWebSocket(unittest.TestCase):
         req = self.make_request('POST', '/')
         ws = WebSocketResponse()
         with self.assertRaises(HTTPMethodNotAllowed):
-            ws.start(req)
+            self.loop.run_until_complete(ws.prepare(req))
 
     def test_start_without_upgrade(self):
         req = self.make_request('GET', '/',
                                 headers=CIMultiDict({}))
         ws = WebSocketResponse()
         with self.assertRaises(HTTPBadRequest):
-            ws.start(req)
+            self.loop.run_until_complete(ws.prepare(req))
 
     def test_wait_closed_before_start(self):
 
@@ -254,7 +254,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_write_eof_idempotent(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
         self.loop.run_until_complete(ws.close())
 
         @asyncio.coroutine
@@ -268,7 +268,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_receive_exc_in_reader(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
 
         exc = ValueError()
         res = asyncio.Future(loop=self.loop)
@@ -287,7 +287,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_receive_cancelled(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
 
         res = asyncio.Future(loop=self.loop)
         res.set_exception(asyncio.CancelledError())
@@ -300,7 +300,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_receive_timeouterror(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
 
         res = asyncio.Future(loop=self.loop)
         res.set_exception(asyncio.TimeoutError())
@@ -313,7 +313,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_receive_client_disconnected(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
 
         exc = errors.ClientDisconnectedError()
         res = asyncio.Future(loop=self.loop)
@@ -333,7 +333,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_multiple_receive_on_close_connection(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
         self.loop.run_until_complete(ws.close())
         self.loop.run_until_complete(ws.receive())
         self.loop.run_until_complete(ws.receive())
@@ -345,7 +345,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_concurrent_receive(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
         ws._waiting = True
 
         self.assertRaises(
@@ -356,7 +356,7 @@ class TestWebWebSocket(unittest.TestCase):
         reader = self.reader.set_parser.return_value = mock.Mock()
 
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
 
         exc = ValueError()
         reader.read.return_value = asyncio.Future(loop=self.loop)
@@ -376,7 +376,7 @@ class TestWebWebSocket(unittest.TestCase):
     def test_close_exc2(self):
         req = self.make_request('GET', '/')
         ws = WebSocketResponse()
-        ws.start(req)
+        self.loop.run_until_complete(ws.prepare(req))
 
         exc = ValueError()
         self.writer.close.side_effect = exc

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -84,7 +84,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
         @asyncio.coroutine
         def handler(request):
             ws = web.WebSocketResponse()
-            ws.start(request)
+            yield from ws.prepare(request)
             msg = yield from ws.receive_str()
             ws.send_str(msg+'/answer')
             yield from ws.close()
@@ -119,7 +119,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
         @asyncio.coroutine
         def handler(request):
             ws = web.WebSocketResponse()
-            ws.start(request)
+            yield from ws.prepare(request)
 
             msg = yield from ws.receive_bytes()
             ws.send_bytes(msg+b'/answer')
@@ -154,7 +154,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
         @asyncio.coroutine
         def handler(request):
             ws = web.WebSocketResponse()
-            ws.start(request)
+            yield from ws.prepare(request)
             yield from ws.receive()
 
             msg = yield from ws.receive()
@@ -186,7 +186,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
         @asyncio.coroutine
         def handler(request):
             ws = web.WebSocketResponse()
-            ws.start(request)
+            yield from ws.prepare(request)
 
             ws.ping('data')
             yield from ws.receive()
@@ -214,7 +214,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
         @asyncio.coroutine
         def handler(request):
             ws = web.WebSocketResponse()
-            ws.start(request)
+            yield from ws.prepare(request)
 
             yield from ws.receive()
             closed.set_result(None)
@@ -242,7 +242,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
         @asyncio.coroutine
         def handler(request):
             ws = web.WebSocketResponse(autoping=False)
-            ws.start(request)
+            yield from ws.prepare(request)
 
             msg = yield from ws.receive()
             self.assertEqual(msg.tp, web.MsgType.ping)
@@ -279,7 +279,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
             ws = web.WebSocketResponse()
             ws.set_status(200)
             self.assertEqual(200, ws.status)
-            ws.start(request)
+            yield from ws.prepare(request)
             self.assertEqual(101, ws.status)
             yield from ws.close()
             closed.set_result(None)
@@ -302,7 +302,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
         @asyncio.coroutine
         def handler(request):
             ws = web.WebSocketResponse(protocols=('foo', 'bar'))
-            ws.start(request)
+            yield from ws.prepare(request)
             yield from ws.close()
             self.assertEqual('bar', ws.protocol)
             closed.set_result(None)
@@ -326,7 +326,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
         @asyncio.coroutine
         def handler(request):
             ws = web.WebSocketResponse(protocols=('foo', 'bar'))
-            ws.start(request)
+            yield from ws.prepare(request)
             yield from ws.close()
             closed.set_result(None)
             return ws
@@ -352,7 +352,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
         def handler(request):
             ws = web.WebSocketResponse(
                 autoclose=False, protocols=('foo', 'bar'))
-            ws.start(request)
+            yield from ws.prepare(request)
 
             msg = yield from ws.receive()
             self.assertEqual(msg.tp, web.MsgType.close)
@@ -387,7 +387,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
         @asyncio.coroutine
         def handler(request):
             ws = web.WebSocketResponse(protocols=('foo', 'bar'))
-            ws.start(request)
+            yield from ws.prepare(request)
             yield from ws.close()
             closed.set_result(None)
             return ws


### PR DESCRIPTION
Signals support is very important for `aiohttp.web`, I see strong request for the feature.
We have a PR for that #439  (@alexsdutton, thanks a lot BTW for your work)

I insist signal handlers should be coroutines. Just signal callbacks are very subtle: we may want to access, say, database for modifying response headers (the main purpose for signals right now).
Keeping both synchronous and asynchronous signals just makes a mess -- signals should be coroutines. Period.

Thus I propose deprecation `StreamResponse.start(requiest)` method in favor of `StreamResponse.prepare(request)` coroutine (`.begin()` is an option but I feel `.prepare()` is better name).

The change is backward compatible with limitation: old code still may use `resp.start(request)` way but we will not apply signal handling for it.

New code should use `.prepare()` with benefit of signal handling.

Any objections? @fafhrd91 @kxepal 

TDB:

- [x] Make tests for backward compatibility (use `resp.start()` and catch a deprecation warning). We should do it at least for keeping our test coverage level.
- [x] Update docs with marking `.start()` deprecated and forcing to brand new `.prepare()` usage.