### PR TITLE
Add test for default Expect handler

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -76,7 +76,7 @@ class RequestHandler(ServerHttpProtocol):
             resp = None
             request._match_info = match_info
             expect = request.headers.get(hdrs.EXPECT)
-            if expect and expect.lower() == "100-continue":
+            if expect:
                 resp = (
                     yield from match_info.route.handle_expect_header(request))
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -14,7 +14,8 @@ from urllib.parse import urlencode, unquote
 from . import hdrs
 from .abc import AbstractRouter, AbstractMatchInfo
 from .protocol import HttpVersion11
-from .web_exceptions import HTTPMethodNotAllowed, HTTPNotFound, HTTPNotModified
+from .web_exceptions import (HTTPMethodNotAllowed, HTTPNotFound,
+                             HTTPNotModified, HTTPExpectationFailed)
 from .web_reqrep import StreamResponse
 from .multidict import upstr
 
@@ -43,9 +44,17 @@ class UrlMappingMatchInfo(dict, AbstractMatchInfo):
 
 @asyncio.coroutine
 def _defaultExpectHandler(request):
-    """Default handler for Except: 100-continue"""
+    """Default handler for Except header.
+
+    Just send "100 Continue" to client.
+    raise HTTPExpectationFailed if value of header is not "100-continue"
+    """
+    expect = request.headers.get(hdrs.EXPECT)
     if request.version == HttpVersion11:
-        request.transport.write(b"HTTP/1.1 100 Continue\r\n\r\n")
+        if expect.lower() == "100-continue":
+            request.transport.write(b"HTTP/1.1 100 Continue\r\n\r\n")
+        else:
+            raise HTTPExpectationFailed(text="Unknown Expect: %s" % expect)
 
 
 class Route(metaclass=abc.ABCMeta):


### PR DESCRIPTION
Server should return 417 if any of the expectations cannot be met.

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20