### PR TITLE
Avoid sending cookie attributes in Cookie header

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -223,8 +223,7 @@ class ClientRequest:
 
         for name, value in cookies:
             if isinstance(value, http.cookies.Morsel):
-                # use dict method because SimpleCookie class modifies value
-                dict.__setitem__(c, name, value)
+                c[value.key] = value.value
             else:
                 c[name] = value
 


### PR DESCRIPTION
Current implementation sends attributes of every cookie key-value pair in Cookie HTTP header:

key=value;
httponly;
Path=/;
secure;
key=value;
httponly;
Path=/;
secure;
key=value;
httponly;
Path=/;
expires=Sun, 31-Jan-2016 11:00:00 GMT;
Domain=.example.net.;

This behaviour is wrong, you can inspect specs to see that attributes must exist only in incoming Set-Cookie header and affect only cookie storage logic in decisions whether to send particular pair or not.

https://tools.ietf.org/html/rfc6265#section-3.1