### PR TITLE
Keepalive refactoring

### DIFF
--- a/aiohttp/protocol.py
+++ b/aiohttp/protocol.py
@@ -886,7 +886,7 @@ class Request(HttpMessage):
                  http_version=HttpVersion11, close=False):
         # set the default for HTTP 1.0 to be different
         # will only be overwritten with keep-alive header
-        if http_version < HttpVersion11:
+        if http_version < HttpVersion10:
             close = True
 
         super().__init__(transport, http_version, close)

--- a/aiohttp/protocol.py
+++ b/aiohttp/protocol.py
@@ -675,14 +675,18 @@ class HttpMessage(metaclass=ABCMeta):
 
     def _add_default_headers(self):
         # set the connection header
+        connection = None
         if self.upgrade:
             connection = 'upgrade'
         elif not self.closing if self.keepalive is None else self.keepalive:
-            connection = 'keep-alive'
+            if self.version == HttpVersion10:
+                connection = 'keep-alive'
         else:
-            connection = 'close'
+            if self.version == HttpVersion11:
+                connection = 'close'
 
-        self.headers[hdrs.CONNECTION] = connection
+        if connection is not None:
+            self.headers[hdrs.CONNECTION] = connection
 
     def write(self, chunk, *,
               drain=False, EOF_MARKER=EOF_MARKER, EOL_MARKER=EOL_MARKER):

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -413,7 +413,6 @@ def test_raw_headers(create_app_and_client, loop):
     resp = yield from client.get('/')
     assert resp.status == 200
     assert resp.raw_headers == ((b'CONTENT-LENGTH', b'0'),
-                                (b'CONNECTION', b'keep-alive'),
                                 (b'DATE', mock.ANY),
                                 (b'SERVER', mock.ANY))
     resp.close()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -173,13 +173,21 @@ def test_add_headers_hop_headers(transport):
     assert [] == list(msg.headers)
 
 
-def test_default_headers(transport):
+def test_default_headers_http_10(transport):
+    msg = protocol.Response(transport, 200,
+                            http_version=protocol.HttpVersion10)
+    msg._add_default_headers()
+
+    assert 'DATE' in msg.headers
+    assert 'keep-alive' == msg.headers['CONNECTION']
+
+
+def test_default_headers_http_11(transport):
     msg = protocol.Response(transport, 200)
     msg._add_default_headers()
 
-    headers = [r for r, _ in msg.headers.items()]
-    assert 'DATE' in headers
-    assert 'CONNECTION' in headers
+    assert 'DATE' in msg.headers
+    assert 'CONNECTION' not in msg.headers
 
 
 def test_default_headers_server(transport):
@@ -222,13 +230,24 @@ def test_default_headers_connection_close(transport):
     assert [('CONNECTION', 'close')] == headers
 
 
-def test_default_headers_connection_keep_alive(transport):
-    msg = protocol.Response(transport, 200)
+def test_default_headers_connection_keep_alive_http_10(transport):
+    msg = protocol.Response(transport, 200,
+                            http_version=protocol.HttpVersion10)
     msg.keepalive = True
     msg._add_default_headers()
 
     headers = [r for r in msg.headers.items() if r[0] == 'CONNECTION']
     assert [('CONNECTION', 'keep-alive')] == headers
+
+
+def test_default_headers_connection_keep_alive_11(transport):
+    msg = protocol.Response(transport, 200,
+                            http_version=protocol.HttpVersion11)
+    msg.keepalive = True
+    msg._add_default_headers()
+
+    headers = [r for r in msg.headers.items() if r[0] == 'CONNECTION']
+    assert 'CONNECTION' not in headers
 
 
 def test_send_headers(transport):

--- a/tests/test_web_exceptions.py
+++ b/tests/test_web_exceptions.py
@@ -57,7 +57,6 @@ def test_HTTPOk(buf, request):
     assert re.match(('HTTP/1.1 200 OK\r\n'
                      'CONTENT-TYPE: text/plain; charset=utf-8\r\n'
                      'CONTENT-LENGTH: 7\r\n'
-                     'CONNECTION: keep-alive\r\n'
                      'DATE: .+\r\n'
                      'SERVER: .+\r\n\r\n'
                      '200: OK'), txt)
