### PR TITLE
Remove python 3.3 from setup.py and add framework to classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,9 +95,9 @@ args = dict(
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Intended Audience :: Developers',
+        'Framework :: Aiohttp',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP'],

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ args = dict(
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Intended Audience :: Developers',
-        'Framework :: Aiohttp',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',


### PR DESCRIPTION
Also I have added new classifier `Framework :: Aiohttp`, as django and flask do, so related to aiohttp libraries can specify framework too.