### PR TITLE
Fix wsgi environment building

### DIFF
--- a/aiohttp/wsgi.py
+++ b/aiohttp/wsgi.py
@@ -68,7 +68,7 @@ class WSGIServerHttpProtocol(server.ServerHttpProtocol):
         for hdr_name, hdr_value in message.headers.items():
             if hdr_name == 'AUTHORIZATION':
                 continue
-            if hdr_name == 'SCRIPT_NAME':
+            elif hdr_name == 'SCRIPT_NAME':
                 script_name = hdr_value
             elif hdr_name == 'CONTENT-TYPE':
                 environ['CONTENT_TYPE'] = hdr_value

--- a/aiohttp/wsgi.py
+++ b/aiohttp/wsgi.py
@@ -83,16 +83,23 @@ class WSGIServerHttpProtocol(server.ServerHttpProtocol):
 
             environ[key] = hdr_value
 
+        # authors should be aware that REMOTE_HOST and REMOTE_ADDR
+        # may not qualify the remote addr
+        # also SERVER_PORT variable MUST be set to the TCP/IP port number on
+        # which this request is received from the client.
+        # http://www.ietf.org/rfc/rfc3875
+
         remote = self.transport.get_extra_info('peername')
         environ['REMOTE_ADDR'] = remote[0]
         environ['REMOTE_PORT'] = remote[1]
+
+        sockname = self.transport.get_extra_info('sockname')
+        environ['SERVER_PORT'] = str(sockname[1])
         host = message.headers.get("HOST", None)
         if host:
-            host = host.split(":")
+            environ['SERVER_NAME'] = host.split(":")[0]
         else:
-            host = self.transport.get_extra_info('sockname')
-        environ['SERVER_NAME'] = host[0]
-        environ['SERVER_PORT'] = str(host[1]) if len(host) > 1 else '80'
+            environ['SERVER_NAME'] = sockname[0]
 
         path_info = uri_parts.path
         if script_name:

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -22,7 +22,8 @@ class TestHttpWsgiServerProtocol(unittest.TestCase):
         self.writer = unittest.mock.Mock()
         self.writer.drain.return_value = ()
         self.transport = unittest.mock.Mock()
-        self.transport.get_extra_info.return_value = ('1.2.3.4', 8080)
+        self.transport.get_extra_info.side_effect = [('1.2.3.4', 1234),
+                                                     ('2.3.4.5', 80)]
 
         self.headers = multidict.MultiDict({"HOST": "python.org"})
         self.message = protocol.RawRequestMessage(
@@ -68,32 +69,35 @@ class TestHttpWsgiServerProtocol(unittest.TestCase):
              ('CONTENT-LENGTH', '209'),
              ('X_TEST', '123'),
              ('X_TEST', '456')))
-        environ = self._make_one(is_ssl=True)
+        environ = self._make_one()
         self.assertEqual(environ['CONTENT_TYPE'], 'text/plain')
         self.assertEqual(environ['CONTENT_LENGTH'], '209')
         self.assertEqual(environ['HTTP_X_TEST'], '123,456')
         self.assertEqual(environ['SCRIPT_NAME'], 'script')
         self.assertEqual(environ['SERVER_NAME'], 'python.org')
         self.assertEqual(environ['SERVER_PORT'], '80')
+        get_extra_info_calls = self.transport.get_extra_info.mock_calls
+        expected_calls = [
+            unittest.mock.call('peername'),
+            unittest.mock.call('sockname'),
+        ]
+        self.assertEqual(expected_calls, get_extra_info_calls)
 
-    def test_environ_host_header(self):
+    def test_environ_host_header_alternate_port(self):
+        self.transport.get_extra_info = unittest.mock.Mock(
+            side_effect=[('1.2.3.4', 1234), ('3.4.5.6', 82)]
+        )
+        self.headers.update({'HOST': 'example.com:9999'})
         environ = self._make_one()
+        self.assertEqual(environ['SERVER_PORT'], '82')
 
