### PR TITLE
resolve #563 by updating ClientResponse doc to match actual return types

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -995,6 +995,7 @@ Response object
       :param callable loads: :func:`callable` used for loading *JSON*
                              data, :func:`json.loads` by default.
 
-      :return dict: *BODY* as *JSON* data.
+      :rtype: dict, list, str, int, float, bool or None
+      :return: *BODY* as *JSON* data or None if it contains no non-whitespace symbols
 
 .. disqus::


### PR DESCRIPTION
Added types from the JSON conversion table (https://docs.python.org/3.5/library/json.html#encoders-and-decoders). This might not look pretty, but at least now the user should be aware about what kind of output to expect from the function, which I think is more important.