### PR TITLE
Timeout context manager

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -485,8 +485,6 @@ class Timeout:
 
     @asyncio.coroutine
     def __aenter__(self):
-        if self._timeout is None:
-            return self
         self._task = asyncio.Task.current_task(loop=self._loop)
         self._cancel_handler = self._loop.call_later(
             self._timeout, self._cancel_task)
@@ -494,9 +492,6 @@ class Timeout:
 
     @asyncio.coroutine
     def __aexit__(self, exc_type, exc_val, exc_tb):
-        if self._timeout is None:
-            return
-
         if self._cancelled:
             if self._raise_error:
                 raise asyncio.TimeoutError
@@ -509,7 +504,3 @@ class Timeout:
 
     def _cancel_task(self):
         self._cancelled = self._task.cancel()
-
-    def cancel(self):
-        """Stop counting time and timeout logic"""
-        self._cancel_handler.cancel()

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -481,15 +481,13 @@ class Timeout:
         self._cancelled = False
         self._cancel_handler = None
 
-    @asyncio.coroutine
-    def __aenter__(self):
+    def __enter__(self):
         self._task = asyncio.Task.current_task(loop=self._loop)
         self._cancel_handler = self._loop.call_later(
             self._timeout, self._cancel_task)
         return self
 
-    @asyncio.coroutine
-    def __aexit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb):
         if self._cancelled:
             self._task = None
             raise asyncio.TimeoutError

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 from . import hdrs, multidict
 from .errors import InvalidURL
 
-__all__ = ('BasicAuth', 'FormData', 'parse_mimetype')
+__all__ = ('BasicAuth', 'FormData', 'parse_mimetype', 'Timeout')
 
 
 class BasicAuth(namedtuple('BasicAuth', ['login', 'password', 'encoding'])):
@@ -467,9 +467,14 @@ class Timeout:
     """Timeout context manager.
 
     Useful in cases when you want to apply timeout logic around block
-    of code or in cases when asyncio.wait_for is not suitable.
+    of code or in cases when asyncio.wait_for is not suitable. For example:
 
-    :param timeout: time out time in seconds
+    >>> with aiohttp.Timeout(0.001):
+    >>>     async with aiohttp.get('https://github.com') as r:
+    >>>         await r.text()
+
+
+    :param timeout: timeout value in seconds
     :param loop: asyncio compatible event loop
     """
     def __init__(self, timeout, *, loop=None):

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -488,7 +488,7 @@ class Timeout:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self._cancelled:
+        if exc_type is asyncio.CancelledError and self._cancelled:
             self._task = None
             raise asyncio.TimeoutError
         self._cancel_handler.cancel()

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -6,7 +6,6 @@ import functools
 import io
 import os
 import re
-import warnings
 from urllib.parse import quote, urlencode
 from collections import namedtuple
 
@@ -503,13 +502,9 @@ class Timeout:
         else:
             self._cancel_handler.cancel()
 
-    def __del__(self):
-        if self._task:
-            # just for preventing improper usage
-            warnings.warn("Use async with")
-
     def _cancel_task(self):
         self._cancelled = self._task.cancel()
 
     def cancel(self):
+        """Stop counting time and timeout logic"""
         self._cancel_handler.cancel()

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -493,8 +493,8 @@ class Timeout:
         if self._cancelled:
             self._task = None
             raise asyncio.TimeoutError
-        else:
-            self._cancel_handler.cancel()
+        self._cancel_handler.cancel()
+        self._task = None
 
     def _cancel_task(self):
         self._cancelled = self._task.cancel()

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -470,15 +470,13 @@ class Timeout:
     of code or in cases when asyncio.wait_for is not suitable.
 
     :param timeout: time out time in seconds
