### PR TITLE
Add pyflakes version requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - pip install --upgrade setuptools
   - pip install cython
   - pip install flake8
+  - pip install "pyflakes>=1.0.0"
   - pip install docutils
   - pip install coverage
   - pip install gunicorn

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 flake8
+pyflakes>=1.0.0
 coverage
 sphinx
 alabaster>=0.6.2

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ whitelist_externals =
 deps =
     wheel
     flake8
+    pyflakes>=1.0.0
     coverage
 
 commands =


### PR DESCRIPTION
The version of pyflakes restricted by flake8 is too old.
And The old version causes an error when testing python3.5
related features.

The following error shows up when `make test`

```
Traceback (most recent call last):
  File "/Users/carlcarl/.pyenv/versions/3.5.0/lib/python3.5/multiprocessing/process.py", line 254, in _bootstrap
    self.run()
  File "/Users/carlcarl/.pyenv/versions/3.5.0/lib/python3.5/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/carlcarl/.pyenv/versions/aiohttp-3.5.0/lib/python3.5/site-packages/flake8/reporter.py", line 74, in process_main
    self._process_main()
  File "/Users/carlcarl/.pyenv/versions/aiohttp-3.5.0/lib/python3.5/site-packages/flake8/reporter.py", line 50, in _process_main
    self.input_file(filename)
  File "/Users/carlcarl/.pyenv/versions/aiohttp-3.5.0/lib/python3.5/site-packages/flake8/engine.py", line 95, in input_file
    return fchecker.check_all(expected=expected, line_offset=line_offset)
  File "/Users/carlcarl/.pyenv/versions/aiohttp-3.5.0/lib/python3.5/site-packages/pep8.py", line 1412, in check_all
    self.check_ast()
  File "/Users/carlcarl/.pyenv/versions/aiohttp-3.5.0/lib/python3.5/site-packages/pep8.py", line 1358, in check_ast
    checker = cls(tree, self.filename)
  File "/Users/carlcarl/.pyenv/versions/aiohttp-3.5.0/lib/python3.5/site-packages/flake8/_pyflakes.py", line 43, in __init__
    withDoctest=self.withDoctest)
  File "/Users/carlcarl/.pyenv/versions/aiohttp-3.5.0/lib/python3.5/site-packages/pyflakes/checker.py", line 294, in __init__
    self.handleChildren(tree)
  File "/Users/carlcarl/.pyenv/versions/aiohttp-3.5.0/lib/python3.5/site-packages/pyflakes/checker.py", line 547, in handleChildren
    self.handleNode(node, tree)
  File "/Users/carlcarl/.pyenv/versions/aiohttp-3.5.0/lib/python3.5/site-packages/pyflakes/checker.py", line 588, in handleNode
    handler = self.getNodeHandler(node.__class__)
  File "/Users/carlcarl/.pyenv/versions/aiohttp-3.5.0/lib/python3.5/site-packages/pyflakes/checker.py", line 458, in getNodeHandler
    self._nodeHandlers[node_class] = handler = getattr(self, nodeType)
AttributeError: 'FlakesChecker' object has no attribute 'ASYNCFUNCTIONDEF'
```