### PR TITLE
Add more HTTP status codes

### DIFF
--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -39,6 +39,11 @@ __all__ = (
     'HTTPUnsupportedMediaType',
     'HTTPRequestRangeNotSatisfiable',
     'HTTPExpectationFailed',
+    'HTTPMisdirectedRequest',
+    'HTTPUpgradeRequired',
+    'HTTPPreconditionRequired',
+    'HTTPTooManyRequests',
+    'HTTPRequestHeaderFieldsTooLarge',
     'HTTPServerError',
     'HTTPInternalServerError',
     'HTTPNotImplemented',
@@ -46,6 +51,9 @@ __all__ = (
     'HTTPServiceUnavailable',
     'HTTPGatewayTimeout',
     'HTTPVersionNotSupported',
+    'HTTPVariantAlsoNegotiates',
+    'HTTPNotExtended',
+    'HTTPNetworkAuthenticationRequired',
 )
 
 

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -324,8 +324,10 @@ class HTTPVersionNotSupported(HTTPServerError):
 class HTTPVariantAlsoNegotiates(HTTPServerError):
     status_code = 506
 
+
 class HTTPNotExtended(HTTPServerError):
     status_code = 510
+
 
 class HTTPNetworkAuthenticationRequired(HTTPServerError):
     status_code = 511

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -253,6 +253,26 @@ class HTTPExpectationFailed(HTTPClientError):
     status_code = 417
 
 
+class HTTPMisdirectedRequest(HTTPClientError):
+    status_code = 421
+
+
+class HTTPUpgradeRequired(HTTPClientError):
+    status_code = 426
+
+
+class HTTPPreconditionRequired(HTTPClientError):
+    status_code = 428
+
+
+class HTTPTooManyRequests(HTTPClientError):
+    status_code = 429
+
+
+class HTTPRequestHeaderFieldsTooLarge(HTTPClientError):
+    status_code = 431
+
+
 ############################################################
 # 5xx Server Error
 ############################################################
@@ -291,3 +311,13 @@ class HTTPGatewayTimeout(HTTPServerError):
 
 class HTTPVersionNotSupported(HTTPServerError):
     status_code = 505
+
+
+class HTTPVariantAlsoNegotiates(HTTPServerError):
+    status_code = 506
+
+class HTTPNotExtended(HTTPServerError):
+    status_code = 510
+
+class HTTPNetworkAuthenticationRequired(HTTPServerError):
+    status_code = 511

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -513,6 +513,11 @@ HTTP Exception hierarchy chart::
            * 415 - HTTPUnsupportedMediaType
            * 416 - HTTPRequestRangeNotSatisfiable
            * 417 - HTTPExpectationFailed
+           * 421 - HTTPMisdirectedRequest
+           * 426 - HTTPUpgradeRequired
+           * 428 - HTTPPreconditionRequired
+           * 429 - HTTPTooManyRequests
+           * 431 - HTTPRequestHeaderFieldsTooLarge
          HTTPServerError
            * 500 - HTTPInternalServerError
            * 501 - HTTPNotImplemented
@@ -520,6 +525,9 @@ HTTP Exception hierarchy chart::
            * 503 - HTTPServiceUnavailable
            * 504 - HTTPGatewayTimeout
            * 505 - HTTPVersionNotSupported
+           * 506 - HTTPVariantAlsoNegotiates
+           * 510 - HTTPNotExtended
+           * 511 - HTTPNetworkAuthenticationRequired
 
 All HTTP exceptions have the same constructor::
 


### PR DESCRIPTION
The web_exceptions.py file didn't have all of the declared HTTP status codes (since some were declared in RFCs and such), so I added them. I also put them in the docs where it shows a chart of the HTTP status codes. I added all of the ones that Wikipedia said were official: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes