### PR TITLE
Fix docs syntax highlighting

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -3,9 +3,8 @@
 HTTP Client
 ===========
 
-.. highlight:: python
-
 .. module:: aiohttp
+
 .. currentmodule:: aiohttp
 
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -3,9 +3,8 @@
 HTTP Client Reference
 =====================
 
-.. highlight:: python
-
 .. module:: aiohttp
+
 .. currentmodule:: aiohttp
 
 

--- a/docs/client_websockets.rst
+++ b/docs/client_websockets.rst
@@ -3,8 +3,6 @@
 WebSockets Client
 =================
 
-.. highlight:: python
-
 .. module:: aiohttp
 
 .. currentmodule:: aiohttp

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,6 +123,9 @@ exclude_patterns = ['_build']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# The default language to highlight source code in.
+highlight_language = 'python3'
+
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -3,8 +3,6 @@
 Logging
 =======
 
-.. highlight:: python
-
 .. currentmodule:: aiohttp
 
 

--- a/docs/multidict.rst
+++ b/docs/multidict.rst
@@ -4,8 +4,6 @@
  Multidicts
 ============
 
-.. highlight:: python
-
 .. module:: aiohttp
 
 

--- a/docs/multipart.rst
+++ b/docs/multipart.rst
@@ -1,5 +1,3 @@
-.. highlight:: python
-
 .. module:: aiohttp.multipart
 
 .. _aiohttp-multipart:

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -3,8 +3,6 @@
 Low-level HTTP Server
 =====================
 
-.. highlight:: python
-
 .. currentmodule:: aiohttp.server
 
 .. note::

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -3,8 +3,6 @@
 HTTP Server Usage
 =================
 
-.. highlight:: python
-
 .. currentmodule:: aiohttp.web
 
 .. versionchanged:: 0.12

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -3,8 +3,6 @@
 HTTP Server Reference
 =====================
 
-.. highlight:: python
-
 .. module:: aiohttp.web
 
 .. versionchanged:: 0.12


### PR DESCRIPTION
I've noticed that since the `async/await` syntax was introduced to the examples, syntax highlighting has been iffy. The fix seems to be to set the highlight language to `python3`.

I've also factored out the `.. highlight` directives in each file by setting the global default `highlight_language = 'python3'` in `conf.py`.