### PR TITLE
Enable use of `await` for a class based view

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -386,6 +386,9 @@ class View(AbstractView):
         resp = yield from method()
         return resp
 
+    def __await__(self):
+        return (yield from self.__iter__())
+
     def _raise_allowed_methods(self):
         allowed_methods = {m for m in hdrs.METH_ALL if hasattr(self, m)}
         raise HTTPMethodNotAllowed(self.request.method, allowed_methods)


### PR DESCRIPTION
Currently if you implement a middleware in the 3.5 syntax (native coroutines, e.g. `async def` and `await`) for class based views, they will yield a `TypeError` saying that that `web.View is not awaitable`.  This is due to a new magic method `__await__` for classes that needs to be implemented.  This change simply uses the current `__iter__` behavior (supporting 3.4 `@asyncio.coroutine` and `yield from`) and enables the 3.5 `await` keyword (required for native coroutines, e.g. `async def`)

A quick example of an error this can cause is in middleware written in the 3.5 syntax:

```
def db_middleware(dsn):
    async def factory(app, handler):
        async def middleware(request):
            db = app.get('db')
            if not db:
                app['db'] = db = await create_engine(dsn)
            request.app['db'] = db
            response = await handler(request)
        return middleware
    return factory
```

Without the `__await__` method implemented a `TypeError` is raised.

Validated to work with 3.4+