-    :param raise_error: if set, TimeoutError is raised in case of timeout
     :param loop: asyncio compatible event loop
     """
-    def __init__(self, timeout, *, raise_error=False, loop=None):
+    def __init__(self, timeout, *, loop=None):
         self._timeout = timeout
         if loop is None:
             loop = asyncio.get_event_loop()
         self._loop = loop
-        self._raise_error = raise_error
         self._task = None
         self._cancelled = False
         self._cancel_handler = None
@@ -493,12 +491,8 @@ class Timeout:
     @asyncio.coroutine
     def __aexit__(self, exc_type, exc_val, exc_tb):
         if self._cancelled:
-            if self._raise_error:
-                raise asyncio.TimeoutError
-            else:
-                # suppress
-                self._task = None
-                return True
+            self._task = None
+            raise asyncio.TimeoutError
         else:
             self._cancel_handler.cancel()
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -485,6 +485,8 @@ class Timeout:
 
     @asyncio.coroutine
     def __aenter__(self):
+        if self._timeout is None:
+            return self
         self._task = asyncio.Task.current_task(loop=self._loop)
         self._cancel_handler = self._loop.call_later(
             self._timeout, self._cancel_task)
@@ -492,6 +494,9 @@ class Timeout:
 
     @asyncio.coroutine
     def __aexit__(self, exc_type, exc_val, exc_tb):
+        if self._timeout is None:
+            return
+
         if self._cancelled:
             if self._raise_error:
                 raise asyncio.TimeoutError

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -539,6 +539,11 @@ time to wait for a response from a server::
       File "<stdin>", line 1, in <module>
     asyncio.TimeoutError()
 
+Or wrap your client call in :class:`Timeout` context manager::
+
+    with aiohttp.Timeout(0.001):
+        async with aiohttp.get('https://github.com') as r:
+            await r.text()
 
 .. warning::
 

--- a/tests/test_py35/test_timeout.py
+++ b/tests/test_py35/test_timeout.py
@@ -60,6 +60,7 @@ def test_timeout_finish_in_time(loop):
     async def run():
         async with Timeout(0.1, raise_error=True, loop=loop):
             await asyncio.sleep(0.01, loop=loop)
+            return 'done'
 
     loop.run_until_complete(run())
 
@@ -69,18 +70,17 @@ def test_timeout_gloabal_loop(loop):
 
     async def run():
         async with Timeout(0.1) as t:
-            await asyncio.sleep(0.01, loop=loop)
+            await asyncio.sleep(0.01)
             assert t._loop is loop
 
     loop.run_until_complete(run())
 
 
 def test_timeout_not_relevant_exception(loop):
-    asyncio.set_event_loop(loop)
 
     async def run():
         with pytest.raises(KeyError):
-            async with Timeout(0.1):
+            async with Timeout(0.1, loop=loop):
                 raise KeyError
 
     loop.run_until_complete(run())
@@ -89,9 +89,56 @@ def test_timeout_not_relevant_exception(loop):
 def test_timeout_blocking_loop(loop):
     async def long_running_task():
         time.sleep(0.1)
+        return 'done'
 
     async def run():
         async with Timeout(0.01, raise_error=True, loop=loop):
-            await long_running_task()
+            result = await long_running_task()
+            assert result == 'done'
 
     loop.run_until_complete(run())
+
+
+# ported tests from asyncio.wait_for
+def test_timeout_is_none(loop):
+
+    async def long_running_task():
+        return 'done'
+
+    async def run():
+        async with Timeout(None, raise_error=True, loop=loop):
+            value = await long_running_task()
+        assert value == 'done'
+
+    loop.run_until_complete(run())
+
+
+def test_for_race_conditions(loop):
+    async def run():
+        fut = asyncio.Future(loop=loop)
+        loop.call_later(0.1, fut.set_result('ok'))
+        async with Timeout(0.2, raise_error=True, loop=loop):
+            resp = await fut
+            assert resp == 'ok'
+
+    loop.run_until_complete(run())
+
+
+def test_timeout(loop):
+
+    async def go():
+        foo_running = None
+
+        start = loop.time()
+        with pytest.raises(asyncio.TimeoutError):
+            async with Timeout(0.1, raise_error=True, loop=loop):
+                foo_running = True
+                try:
+                    await asyncio.sleep(0.2, loop=loop)
+                finally:
+                    foo_running = False
+
+        assert abs(0.1 - (loop.time() - start)) < 0.002
+        assert not foo_running
+
+    loop.run_until_complete(go())

--- a/tests/test_py35/test_timeout.py
+++ b/tests/test_py35/test_timeout.py
@@ -1,0 +1,97 @@
+import asyncio
+import time
+
+import pytest
+from aiohttp.helpers import Timeout
+
+
+def test_timeout_without_error_raising(loop):
+    canceled_raised = False
+
+    async def long_running_task():
+        try:
+            await asyncio.sleep(10, loop=loop)
+        except asyncio.CancelledError:
+            nonlocal canceled_raised
+            canceled_raised = True
+            raise
+
+    async def run():
+        async with Timeout(0.01, loop=loop) as t:
+            await long_running_task()
+            assert t._loop is loop
+        assert canceled_raised, 'CancelledError was not raised'
+
+    loop.run_until_complete(run())
+
+
+def test_timeout_raise_error(loop):
+    async def long_running_task():
+        await asyncio.sleep(10, loop=loop)
+
+    async def run():
+        with pytest.raises(asyncio.TimeoutError):
+            async with Timeout(0.01, raise_error=True, loop=loop):
+                await long_running_task()
+
+    loop.run_until_complete(run())
+
+
+def test_timeout_cancel(loop):
+    canceled_raised = False
+
+    async def long_running_task():
+        try:
+            await asyncio.sleep(0.1, loop=loop)
+        except Exception:
+            nonlocal canceled_raised
+            canceled_raised = True
+            raise
+
+    async def run():
+        async with Timeout(0.01, raise_error=True, loop=loop) as t:
+            t.cancel()
+            await long_running_task()
+        assert not canceled_raised, 'CancelledError should not be raised'
+    loop.run_until_complete(run())
+
+
+def test_timeout_finish_in_time(loop):
+    async def run():
+        async with Timeout(0.1, raise_error=True, loop=loop):
+            await asyncio.sleep(0.01, loop=loop)
+
+    loop.run_until_complete(run())
+
+
+def test_timeout_gloabal_loop(loop):
+    asyncio.set_event_loop(loop)
+
+    async def run():
+        async with Timeout(0.1) as t:
+            await asyncio.sleep(0.01, loop=loop)
+            assert t._loop is loop
+
+    loop.run_until_complete(run())
+
+
+def test_timeout_not_relevant_exception(loop):
+    asyncio.set_event_loop(loop)
+
+    async def run():
+        with pytest.raises(KeyError):
+            async with Timeout(0.1):
+                raise KeyError
+
+    loop.run_until_complete(run())
+
+
+def test_timeout_blocking_loop(loop):
+    async def long_running_task():
+        time.sleep(0.1)
+
+    async def run():
+        async with Timeout(0.01, raise_error=True, loop=loop):
+            await long_running_task()
+
+    loop.run_until_complete(run())

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -65,6 +65,16 @@ def test_timeout_not_relevant_exception(loop):
     loop.run_until_complete(run())
 
 
+def test_timeout_canceled_error_is_converted_to_timeout(loop):
+    @asyncio.coroutine
+    def run():
+        with pytest.raises(asyncio.CancelledError):
+            with Timeout(0.001, loop=loop):
+                raise asyncio.CancelledError
+
+    loop.run_until_complete(run())
+
+
 def test_timeout_blocking_loop(loop):
     @asyncio.coroutine
     def long_running_task():

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -8,18 +8,20 @@ from aiohttp.helpers import Timeout
 def test_timeout(loop):
     canceled_raised = False
 
-    async def long_running_task():
+    @asyncio.coroutine
+    def long_running_task():
         try:
-            await asyncio.sleep(10, loop=loop)
+            yield from asyncio.sleep(10, loop=loop)
         except asyncio.CancelledError:
             nonlocal canceled_raised
             canceled_raised = True
             raise
 
-    async def run():
+    @asyncio.coroutine
+    def run():
         with pytest.raises(asyncio.TimeoutError):
-            async with Timeout(0.01, loop=loop) as t:
-                await long_running_task()
+            with Timeout(0.01, loop=loop) as t:
+                yield from long_running_task()
                 assert t._loop is loop
         assert canceled_raised, 'CancelledError was not raised'
 
@@ -27,13 +29,15 @@ def test_timeout(loop):
 
 
 def test_timeout_finish_in_time(loop):
-    async def long_running_task():
-        await asyncio.sleep(0.01, loop=loop)
+    @asyncio.coroutine
+    def long_running_task():
+        yield from asyncio.sleep(0.01, loop=loop)
         return 'done'
 
-    async def run():
-        async with Timeout(0.1, loop=loop):
-            resp = await long_running_task()
+    @asyncio.coroutine
+    def run():
+        with Timeout(0.1, loop=loop):
+            resp = yield from long_running_task()
         assert resp == 'done'
 
     loop.run_until_complete(run())
@@ -42,57 +46,63 @@ def test_timeout_finish_in_time(loop):
 def test_timeout_gloabal_loop(loop):
     asyncio.set_event_loop(loop)
 
-    async def run():
-        async with Timeout(0.1) as t:
-            await asyncio.sleep(0.01)
+    @asyncio.coroutine
+    def run():
+        with Timeout(0.1) as t:
+            yield from asyncio.sleep(0.01)
             assert t._loop is loop
 
     loop.run_until_complete(run())
 
 
 def test_timeout_not_relevant_exception(loop):
-    async def run():
+    @asyncio.coroutine
+    def run():
         with pytest.raises(KeyError):
-            async with Timeout(0.1, loop=loop):
+            with Timeout(0.1, loop=loop):
                 raise KeyError
 
     loop.run_until_complete(run())
 
 
 def test_timeout_blocking_loop(loop):
-    async def long_running_task():
+    @asyncio.coroutine
+    def long_running_task():
         time.sleep(0.1)
         return 'done'
 
-    async def run():
-        async with Timeout(0.01, loop=loop):
-            result = await long_running_task()
+    @asyncio.coroutine
+    def run():
+        with Timeout(0.01, loop=loop):
+            result = yield from long_running_task()
         assert result == 'done'
 
     loop.run_until_complete(run())
 
 
 def test_for_race_conditions(loop):
-    async def run():
+    @asyncio.coroutine
+    def run():
         fut = asyncio.Future(loop=loop)
         loop.call_later(0.1, fut.set_result('done'))
-        async with Timeout(0.2, loop=loop):
-            resp = await fut
+        with Timeout(0.2, loop=loop):
+            resp = yield from fut
         assert resp == 'done'
 
     loop.run_until_complete(run())
 
 
 def test_timeout_time(loop):
-    async def go():
+    @asyncio.coroutine
+    def go():
         foo_running = None
 
         start = loop.time()
         with pytest.raises(asyncio.TimeoutError):
-            async with Timeout(0.1, loop=loop):
+            with Timeout(0.1, loop=loop):
                 foo_running = True
                 try:
-                    await asyncio.sleep(0.2, loop=loop)
+                    yield from asyncio.sleep(0.2, loop=loop)
                 finally:
                     foo_running = False
 


### PR DESCRIPTION
@asvetlov  I implemented your idea about timeout context manager.

Open questions:
1) May be we should implement context manager as regular one `with Timeout(1):` instead  `async with Timeout(1)?:`
2) Do we need cancel logic:
```python
async with Timeout(1) as timeout:
   timeout.cancel()
   await do() 
```
3) what about raising exception in case of blocking code?:
```python
async with Timeout(1) as timeout:
    time.sleep(2)
```
Edit: Add related stackoverflow question:
http://stackoverflow.com/questions/33217429/creating-a-temporary-async-timer-callback-to-a-bound-method-with-python-asyncio