### PR TITLE
[docs] Add note about async/await syntax in the examples, Python 3.5+ v. 3.4

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,24 @@ Server example::
     except KeyboardInterrupt:
         pass
 
+.. note::
+
+   Throughout this documentation, examples utilize the `async/await` syntax
+   introduced by :pep:`492` that is only valid for Python 3.5+.
+
+   If you are using Python 3.4, please replace ``await`` with
+   ``yield from`` and ``async def`` with a ``@coroutine`` decorator.
+   For example, this::
+
+       async def coro(...):
+           ret = await f()
+
+   shoud be replaced by::
+
+       @asyncio.coroutine
+       def coro(...):
+           ret = yield from f()
+
 
 Source code
 -----------


### PR DESCRIPTION
Issue https://github.com/KeepSafe/aiohttp/issues/683