### PR TITLE
add option to pass Origin header in ws_connect

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -228,7 +228,8 @@ class ClientSession:
                    timeout=10.0,
                    autoclose=True,
                    autoping=True,
-                   auth=None):
+                   auth=None,
+                   origin=None):
         """Initiate websocket connection."""
         return _WSRequestContextManager(
             self._ws_connect(url,
@@ -236,7 +237,8 @@ class ClientSession:
                              timeout=timeout,
                              autoclose=autoclose,
                              autoping=autoping,
-                             auth=auth))
+                             auth=auth,
+                             origin=origin))
 
     @asyncio.coroutine
     def _ws_connect(self, url, *,
@@ -244,7 +246,8 @@ class ClientSession:
                     timeout=10.0,
                     autoclose=True,
                     autoping=True,
-                    auth=None):
+                    auth=None,
+                    origin=None):
 
         sec_key = base64.b64encode(os.urandom(16))
 
@@ -256,6 +259,8 @@ class ClientSession:
         }
         if protocols:
             headers[hdrs.SEC_WEBSOCKET_PROTOCOL] = ','.join(protocols)
+        if origin is not None:
+            headers[hdrs.ORIGIN] = origin
 
         # send request
         resp = yield from self.request('get', url, headers=headers,
@@ -659,7 +664,7 @@ def delete(url, **kwargs):
 
 def ws_connect(url, *, protocols=(), timeout=10.0, connector=None, auth=None,
                ws_response_class=ClientWebSocketResponse, autoclose=True,
-               autoping=True, loop=None):
+               autoping=True, loop=None, origin=None):
 
     if loop is None:
         loop = asyncio.get_event_loop()
@@ -675,5 +680,6 @@ def ws_connect(url, *, protocols=(), timeout=10.0, connector=None, auth=None,
                             protocols=protocols,
                             timeout=timeout,
                             autoclose=autoclose,
-                            autoping=autoping),
+                            autoping=autoping,
+                            origin=origin),
         session=session)

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -305,7 +305,9 @@ The client session supports context manager protocol for self closing.
 
    .. coroutinemethod:: ws_connect(url, *, protocols=(), timeout=10.0,\
                                    auth=None,\
-                                   autoclose=True, autoping=True)
+                                   autoclose=True,\
+                                   autoping=True,\
+                                   origin=None)
 
       Create a websocket connection. Returns a
       :class:`ClientWebSocketResponse` object.
@@ -327,6 +329,8 @@ The client session supports context manager protocol for self closing.
       :param bool autoping: automatically send `pong` on `ping`
                             message from server
 
+      :param str origin: Origin header to send to server
+
       .. versionadded:: 0.16
 
          Add :meth:`ws_connect`.
@@ -334,6 +338,10 @@ The client session supports context manager protocol for self closing.
       .. versionadded:: 0.18
 
          Add *auth* parameter.
+
+      .. versionadded:: 0.19
+
+         Add *origin* parameter.
 
    .. method:: close()
 

--- a/docs/client_websockets.rst
+++ b/docs/client_websockets.rst
@@ -62,7 +62,8 @@ coroutines, do not create an instance of class
 .. coroutinefunction:: ws_connect(url, *, protocols=(), \
                                   timeout=10.0, connector=None, auth=None,\
                                   ws_response_class=ClientWebSocketResponse,\
-                                  autoclose=True, autoping=True, loop=None)
+                                  autoclose=True, autoping=True, loop=None,\
+                                  origin=None)
 
    This function creates a websocket connection, checks the response and
    returns a :class:`ClientWebSocketResponse` object. In case of failure
@@ -98,9 +99,15 @@ coroutines, do not create an instance of class
                 used for getting default event loop, but we strongly
                 recommend to use explicit loops everywhere.
 
+   :param str origin: Origin header to send to server
+
    .. versionadded:: 0.18
 
       Add *auth* parameter.
+
+   .. versionadded:: 0.19
+
+      Add *origin* parameter.
 
 
 ClientWebSocketResponse


### PR DESCRIPTION
This PR allows passing of Origin header to `ws_connect()`.

I believe WebSockets specification requires passing of Origin header (https://tools.ietf.org/html/rfc6455#section-4.2.2).

Some servers requires proper Origin headers (according to specification), so without this patch it's not possible to connect to such servers using `ws_connect()`.