-        self.assertEqual(environ['HTTP_HOST'], 'python.org')
-        self.assertEqual(environ['SERVER_NAME'], 'python.org')
-        self.assertEqual(environ['SERVER_PORT'], '80')
-        self.assertEqual(environ['SERVER_PROTOCOL'], 'HTTP/1.0')
-
-    def test_environ_host_port_header(self):
-        headers = multidict.MultiDict({'HOST': 'python.org:443'})
-        self.message = protocol.RawRequestMessage(
-            'GET', '/path', (1, 1), headers, True, 'deflate')
-        environ = self._make_one()
-
-        self.assertEqual(environ['HTTP_HOST'], 'python.org:443')
-        self.assertEqual(environ['SERVER_NAME'], 'python.org')
-        self.assertEqual(environ['SERVER_PORT'], '443')
-        self.assertEqual(environ['SERVER_PROTOCOL'], 'HTTP/1.1')
+    def test_environ_host_header_alternate_port_ssl(self):
+        self.transport.get_extra_info = unittest.mock.Mock(
+            side_effect=[('1.2.3.4', 1234), ('3.4.5.6', 82)]
+        )
+        self.headers.update({'HOST': 'example.com:9999'})
+        environ = self._make_one(is_ssl=True)
+        self.assertEqual(environ['SERVER_PORT'], '82')
 
     def test_wsgi_response(self):
         srv = self._make_srv()
@@ -268,6 +272,5 @@ class TestHttpWsgiServerProtocol(unittest.TestCase):
         self.message = protocol.RawRequestMessage(
             'GET', '/', (1, 0), headers, True, 'deflate')
         environ = self._make_one()
-        self.assertEqual('1.2.3.4', environ['SERVER_NAME'])
-        self.assertEqual('8080', environ['SERVER_PORT'])
-        self.transport.get_extra_info.assert_called_with('sockname')
+        self.assertEqual(environ['SERVER_NAME'], '2.3.4.5')
+        self.assertEqual(environ['SERVER_PORT'], '80')

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -255,8 +255,8 @@ class TestHttpWsgiServerProtocol(unittest.TestCase):
         self.assertEqual(environ['PATH_INFO'], path)
 
     def test_not_add_authorization(self):
-        self.headers.extend({"AUTHORIZATION": "spam",
-                             "X-CUSTOM-HEADER": "eggs"})
+        self.headers.extend({'AUTHORIZATION': 'spam',
+                             'X-CUSTOM-HEADER': 'eggs'})
         self.message = protocol.RawRequestMessage(
             'GET', '/', (1, 1), self.headers, True, 'deflate')
         environ = self._make_one()
@@ -268,5 +268,6 @@ class TestHttpWsgiServerProtocol(unittest.TestCase):
         self.message = protocol.RawRequestMessage(
             'GET', '/', (1, 0), headers, True, 'deflate')
         environ = self._make_one()
-        self.assertEqual('1.2.3.4', environ["SERVER_NAME"])
-        self.assertEqual('8080', environ["SERVER_PORT"])
+        self.assertEqual('1.2.3.4', environ['SERVER_NAME'])
+        self.assertEqual('8080', environ['SERVER_PORT'])
+        self.transport.get_extra_info.assert_called_with('sockname')


### PR DESCRIPTION
Fixed issues:

SERVER_NAME and SERVER_PORT variables may be determined in two ways:

 if protocol is HTTP/1.0:
  Value of `Host` header. If there is no such header, then address of
  transport may be taken (transport.get_extra_info('sockname'))

 if protocol is HTTP/1.1:
  Value of `Host` header. If there is no such header, the Bad Request
  should be raised, because this header is required in HTTP/1.1.

REMOTE_ADDR and REMOTE_PORT should be address and port of host connected
to http server.

```
https://www.ietf.org/rfc/rfc3875:
4.1.8.  REMOTE_ADDR
   The REMOTE_ADDR variable MUST be set to the network address of the
   client sending the request to the server.
```

Also, header `Authorization` should not be in environment at all.