### PR TITLE
TCPConnector processes both IPv4 and IPv6 by default #559

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,3 +63,5 @@ CHANGES
 - Add `async with` support for `ClientSession.request()` and family #536
 
 - Ignore message body on 204 and 304 responses #505
+
+- `TCPConnector` processed both IPv4 and IPv6 by default #559

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -388,7 +388,7 @@ class TCPConnector(BaseConnector):
 
     def __init__(self, *, verify_ssl=True, fingerprint=None,
                  resolve=_marker, use_dns_cache=_marker,
-                 family=socket.AF_INET, ssl_context=None,
+                 family=0, ssl_context=None,
                  **kwargs):
         super().__init__(**kwargs)
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -619,8 +619,9 @@ BaseConnector
 TCPConnector
 ^^^^^^^^^^^^
 
-.. class:: TCPConnector(*, verify_ssl=True, fingerprint=None, use_dns_cache=False, \
-                        family=socket.AF_INET, \
+.. class:: TCPConnector(*, verify_ssl=True, fingerprint=None,\
+                        use_dns_cache=False, \
+                        family=0, \
                         ssl_context=None, conn_timeout=None, \
                         keepalive_timeout=30, limit=None, share_cookies=False, \
                         force_close=False, loop=None)
@@ -660,8 +661,16 @@ TCPConnector
 
       .. deprecated:: 0.17
 
-   :param int family: TCP socket family, ``AF_INET`` by default
-                      (*IPv4*). For *IPv6* use ``AF_INET6``.
+   :param int family: TCP socket family, both IPv4 and IPv6 by default.
+                      For *IPv4* only use :const:`socket.AF_INET`,
+                      for  *IPv6* only -- :const:`socket.AF_INET6`.
+
+      .. versionchanged:: 0.18
+
+         *family* is `0` by default, that means both IPv4 and IPv6 are
+         accepted. To specify only concrete version please pass
+         :const:`socket.AF_INET` or :const:`socket.AF_INET6`
+         explicitly.
 
    :param ssl.SSLContext ssl_context: ssl context used for processing
       *HTTPS* requests (optional).

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -467,7 +467,7 @@ class TestBaseConnector(unittest.TestCase):
             self.assertFalse(conn.resolve)
         self.assertFalse(conn.use_dns_cache)
 
-        self.assertEqual(conn.family, socket.AF_INET)
+        self.assertEqual(conn.family, 0)
 
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(conn.resolved_hosts, {})


### PR DESCRIPTION
See #559