### PR TITLE
Forbid duplicating of web.Application and web.Request

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -257,6 +257,9 @@ class Application(dict):
     def register_on_finish(self, func, *args, **kwargs):
         self._finish_callbacks.insert(0, (func, args, kwargs))
 
+    def copy(self):
+        raise NotImplementedError
+
     def __call__(self):
         """gunicorn compatibility"""
         return self

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -389,6 +389,9 @@ class Request(dict, HeadersMixin):
         self._post = MultiDictProxy(out)
         return self._post
 
+    def copy(self):
+        raise NotImplementedError
+
     def __repr__(self):
         return "<{} {} {} >".format(self.__class__.__name__,
                                     self.method, self.path)

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -661,6 +661,7 @@ and call ``aiohttp_debugtoolbar.setup``::
 
 Debug toolbar is ready to use. Enjoy!!!
 
+.. _aiohttp-web-data-sharing:
 
 Data sharing
 ------------

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -22,6 +22,13 @@ The Request object contains all the information about an incoming HTTP request.
 Every :ref:`handler<aiohttp-web-handler>` accepts a request instance as the
 first positional parameter.
 
+A :class:`Request` is a :obj:`dict`-like object, allowing it to be used for
+:ref:`sharing data<aiohttp-web-data-sharing>` among
+:ref:`aiohttp-web-middlewares` and :ref:`aiohttp-web-signals` handlers.
+
+Although :class:`Request` is :obj:`dict`-like object, it can't be duplicated
+like one using :meth:`Request.copy`.
+
 .. note::
 
    You should never create the :class:`Request` instance manually --
@@ -897,9 +904,10 @@ factory*. *RequestHandlerFactory* could be constructed with
 *Application* contains a *router* instance and a list of callbacks that
 will be called during application finishing.
 
-*Application* is a :class:`dict`, so you can use it as registry for
-arbitrary properties for later access from
-:ref:`handler<aiohttp-web-handler>` via :attr:`Request.app` property::
+:class:`Application` is a :obj:`dict`-like object, so you can use it for
+:ref:`sharing data<aiohttp-web-data-sharing>` globally by storing arbitrary
+properties for later access from a :ref:`handler<aiohttp-web-handler>` via the
+:attr:`Request.app` property::
 
    app = Application(loop=loop)
    app['database'] = await aiopg.create_engine(**db_config)
@@ -908,6 +916,8 @@ arbitrary properties for later access from
        with (await request.app['database']) as conn:
            conn.execute("DELETE * FROM table")
 
+Although :class:`Application` is a :obj:`dict`-like object, it can't be
+duplicated like one using :meth:`Application.copy`.
 
 .. class:: Application(*, loop=None, router=None, logger=<default>, \
                        middlewares=(), **kwargs)

--- a/tests/test_web_application.py
+++ b/tests/test_web_application.py
@@ -16,6 +16,12 @@ def test_app_call(loop):
     assert app is app()
 
 
+def test_app_copy(loop):
+    app = web.Application(loop=loop)
+    with pytest.raises(NotImplementedError):
+        app.copy()
+
+
 def test_app_default_loop(loop):
     asyncio.set_event_loop(loop)
     app = web.Application()

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -205,6 +205,12 @@ def test_request_is_dict(make_request):
     assert 'value' == req['key']
 
 
+def test_copy(make_request):
+    req = make_request('GET', '/')
+    with pytest.raises(NotImplementedError):
+        req.copy()
+
+
 def test___repr__(make_request):
     req = make_request('GET', '/path/to')
     assert "<Request GET /path/to >" == repr(req)


### PR DESCRIPTION
Issue #602 

I'm not sure what changes to the docs should be made. Should I just add a note saying `Application` & `Request` can't be duplicated using `.copy()`?