### PR TITLE
make new resources classes public

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -25,7 +25,9 @@ from .multidict import upstr
 
 
 __all__ = ('UrlDispatcher', 'UrlMappingMatchInfo',
-           'Resource', 'PlainResource', 'DynamicResource',
+           'AbstractResource', 'Resource', 'PlainResource', 'DynamicResource',
+           'ResourceAdapter',
+           'AbstractRoute', 'ResourceRoute',
            'Route', 'PlainRoute', 'DynamicRoute', 'StaticRoute', 'View')
 
 


### PR DESCRIPTION
These classes are documented as members of aiohttp.web, but they aren't because they are not exported in `__all__`:
`AbstractResource`, `ResourceAdapter`, `AbstractRoute`, `ResourceRoute`.