### PR TITLE
fix syntax in same key example

### DIFF
--- a/docs/multidict.rst
+++ b/docs/multidict.rst
@@ -51,9 +51,9 @@ MultiDict
 
    If the same key appears several times it will be added, e.g.::
 
-      >>> d = MultiDict[('a', 1), ('b', 2), ('a', 3)])
+      >>> d = MultiDict([('a', 1), ('b', 2), ('a', 3)])
       >>> d
-      <MultiDict {'a': 1, 'b': 2, 'a': 3}>
+      <MultiDict ('a': 1, 'b': 2, 'a': 3)>
 
    .. method:: len(d)
 


### PR DESCRIPTION
```
>>> d = MultiDict[('a', 1), ('b', 2), ('a', 3)])
  File "<ipython-input-2-f83c203956e2>", line 1
    d = MultiDict[('a', 1), ('b', 2), ('a', 3)])
                                           ^
SyntaxError: invalid syntax
```

After adding the missing '(' between 't' and '[':

```
>>> d = MultiDict([('a', 1), ('b', 2), ('a', 3)])
>>> d
<MultiDict('a': 1, 'b': 2, 'a': 3)>
```