### PR TITLE
Allow disabling sendfile w/ env 'AIOHTTP_NOSENDFILE=1'

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -163,6 +163,9 @@ class StaticRoute(Route):
             raise ValueError(
                 "No directory exists at '{}'".format(self._directory))
 
+        if os.environ.get("AIOHTTP_NOSENDFILE") == "1":
+            self._sendfile = self._sendfile_fallback
+
     def match(self, path):
         if not path.startswith(self._prefix):
             return None

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1125,15 +1125,30 @@ Router is any object that implements :class:`AbstractRouter` interface.
    .. method:: add_static(prefix, path, *, name=None, expect_handler=None, \
                           chunk_size=256*1024, response_factory=StreamResponse)
 
-      Adds router for returning static files.
+      Adds a router and a handler for returning static files.
 
-      Useful for handling static content like images, javascript and css files.
+      Useful for serving static content like images, javascript and css files.
+
+      On platforms that support it, the handler will transfer files more
+      efficiently using the ``sendfile`` system call.
+
+      In some situations it might be necessary to avoid using the ``sendfile``
+      system call even if the platform supports it. This can be accomplished by
+      by setting environment variable ``AIOHTTP_NOSENDFILE=1``.
 
       .. warning::
 
          Use :meth:`add_static` for development only. In production,
          static content should be processed by web servers like *nginx*
          or *apache*.
+
+      .. versionchanged:: 0.18.0
+         Transfer files using the ``sendfile`` system call on supported
+         platforms.
+
+      .. versionchanged:: 0.19.0
+         Disable ``sendfile`` by setting environment variable
+         ``AIOHTTP_NOSENDFILE=1``
 
       :param str prefix: URL path prefix for handled static files
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1019,6 +1019,13 @@ class StaticFileMixin(WebFunctionalSetupMixin):
 
         self.loop.run_until_complete(go(here, filename))
 
+    def test_env_nosendfile(self):
+        directory = os.path.dirname(__file__)
+
+        with mock.patch.dict(os.environ, {'AIOHTTP_NOSENDFILE': '1'}):
+            route = web.StaticRoute(None, "/", directory)
+            self.assertEqual(route._sendfile, route._sendfile_fallback)
+
 
 class TestStaticFileSendfileFallback(StaticFileMixin,
                                      unittest.TestCase):


### PR DESCRIPTION
`StaticRoute` can now be forced to not use `sendfile` system call if environment variable `AIOHTTP_NOSENDFILE=1`.

See issue #628 