### PR TITLE
Proposal for adding on_shutdown signal

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -246,7 +246,19 @@ class Application(dict):
             self, self.router, loop=self.loop, **kwargs)
 
     @asyncio.coroutine
+    def shutdown(self):
+        """Causes on_shutdown signal
+
+        Should be called before finish()
+        """
+        yield from self.on_shutdown.send(self)
+
+    @asyncio.coroutine
     def finish(self):
+        """Finalize application by calling all registered callbacks
+
+        Should be called before shutdown()
+        """
         callbacks = self._finish_callbacks
         self._finish_callbacks = []
 

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -207,6 +207,7 @@ class Application(dict):
         self._on_pre_signal = PreSignal()
         self._on_post_signal = PostSignal()
         self._on_response_prepare = Signal(self)
+        self._on_shutdown = Signal(self)
 
     @property
     def debug(self):
@@ -223,6 +224,10 @@ class Application(dict):
     @property
     def on_post_signal(self):
         return self._on_post_signal
+
+    @property
+    def on_shutdown(self):
+        return self._on_shutdown
 
     @property
     def router(self):

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -67,6 +67,9 @@ class GunicornWebWorker(base.Worker):
                               self.pid, len(handler.connections))
                 server.close()
 
+            # send on_shutdown event
+            yield from self.wsgi.shutdown()
+
             # stop alive connections
             tasks = [
                 handler.finish_connections(

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -51,5 +51,10 @@
 
        An endpoint that returns HTTP response.
 
+   websocket
+
+       A protocol providing full-duplex communication channels over a
+       single TCP connection. The WebSocket protocol was standardized
+       by the IETF as :rfc:`6455`
 
 .. disqus::

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -835,7 +835,8 @@ Signal handler may looks like:
     app.on_shutdown.append(on_shutdown)
 
 
-Server finalizer should raise shutdown signal::
+Server finalizer should raise shutdown signal by
+:meth:`Application.shutdown` call::
 
    loop = asyncio.get_event_loop()
    handler = app.make_handler()
@@ -849,7 +850,7 @@ Server finalizer should raise shutdown signal::
    finally:
        srv.close()
        loop.run_until_complete(srv.wait_closed())
-       loop.run_until_complete(app.on_shutdown.send(app))
+       loop.run_until_complete(app.shutdown())
        loop.run_until_complete(handler.finish_connections(60.0))
        loop.run_until_complete(app.finish())
    loop.close()

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1007,8 +1007,26 @@ duplicated like one using :meth:`Application.copy`.
 
       Signal handlers should have the following signature::
 
-          async def handler(request, response):
+          async def on_prepare(request, response):
               pass
+
+   .. attribute:: on_shutdown
+
+      A :class:`~aiohttp.signals.Signal` that is fired on application shutdown.
+
+      Subscribers may use the signal for gracefully closing long running
+      connections, e.g. websockets and data streaming.
+
+      Signal handlers should have the following signature::
+
+          async def on_shutdown(app):
+              pass
+
+      It's up to end user to figure out which :term:`web-handler`\s
+      are still alive and how to finish them properly.
+
+      We suggest to keep a list of long running handlers in
+      :class:`Application` dictionary.
 
    .. method:: make_handler(**kwargs)
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1025,8 +1025,10 @@ duplicated like one using :meth:`Application.copy`.
       It's up to end user to figure out which :term:`web-handler`\s
       are still alive and how to finish them properly.
 
-      We suggest to keep a list of long running handlers in
+      We suggest keeping a list of long running handlers in
       :class:`Application` dictionary.
+
+      .. seealso:: :ref:`aiohttp-web-graceful-shutdown`
 
    .. method:: make_handler(**kwargs)
 
@@ -1048,10 +1050,18 @@ duplicated like one using :meth:`Application.copy`.
          await loop.create_server(app.make_handler(),
                                   '0.0.0.0', 8080)
 
+   .. coroutinemethod:: shutdown()
+
+      A :ref:`coroutine<coroutine>` that should be called on
+      server stopping but before :meth:`finish()`.
+
+      The purpose of the method is calling :attr:`on_shutdown` signal
+      handlers.
+
    .. coroutinemethod:: finish()
 
-      A :ref:`coroutine<coroutine>` that should be called after
-      server stopping.
+      A :ref:`coroutine<coroutine>` that should be called on
+      server stopping but after :meth:`shutdown`.
 
       This method executes functions registered by
       :meth:`register_on_finish` in LIFO order.

--- a/tests/test_web_application.py
+++ b/tests/test_web_application.py
@@ -82,3 +82,20 @@ def test_non_default_router(loop):
         app = web.Application(loop=self.loop)
         app.logger = logger
         self.assertIs(app.logger, logger)
+
+
+@pytest.mark.run_loop
+def test_on_shutdown(loop):
+    app = web.Application(loop=loop)
+    called = False
+
+    @asyncio.coroutine
+    def on_shutdown(app_param):
+        nonlocal called
+        assert app is app_param
+        called = True
+
+    app.on_shutdown.append(on_shutdown)
+
+    yield from app.shutdown()
+    assert called

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -145,7 +145,11 @@ def test_close(worker, loop):
         loop=loop)
     handler.finish_connections.return_value.set_result(1)
 
+    app.shutdown.return_value = asyncio.Future(loop=loop)
+    app.shutdown.return_value.set_result(None)
+
     loop.run_until_complete(worker.close())
+    app.shutdown.assert_called_with()
     app.finish.assert_called_with()
     handler.finish_connections.assert_called_with(timeout=95.0)
     srv.close.assert_called_with()


### PR DESCRIPTION
We need a way for closing long-running responses like websockets and data streaming,

The proposal does it by introducing `on_shutdown` signal and documenting the recommended way to use it.

Consider it as pre-requisite for #690