### PR TITLE
Collect history of responses if redirects occur.

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -141,6 +141,7 @@ class ClientSession:
             raise RuntimeError('Session is closed')
 
         redirects = 0
+        history = []
         if not isinstance(method, upstr):
             method = upstr(method)
 
@@ -193,6 +194,7 @@ class ClientSession:
             # redirects
             if resp.status in (301, 302, 303, 307) and allow_redirects:
                 redirects += 1
+                history.append(resp)
                 if max_redirects and redirects >= max_redirects:
                     resp.close(force=True)
                     break
@@ -221,6 +223,7 @@ class ClientSession:
 
             break
 
+        resp.history = history
         return resp
 
     def ws_connect(self, url, *,

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -512,6 +512,7 @@ class ClientResponse:
     cookies = None  # Response cookies (Set-Cookie)
     content = None  # Payload stream
     headers = None  # Response headers, CIMultiDictProxy
+    history = None  # List of responses, if redirects occured
 
     _connection = None  # current connection
     flow_control_class = FlowControlStreamReader  # reader flow control

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -527,6 +527,22 @@ If a response contains some Cookies, you can quickly access them::
    <aiohttp-client-session>` object.
 
 
+Response History
+----------------
+
+If a request was redirected, it is possible to view previous responses using
+the history attribute::
+
+    >>> r = await aiohttp.get('http://example.com/some/redirect/')
+    >>> r
+    <ClientResponse(http://example.com/some/other/url/) [200]>
+    >>> r.history
+    [<ClientResponse(http://example.com/some/redirect/) [301]>]
+
+If no redirects occured or ``allow_redirects`` is set to ``False``, history will
+be an empty list.
+
+
 Timeouts
 --------
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -954,6 +954,11 @@ Response object
 
       HTTP headers of response, :class:`CIMultiDictProxy`.
 
+   .. attribute:: history
+
+      List of :class:`ClientResponse` objects of preceding requests, if there
+      were redirects.
+
    .. method:: close()
 
       Close response and underlying connection.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -956,7 +956,7 @@ Response object
 
    .. attribute:: history
 
-      List of :class:`ClientResponse` objects of preceding requests, if there
+      :class:`list` of :class:`ClientResponse` objects of preceding requests, if there
       were redirects.
 
    .. method:: close()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -350,10 +350,16 @@ def test_history(create_app_and_client):
     app.router.add_route('GET', '/redirect', handler_redirect)
 
     resp = yield from client.get('/ok')
-    assert resp.history == []
-    assert resp.status == 200
+    try:
+        assert resp.history == []
+        assert resp.status == 200
+    finally:
+        resp.release()
 
     resp_redirect = yield from client.get('/redirect')
-    assert len(resp_redirect.history) == 1
-    assert resp_redirect.history[0].status == 301
-    assert resp_redirect.status == 200
+    try:
+        assert len(resp_redirect.history) == 1
+        assert resp_redirect.history[0].status == 301
+        assert resp_redirect.status == 200
+    finally:
+        resp_redirect.release()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -333,3 +333,27 @@ def test_str_params(create_app_and_client):
         assert 200 == resp.status
     finally:
         yield from resp.release()
+
+
+@pytest.mark.run_loop
+def test_history(create_app_and_client):
+    @asyncio.coroutine
+    def handler_redirect(request):
+        return web.Response(status=301, headers={'Location': '/ok'})
+
+    @asyncio.coroutine
+    def handler_ok(request):
+        return web.Response(status=200)
+
+    app, client = yield from create_app_and_client()
+    app.router.add_route('GET', '/ok', handler_ok)
+    app.router.add_route('GET', '/redirect', handler_redirect)
+
+    resp = yield from client.get('/ok')
+    assert resp.history == []
+    assert resp.status == 200
+
+    resp_redirect = yield from client.get('/redirect')
+    assert len(resp_redirect.history) == 1
+    assert resp_redirect.history[0].status == 301
+    assert resp_redirect.status == 200


### PR DESCRIPTION
Hi,

Accessing the history, or the information that a redirect occured at all (except for comparing original and final URL), is something I couldn't find and was missing from the requests library.

I'm completely new to this project, so I have no idea, if what I did, is the correct way to do it or if I missed something.

Feedback appreciated.