### PR TITLE
Added HTTP 308 support

### DIFF
--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -20,6 +20,7 @@ __all__ = (
     'HTTPNotModified',
     'HTTPUseProxy',
     'HTTPTemporaryRedirect',
+    'HTTPPermanentRedirect',
     'HTTPClientError',
     'HTTPBadRequest',
     'HTTPUnauthorized',
@@ -169,6 +170,10 @@ class HTTPUseProxy(_HTTPMove):
 
 class HTTPTemporaryRedirect(_HTTPMove):
     status_code = 307
+
+
+class HTTPPermanentRedirect(_HTTPMove):
+    status_code = 308
 
 
 ############################################################


### PR DESCRIPTION
Added HTTPPermanentRedirect class to support HTTP 308 redirection. This is useful for testing with Curl because it's the only redirection code it does understand to resend the query string.