### PR TITLE
Re add support for OpenSSL < 1.0.0

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -369,6 +369,8 @@ class BaseConnector(object):
         raise NotImplementedError()
 
 
+_SSL_OP_NO_COMPRESSION = getattr(ssl, "OP_NO_COMPRESSION", 0)
+
 _marker = object()
 
 
@@ -449,7 +451,7 @@ class TCPConnector(BaseConnector):
                 sslcontext = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
                 sslcontext.options |= ssl.OP_NO_SSLv2
                 sslcontext.options |= ssl.OP_NO_SSLv3
-                sslcontext.options |= ssl.OP_NO_COMPRESSION
+                sslcontext.options |= _SSL_OP_NO_COMPRESSION
                 sslcontext.set_default_verify_paths()
             else:
                 sslcontext = ssl.create_default_context()


### PR DESCRIPTION
This reverts part of commit 08cedb82a89ea2ec9a1e1f41b2d71a28b35ca45e,
which appears to have accidentally removed openssl < 1.0.0 compatibility when
removing python3.3 compatibility.  See https://github.com/KeepSafe/aiohttp/issues/583