### PR TITLE
Drop obsolete .close(force=True)

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -176,7 +176,7 @@ class ClientSession:
                 try:
                     yield from resp.start(conn, read_until_eof)
                 except:
-                    resp.close(force=True)
+                    resp.close()
                     conn.close()
                     raise
             except (aiohttp.HttpProcessingError,
@@ -194,7 +194,7 @@ class ClientSession:
             if resp.status in (301, 302, 303, 307) and allow_redirects:
                 redirects += 1
                 if max_redirects and redirects >= max_redirects:
-                    resp.close(force=True)
+                    resp.close()
                     break
 
                 # For 301 and 302, mimic IE behaviour, now changed in RFC.
@@ -210,7 +210,7 @@ class ClientSession:
 
                 scheme = urllib.parse.urlsplit(r_url)[0]
                 if scheme not in ('http', 'https', ''):
-                    resp.close(force=True)
+                    resp.close()
                     raise ValueError('Can redirect only to http or https')
                 elif not scheme:
                     r_url = urllib.parse.urljoin(url, r_url)

--- a/aiohttp/websocket_client.py
+++ b/aiohttp/websocket_client.py
@@ -99,16 +99,16 @@ class ClientWebSocketResponse:
                 self._writer.close(code, message)
             except asyncio.CancelledError:
                 self._close_code = 1006
-                self._response.close(force=True)
+                self._response.close()
                 raise
             except Exception as exc:
                 self._close_code = 1006
                 self._exception = exc
-                self._response.close(force=True)
+                self._response.close()
                 return True
 
             if self._closing:
-                self._response.close(force=True)
+                self._response.close()
                 return True
 
             while True:
@@ -117,17 +117,17 @@ class ClientWebSocketResponse:
                         self._reader.read(), self._timeout, loop=self._loop)
                 except asyncio.CancelledError:
                     self._close_code = 1006
-                    self._response.close(force=True)
+                    self._response.close()
                     raise
                 except Exception as exc:
                     self._close_code = 1006
                     self._exception = exc
-                    self._response.close(force=True)
+                    self._response.close()
                     return True
 
                 if msg.tp == MsgType.close:
                     self._close_code = msg.data
-                    self._response.close(force=True)
+                    self._response.close()
                     return True
         else:
             return False


### PR DESCRIPTION
It's default behavior for aiohttp 0.18