### PR TITLE
Rename `loader` keyword argument in `web.Request.json` method.

### DIFF
--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -326,8 +326,13 @@ class Request(dict, HeadersMixin):
         return bytes_body.decode(encoding)
 
     @asyncio.coroutine
-    def json(self, *, loads=json.loads):
+    def json(self, *, loads=json.loads, loader=None):
         """Return BODY as JSON."""
+        if loader:
+            warnings.warn(
+                'Using `loader` is deprecated, use `loads` instead',
+                DeprecationWarning)
+            loads = loader
         body = yield from self.text()
         return loads(body)
 

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -326,10 +326,10 @@ class Request(dict, HeadersMixin):
         return bytes_body.decode(encoding)
 
     @asyncio.coroutine
-    def json(self, *, loader=json.loads):
+    def json(self, *, loads=json.loads):
         """Return BODY as JSON."""
         body = yield from self.text()
-        return loader(body)
+        return loads(body)
 
     @asyncio.coroutine
     def post(self):

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -250,14 +250,14 @@ like one using :meth:`Request.copy`.
          The method **does** store read data internally, subsequent
          :meth:`~Request.text` call will return the same value.
 
-   .. coroutinemethod:: json(*, loader=json.loads)
+   .. coroutinemethod:: json(*, loads=json.loads)
 
       Read request body decoded as *json*.
 
       The method is just a boilerplate :ref:`coroutine <coroutine>`
       implemented as::
 
-         async def json(self, *, loader=json.loads):
+         async def json(self, *, loads=json.loads):
              body = await self.text()
              return loader(body)
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -144,6 +144,8 @@ class TestWebFunctional(WebFunctionalSetupMixin, unittest.TestCase):
             self.assertEqual(dct, data)
             data2 = yield from request.json(loads=json.loads)
             self.assertEqual(data, data2)
+            data3 = yield from request.json(loader=json.loads)
+            self.assertEqual(data, data3)
             resp = web.Response()
             resp.content_type = 'application/json'
             resp.body = json.dumps(data).encode('utf8')

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -142,7 +142,7 @@ class TestWebFunctional(WebFunctionalSetupMixin, unittest.TestCase):
         def handler(request):
             data = yield from request.json()
             self.assertEqual(dct, data)
-            data2 = yield from request.json()
+            data2 = yield from request.json(loads=json.loads)
             self.assertEqual(data, data2)
             resp = web.Response()
             resp.content_type = 'application/json'


### PR DESCRIPTION
This adds consistency to the library as:

* `loads` alredy used in `client.Response.json` method
* `dumps` used in `web.json_response` function (introduced in 0.19.0)