@@ -95,7 +94,6 @@ def test_HTTPFound(buf, request):
                     'CONTENT-TYPE: text/plain; charset=utf-8\r\n'
                     'CONTENT-LENGTH: 10\r\n'
                     'LOCATION: /redirect\r\n'
-                    'CONNECTION: keep-alive\r\n'
                     'DATE: .+\r\n'
                     'SERVER: .+\r\n\r\n'
                     '302: Found', txt)
@@ -122,7 +120,6 @@ def test_HTTPMethodNotAllowed(buf, request):
                     'CONTENT-TYPE: text/plain; charset=utf-8\r\n'
                     'CONTENT-LENGTH: 23\r\n'
                     'ALLOW: POST,PUT\r\n'
-                    'CONNECTION: keep-alive\r\n'
                     'DATE: .+\r\n'
                     'SERVER: .+\r\n\r\n'
                     '405: Method Not Allowed', txt)

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -531,7 +531,7 @@ class TestWebFunctional(WebFunctionalSetupMixin, unittest.TestCase):
         def go():
             _, _, url = yield from self.create_server('GET', '/', handler)
             resp = yield from request('GET', url, loop=self.loop,
-                                      version=HttpVersion10)
+                                      version=HttpVersion11)
             self.assertNotIn('CONNECTION', resp.headers)
             resp.close()
 
@@ -547,11 +547,12 @@ class TestWebFunctional(WebFunctionalSetupMixin, unittest.TestCase):
         @asyncio.coroutine
         def go():
             _, _, url = yield from self.create_server('GET', '/', handler)
-            resp = yield from request('GET', url, loop=self.loop,
-                                      version=HttpVersion10)
-            self.assertEqual(resp.version, HttpVersion10)
-            self.assertEqual('keep-alive', resp.headers['CONNECTION'])
-            resp.close()
+            with ClientSession(loop=self.loop) as session:
+                resp = yield from session.get(url,
+                                              version=HttpVersion10)
+                self.assertEqual(resp.version, HttpVersion10)
+                self.assertEqual('keep-alive', resp.headers['CONNECTION'])
+                resp.close()
 
         self.loop.run_until_complete(go())
 
@@ -587,7 +588,7 @@ class TestWebFunctional(WebFunctionalSetupMixin, unittest.TestCase):
             headers = {'Connection': 'close'}
             resp = yield from request('GET', url, loop=self.loop,
                                       headers=headers, version=HttpVersion10)
-            self.assertEqual('close', resp.headers['CONNECTION'])
+            self.assertNotIn('CONNECTION', resp.headers)
             resp.close()
 
         self.loop.run_until_complete(go())

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -813,7 +813,6 @@ def test_send_headers_for_empty_body():
     yield from resp.write_eof()
     txt = buf.decode('utf8')
     assert re.match('HTTP/1.1 200 OK\r\nCONTENT-LENGTH: 0\r\n'
-                    'CONNECTION: keep-alive\r\n'
                     'DATE: .+\r\nSERVER: .+\r\n\r\n', txt)
 
 
@@ -836,7 +835,6 @@ def test_render_with_body():
     yield from resp.write_eof()
     txt = buf.decode('utf8')
     assert re.match('HTTP/1.1 200 OK\r\nCONTENT-LENGTH: 4\r\n'
-                    'CONNECTION: keep-alive\r\n'
                     'DATE: .+\r\nSERVER: .+\r\n\r\ndata', txt)
 
 
@@ -861,7 +859,6 @@ def test_send_set_cookie_header():
     txt = buf.decode('utf8')
     assert re.match('HTTP/1.1 200 OK\r\nCONTENT-LENGTH: 0\r\n'
                     'SET-COOKIE: name=value\r\n'
-                    'CONNECTION: keep-alive\r\n'
                     'DATE: .+\r\nSERVER: .+\r\n\r\n', txt)
 
 


### PR DESCRIPTION
Fix for #731 

- Enable keepalive for HTTP 1.0 by default
- Disable it for HTTP 0.9 (who cares about 0.9, BTW?)
- For keepalived connections
  - Send `Connection: keep-alive` for HTTP 1.0 only
  - don't send `Connection` header for HTTP 1.1
- For non-keepalived connections
  - Send `Connection: close` for HTTP 1.1 only
  - don't send `Connection` header for HTTP 1.0
