### PR TITLE
Ensure changes to the status attribute are written to the transport.

### DIFF
--- a/aiohttp/protocol.py
+++ b/aiohttp/protocol.py
@@ -830,12 +830,18 @@ class Response(HttpMessage):
         super().__init__(transport, http_version, close)
 
         self.status = status
-        if reason is None:
-            reason = self.calc_reason(status)
+        self.custom_reason = reason
 
-        self.reason = reason
-        self.status_line = 'HTTP/{}.{} {} {}\r\n'.format(
-            http_version[0], http_version[1], status, reason)
+    @property
+    def reason(self):
+        if self.custom_reason is not None:
+            return self.custom_reason
+        return self.calc_reason(self.status)
+
+    @property
+    def status_line(self):
+        return 'HTTP/{}.{} {} {}\r\n'.format(
+            self.version[0], self.version[1], self.status, self.reason)
 
     def _add_default_headers(self):
         super()._add_default_headers()
@@ -861,5 +867,8 @@ class Request(HttpMessage):
 
         self.method = method
         self.path = path
-        self.status_line = '{0} {1} HTTP/{2[0]}.{2[1]}\r\n'.format(
-            method, path, http_version)
+
+    @property
+    def status_line(self):
+        return '{0} {1} HTTP/{2[0]}.{2[1]}\r\n'.format(
+            self.method, self.path, self.version)

--- a/tests/test_http_protocol.py
+++ b/tests/test_http_protocol.py
@@ -14,6 +14,19 @@ class TestHttpMessage(unittest.TestCase):
         self.transport = unittest.mock.Mock()
         asyncio.set_event_loop(None)
 
+    def test_status_line_request(self):
+        msg = protocol.Request(
+            self.transport, 'GET', '/index.html', close=True)
+        self.assertEqual(msg.status_line, 'GET /index.html HTTP/1.1\r\n')
+        msg.path = '/not-index.html'
+        self.assertEqual(msg.status_line, 'GET /not-index.html HTTP/1.1\r\n')
+
+    def test_status_line_response(self):
+        msg = protocol.Response(self.transport, 200, close=True)
+        self.assertEqual(msg.status_line, 'HTTP/1.1 200 OK\r\n')
+        msg.status = 400
+        self.assertEqual(msg.status_line, 'HTTP/1.1 400 Bad Request\r\n')
+
     def test_start_request(self):
         msg = protocol.Request(
             self.transport, 'GET', '/index.html', close=True)


### PR DESCRIPTION
I'm writing a proxy with aiohttp, and I need the possibility of modifying the response status code under certain conditions, something that currently isn't possible.

Personally I'm not a big fan for how I've done the handling of the `reason` of the attribute, but I can't think of a better way to do this.