### PR TITLE
Serialize integers in multipart forms

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -655,6 +655,7 @@ class BodyPartWriter(object):
         self._serialize_map = {
             bytes: self._serialize_bytes,
             str: self._serialize_str,
+            int: self._serialize_int,
             io.IOBase: self._serialize_io,
             MultipartWriter: self._serialize_multipart,
             ('application', 'json'): self._serialize_json,
@@ -756,6 +757,9 @@ class BodyPartWriter(object):
     def _serialize_str(self, obj):
         *_, params = parse_mimetype(self.headers.get(CONTENT_TYPE))
         yield obj.encode(params.get('charset', 'us-ascii'))
+
+    def _serialize_int(self, obj):
+        return self._serialize_str(str(obj))
 
     def _serialize_io(self, obj):
         while True:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -772,6 +772,9 @@ class BodyPartWriterTestCase(unittest.TestCase):
     def test_serialize_str(self):
         self.assertEqual(b'foo', next(self.part._serialize_str('foo')))
 
+    def test_serialize_int(self):
+        self.assertEqual(b'42', next(self.part._serialize_int(42)))
+
     def test_serialize_str_custom_encoding(self):
         self.part.headers[CONTENT_TYPE] = \
             'text/plain;charset=cp1251'


### PR DESCRIPTION
I know this change might be too specific, but users coming from requests are used to passing integers without converting them to strings [1].

[1]: https://github.com/kennethreitz/requests/blob/046a0f215de3fac60326ea1c2c9dd30beb329f61/requests/packages/urllib3/filepost.py#L80