### PR TITLE
Enable passing pre-compressed data in requests (attempt 2)

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -231,8 +231,10 @@ class ClientRequest:
         """Set request content encoding."""
         enc = self.headers.get(hdrs.CONTENT_ENCODING, '').lower()
         if enc:
-            self.compress = enc
-            self.chunked = True  # enable chunked, no need to deal with length
+            if self.compress is not False:
+                self.compress = enc
+                # enable chunked, no need to deal with length
+                self.chunked = True
         elif self.compress:
             if not isinstance(self.compress, str):
                 self.compress = 'deflate'

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -328,6 +328,23 @@ requests together (aka HTTP pipelining)::
                       data=r.content)
 
 
+Uploading pre-compressed data
+-----------------------------
+
+To upload data that is already compressed before passing it to aiohttp, call
+the request function with ``compress=False`` and set the used compression
+algorithm name (usually deflate or zlib) as the value of the
+``Content-Encoding`` header::
+
+    @asyncio.coroutine
+    def my_coroutine( my_data):
+        data = zlib.compress(my_data)
+        headers = {'Content-Encoding': 'deflate'}
+        yield from aiohttp.post(
+            'http://httpbin.org/post', data=data, headers=headers,
+            compress=False)
+
+
 .. _aiohttp-client-session:
 
 Keep-Alive, connection pooling and cookie sharing

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -406,6 +406,9 @@ certification chaining.
 
    :param bool compress: Set to ``True`` if request has to be compressed
                          with deflate encoding.
+                         ``False`` instructs aiohttp to not compress data
+                         even if the Content-Encoding header is set. Use it
+                         when sending pre-compressed data.
                          ``None`` by default (optional).
 
    :param int chunked: Set to chunk size for chunked transfer encoding.


### PR DESCRIPTION
As discussed in issue https://github.com/KeepSafe/aiohttp/issues/619