### PR TITLE
Extend precision of access log "D" to milliseconds

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -254,7 +254,7 @@ def atoms(message, environ, response, transport, request_time):
         'f': headers.get(hdrs.REFERER, '-'),
         'a': headers.get(hdrs.USER_AGENT, '-'),
         'T': str(int(request_time)),
-        'D': str(request_time).split('.', 1)[-1][:5],
+        'D': str(request_time).split('.', 1)[-1][:6],
         'p': "<%s>" % os.getpid()
     }
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 import unittest.mock
 
@@ -114,6 +115,17 @@ class TestHelpers(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             a.prop = 123
+
+
+class TestAtoms(unittest.TestCase):
+
+    def test_get_seconds_and_milliseconds(self):
+        response = dict(status=200, output_length=1)
+        request_time = 321.012345678901234
+
+        atoms = helpers.atoms(None, None, response, None, request_time)
+        self.assertEqual(atoms['T'], '321')
+        self.assertEqual(atoms['D'], '012345')
 
 
 class TestSafeAtoms(unittest.TestCase):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,3 @@
-import datetime
 import unittest
 import unittest.mock
 


### PR DESCRIPTION
The fractional time part had a precision of 10 milliseconds
due to a too-short truncation of the time string.  This commit
adds one digit and includes a test for the case.

Fixes issue #524