### PR TITLE
(#520) Always quote params for Content-Disposition

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -756,11 +756,9 @@ class BodyPartWriter(object):
                     raise ValueError('bad content disposition parameter'
                                      ' {!r}={!r}'.format(key, val))
                 qval = quote(val, '')
+                lparams.append((key, '"%s"' % qval))
                 if key == 'filename':
-                    lparams.append((key, '"%s"' % qval))
                     lparams.append(('filename*', "utf-8''" + qval))
-                else:
-                    lparams.append((key, "%s" % qval))
             sparams = '; '.join('='.join(pair) for pair in lparams)
             value = '; '.join((value, sparams))
         self.headers[CONTENT_DISPOSITION] = value

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -633,7 +633,7 @@ class BodyPartWriterTestCase(unittest.TestCase):
     def test_set_content_disposition(self):
         self.part.set_content_disposition('attachment', foo='bar')
         self.assertEqual(
-            'attachment; foo=bar',
+            'attachment; foo="bar"',
             self.part.headers[CONTENT_DISPOSITION])
 
     def test_set_content_disposition_bad_type(self):


### PR DESCRIPTION
While specification defines params as

     disp-extension-parm = token "=" ( token | quoted-string )

it seems not all implementations are able to handle token-as-a-value
correctly. For else, this change as no effect since token is subset
of quoted-string values.