### PR TITLE
add support for raw str params

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -162,8 +162,6 @@ class ClientRequest:
         if not path:
             path = '/'
 
-        if isinstance(params, bytes):
-            params = params.decode('ascii')
         if isinstance(params, collections.Mapping):
             params = list(params.items())
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1,4 +1,5 @@
 import asyncio
+import collections
 import http.cookies
 import io
 import json
@@ -161,13 +162,14 @@ class ClientRequest:
         if not path:
             path = '/'
 
-        if isinstance(params, dict):
-            params = list(params.items())
-        elif isinstance(params, (MultiDictProxy, MultiDict)):
+        if isinstance(params, bytes):
+            params = params.decode('ascii')
+        if isinstance(params, collections.Mapping):
             params = list(params.items())
 
         if params:
-            params = urllib.parse.urlencode(params)
+            if not isinstance(params, str):
+                params = urllib.parse.urlencode(params)
             if query:
                 query = '%s&%s' % (query, params)
             else:

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -65,6 +65,12 @@ that case you can specify multiple values for each key::
                            params=payload) as r:
         assert r.url == 'http://httpbin.org/get?key=value2&key=value1'
 
+You can also pass ``str`` content as param, but beware - content is not encoded
+by library. Note that ``+`` is not encoded::
+
+    async with aiohttp.get('http://httpbin.org/get',
+                            params='key=value+1') as r:
+            assert r.url = 'http://httpbin.org/get?key=value+1'
 
 Response Content
 ----------------

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -132,8 +132,8 @@ The client session supports context manager protocol for self closing.
 
       :param str url: Request URL
 
-      :param dict params: Parameters to be sent in the query
-                          string of the new request (optional)
+      :param params: Mapping or string to be sent as parameters
+                     in the query string of the new request (optional)
 
       :param data: Dictionary, bytes, or file-like object to
                    send in the body of the request (optional)

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -132,8 +132,19 @@ The client session supports context manager protocol for self closing.
 
       :param str url: Request URL
 
