### PR TITLE
Replace deprecated asyncio.async calls

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -477,7 +477,7 @@ class ClientRequest:
                            for k, value in self.headers.items())))
         request.send_headers()
 
-        self._writer = asyncio.async(
+        self._writer = asyncio.ensure_future(
             self.write_bytes(request, reader), loop=self.loop)
 
         self.response = self.response_class(

--- a/aiohttp/server.py
+++ b/aiohttp/server.py
@@ -141,7 +141,7 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
     def connection_made(self, transport):
         super().connection_made(transport)
 
-        self._request_handler = asyncio.async(self.start(), loop=self._loop)
+        self._request_handler = asyncio.ensure_future(self.start(), loop=self._loop)
 
         # start slow request timer
         if self._timeout:

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -28,7 +28,7 @@ class GunicornWebWorker(base.Worker):
         super().init_process()
 
     def run(self):
-        self._runner = asyncio.async(self._run(), loop=self.loop)
+        self._runner = asyncio.ensure_future(self._run(), loop=self.loop)
 
         try:
             self.loop.run_until_complete(self._runner)


### PR DESCRIPTION
While creating tests for an app that uses aiohttp client, the output was polluted with warnings everywhere.
Temporarily suppressing warnings in tests is not generally a good idea, thus a PR to remedy this issue.

P.S. Just noticed that apparently test_worker.py specifically checks if asyncio.async was called. Never used unittest.mock, so just to confirm, would just replacing "m_asyncio.async.called" to "m_asyncio.ensure_future.called" work?