### PR TITLE
.travis.yml update: pip upgrade and wheel installed for cython caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
 
 install:
+  - pip install --upgrade pip wheel
   - pip install --upgrade setuptools
   - pip install -r requirements-dev.txt
 


### PR DESCRIPTION
Latest pip + wheel build `whl`s which are cached by travis so speeding up new builds
(basically because Cython whl is built and cached).
Works for python3.4, 3.5 seems to have latest pip/wheel