-      :param params: Mapping or string to be sent as parameters
-                     in the query string of the new request (optional)
+      :param params: Mapping, iterable of tuple of *key*/*value* pairs or
+                     string to be sent as parameters in the query
+                     string of the new request (optional)
+
+                     Allowed values are:
+
+                     - :class:`collections.abc.Mapping` e.g. :class:`dict`,
+                       :class:`aiohttp.MultiDict` or
+                       :class:`aiohttp.MultiDictProxy` e.g. :class:`tuple` or
+                       :class:`list`
+                     - :class:`collections.abc.Iterable`
+                     - :class:`str` with preferably url-encoded content
+                       (**Warning:** content will not be encoded by *aiohttp*)
 
       :param data: Dictionary, bytes, or file-like object to
                    send in the body of the request (optional)

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -316,3 +316,20 @@ def test_format_task_get(create_server, loop):
     task = loop.create_task(client.get(url))
     assert "{}".format(task)[:18] == "<Task pending coro"
     yield from task
+
+
+@pytest.mark.run_loop
+def test_str_params(create_app_and_client):
+    @asyncio.coroutine
+    def handler(request):
+        assert 'q=t+est' in request.query_string
+        return web.Response()
+
+    app, client = yield from create_app_and_client()
+    app.router.add_route('GET', '/', handler)
+
+    resp = yield from client.get('/', params='q=t+est')
+    try:
+        assert 200 == resp.status
+    finally:
+        yield from resp.release()

--- a/tests/test_client_functional_oldstyle.py
+++ b/tests/test_client_functional_oldstyle.py
@@ -208,6 +208,38 @@ class TestHttpClientFunctional(unittest.TestCase):
                 yield from asyncio.sleep(0, loop=self.loop)
             self.loop.run_until_complete(go())
 
+    def test_HTTP_200_GET_WITH_STR_PARAMS(self):
+        with test_utils.run_server(self.loop, router=Functional) as httpd:
+            @asyncio.coroutine
+            def go():
+                r = yield from client.request(
+                    'get', httpd.url('method', 'get'),
+                    params='q=t+est', loop=self.loop)
+                content = yield from r.content.read()
+                content = content.decode()
+
+                self.assertIn('"query": "q=t+est"', content)
+                self.assertEqual(r.status, 200)
+                r.close()
+                yield from asyncio.sleep(0, loop=self.loop)
+            self.loop.run_until_complete(go())
+
+    def test_HTTP_200_GET_WITH_BYTES_PARAMS(self):
+        with test_utils.run_server(self.loop, router=Functional) as httpd:
+            @asyncio.coroutine
+            def go():
+                r = yield from client.request(
+                    'get', httpd.url('method', 'get'),
+                    params=b'q=test', loop=self.loop)
+                content = yield from r.content.read()
+                content = content.decode()
+
+                self.assertIn('"query": "q=test"', content)
+                self.assertEqual(r.status, 200)
+                r.close()
+                yield from asyncio.sleep(0, loop=self.loop)
+            self.loop.run_until_complete(go())
+
     def test_POST_DATA(self):
         with test_utils.run_server(self.loop, router=Functional) as httpd:
             url = httpd.url('method', 'post')

--- a/tests/test_client_functional_oldstyle.py
+++ b/tests/test_client_functional_oldstyle.py
@@ -208,38 +208,6 @@ class TestHttpClientFunctional(unittest.TestCase):
                 yield from asyncio.sleep(0, loop=self.loop)
             self.loop.run_until_complete(go())
 
-    def test_HTTP_200_GET_WITH_STR_PARAMS(self):
-        with test_utils.run_server(self.loop, router=Functional) as httpd:
-            @asyncio.coroutine
-            def go():
-                r = yield from client.request(
-                    'get', httpd.url('method', 'get'),
-                    params='q=t+est', loop=self.loop)
-                content = yield from r.content.read()
-                content = content.decode()
-
-                self.assertIn('"query": "q=t+est"', content)
-                self.assertEqual(r.status, 200)
-                r.close()
-                yield from asyncio.sleep(0, loop=self.loop)
-            self.loop.run_until_complete(go())
-
-    def test_HTTP_200_GET_WITH_BYTES_PARAMS(self):
-        with test_utils.run_server(self.loop, router=Functional) as httpd:
-            @asyncio.coroutine
-            def go():
-                r = yield from client.request(
-                    'get', httpd.url('method', 'get'),
-                    params=b'q=test', loop=self.loop)
-                content = yield from r.content.read()
-                content = content.decode()
-
-                self.assertIn('"query": "q=test"', content)
-                self.assertEqual(r.status, 200)
-                r.close()
-                yield from asyncio.sleep(0, loop=self.loop)
-            self.loop.run_until_complete(go())
-
     def test_POST_DATA(self):
         with test_utils.run_server(self.loop, router=Functional) as httpd:
             url = httpd.url('method', 'post')

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -372,6 +372,24 @@ def test_query_multivalued_param(make_request):
         assert req.path == '/?test=foo&test=baz'
 
 
+def test_query_str_param(make_request):
+    for meth in ClientRequest.ALL_METHODS:
+        req = make_request(meth, 'http://python.org', params='test=foo')
+        assert req.path == '/?test=foo'
+
+
+def test_query_bytes_param(make_request):
+    for meth in ClientRequest.ALL_METHODS:
+        req = make_request(meth, 'http://python.org', params=b'test=foo')
+        assert req.path == '/?test=foo'
+
+
+def test_query_str_param_is_not_encoded(make_request):
+    for meth in ClientRequest.ALL_METHODS:
+        req = make_request(meth, 'http://python.org', params='test=f+oo')
+        assert req.path == '/?test=f+oo'
+
+
 def test_params_update_path_and_url(make_request):
     req = make_request('get', 'http://python.org',
                        params=(('test', 'foo'), ('test', 'baz')))

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -378,10 +378,11 @@ def test_query_str_param(make_request):
         assert req.path == '/?test=foo'
 
 
-def test_query_bytes_param(make_request):
+def test_query_bytes_param_raises(make_request):
     for meth in ClientRequest.ALL_METHODS:
-        req = make_request(meth, 'http://python.org', params=b'test=foo')
-        assert req.path == '/?test=foo'
+        with pytest.raises_regexp(TypeError,
+                                  'not a valid non-string.*or mapping'):
+            make_request(meth, 'http://python.org', params=b'test=foo')
 
 
 def test_query_str_param_is_not_encoded(make_request):


### PR DESCRIPTION
So, this is a port of missing `requests` feature.

Please drop if it doesn't fit the API vision.

My use case:

```
yield from session.get(url, params=urllib.parse.urlencode(payload, safe='+'))
```

Thanks for a great library.