### PR TITLE
Validate route name

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1,6 +1,7 @@
 import abc
 import asyncio
 
+import keyword
 import collections
 import mimetypes
 import re
@@ -442,8 +443,12 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         assert isinstance(route, Route), 'Instance of Route class is required.'
 
         name = route.name
+
         if name is not None:
-            if name in self._routes:
+            if not name.isidentifier() or keyword.iskeyword(name):
+                raise ValueError('Incorrect route name value, '
+                                 'Route name should be python identifier')
+            elif name in self._routes:
                 raise ValueError('Duplicate {!r}, '
                                  'already handled by {!r}'
                                  .format(name, self._routes[name]))

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -77,6 +77,12 @@ class TestUrlDispatcher(unittest.TestCase):
         self.router.register_route(route)
         self.assertRaises(ValueError, self.router.register_route, route)
 
+        route = PlainRoute('GET', handler, '1bad name', '/handler/to/path')
+        self.assertRaises(ValueError, self.router.register_route, route)
+
+        route = PlainRoute('GET', handler, 'return', '/handler/to/path')
+        self.assertRaises(ValueError, self.router.register_route, route)
+
     def test_add_route_root(self):
         handler = self.make_handler()
         self.router.add_route('GET', '/', handler)


### PR DESCRIPTION
Previously route name could take incorrect value with spaces, or numbers at start.
@asvetlov