### PR TITLE
Fix syntax error on front page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,7 +41,7 @@ Client example::
     import asyncio
     import aiohttp
 
-    await def fetch_page(client, url):
+    async def fetch_page(client, url):
         async with client.get(url) as response:
             assert response.status == 200
             return await response.read()


### PR DESCRIPTION
The code example on the main website page is broken (tested in 3.5).