### PR TITLE
Fix usage of force_close and keepalive_timeout

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -99,6 +99,9 @@ class Connection(object):
         return self._transport is None
 
 
+_marker = object()
+
+
 class BaseConnector(object):
     """Base connector class.
 
@@ -112,7 +115,7 @@ class BaseConnector(object):
     _closed = True  # prevent AttributeError in __del__ if ctor was failed
     _source_traceback = None
 
-    def __init__(self, *, conn_timeout=None, keepalive_timeout=30,
+    def __init__(self, *, conn_timeout=None, keepalive_timeout=None,
                  share_cookies=False, force_close=False, limit=None,
                  loop=None):
         if loop is None:
@@ -125,14 +128,14 @@ class BaseConnector(object):
         self._conns = {}
         self._acquired = defaultdict(set)
         self._conn_timeout = conn_timeout
-        self._keepalive_timeout = keepalive_timeout
+        self._validate_and_assign_keepalive_timeout_with_force_close(
+            keepalive_timeout, force_close)
         if share_cookies:
             warnings.warn(
                 'Using `share_cookies` is deprecated. '
                 'Use Session object instead', DeprecationWarning)
         self._share_cookies = share_cookies
         self._cleanup_handle = None
-        self._force_close = force_close
         self._limit = limit
         self._waiters = defaultdict(list)
 
@@ -142,6 +145,48 @@ class BaseConnector(object):
             disconnect_error=ServerDisconnectedError)
 
         self.cookies = http.cookies.SimpleCookie()
+
+    def _validate_and_assign_keepalive_timeout_with_force_close(
+            self, keepalive_timeout, force_close):
+        if keepalive_timeout is not _marker and force_close is not _marker:
+            # if keepalive and force_close are something different
+            # rather than object class instance
+            if keepalive_timeout and force_close:
+                # if both keepalive and force_close
+                # were passed as positive values
+                raise ValueError("Can't accept both 'force_close=True' "
+                                 "and 'keepalive_timeout={0}'"
+                                 .format(keepalive_timeout))
+            decide = (keepalive_timeout != 0.0 and keepalive_timeout
+                      is not None and not force_close)
+            self._force_close = False if decide else True
+            self._keepalive_timeout = keepalive_timeout if decide else 0.0
+        elif keepalive_timeout is not _marker:
+            # if only keepalive was passed as something different
+            # rather than object class instance
+            self._force_close = False
+            if not isinstance(keepalive_timeout, float):
+                # if keepalive is not a float
+                if keepalive_timeout is None:
+                    # possibly keepalive can be None
+                    self._keepalive_timeout = 0.0
+                else:
+                    # if keepalive is not float and not None
+                    raise TypeError("keepalive_timeout: float required.")
+            else:
+                self._keepalive_timeout = keepalive_timeout
+        elif force_close is not _marker:
+            # if force_close is something different from object class instance
+            if not isinstance(force_close, bool):
+                raise TypeError("force_close: bool required.")
+            else:
+                self._force_close = force_close
+                self._keepalive_timeout = 0.0 if force_close else 30.0
+        elif keepalive_timeout is _marker and force_close is _marker:
+            # if keepalive was not passed - using default value (30.0 secs)
+            # and force_close set to False
+            self._keepalive_timeout = 30.0
+            self._force_close = False
 
     def __del__(self, _warnings=warnings):
         if self._closed:
@@ -391,8 +436,6 @@ class BaseConnector(object):
 
 
 _SSL_OP_NO_COMPRESSION = getattr(ssl, "OP_NO_COMPRESSION", 0)
-
-_marker = object()
 
 
 class TCPConnector(BaseConnector):

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -38,7 +38,7 @@ def test_keepalive_two_requests_success(create_app_and_client):
     resp2 = yield from client.get('/')
     yield from resp2.read()
 
-    assert 1 == len(client._session.connector._conns)
+    assert 0 == len(client._session.connector._conns)
 
 
 @pytest.mark.run_loop
@@ -57,7 +57,7 @@ def test_keepalive_response_released(create_app_and_client):
     resp2 = yield from client.get('/')
     yield from resp2.release()
 
-    assert 1 == len(client._session.connector._conns)
+    assert 0 == len(client._session.connector._conns)
 
 
 @pytest.mark.run_loop

--- a/tests/test_client_functional_oldstyle.py
+++ b/tests/test_client_functional_oldstyle.py
@@ -868,7 +868,8 @@ class TestHttpClientFunctional(unittest.TestCase):
     def test_keepalive(self):
         from aiohttp import connector
         with self.assertWarns(DeprecationWarning):
-            c = connector.TCPConnector(share_cookies=True, loop=self.loop)
+            c = connector.TCPConnector(share_cookies=True, loop=self.loop,
+                                       keepalive_timeout=30.0)
 
         with test_utils.run_server(self.loop, router=Functional) as httpd:
             r = self.loop.run_until_complete(
@@ -976,7 +977,8 @@ class TestHttpClientFunctional(unittest.TestCase):
 
         @asyncio.coroutine
         def go(url):
-            connector = aiohttp.TCPConnector(loop=self.loop)
+            connector = aiohttp.TCPConnector(
+                loop=self.loop, keepalive_timeout=30.0)
 
             r = yield from client.request('GET', url,
                                           connector=connector,
@@ -1061,7 +1063,8 @@ class TestHttpClientFunctional(unittest.TestCase):
 
             addr = server.sockets[0].getsockname()
 
-            connector = aiohttp.TCPConnector(loop=self.loop)
+            connector = aiohttp.TCPConnector(
+                loop=self.loop, keepalive_timeout=30.0)
 
             url = 'http://{}:{}/'.format(*addr)
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -135,7 +135,8 @@ class TestBaseConnector(unittest.TestCase):
         self.assertTrue(conn.closed)
 
     def test_get(self):
-        conn = aiohttp.BaseConnector(loop=self.loop)
+        conn = aiohttp.BaseConnector(loop=self.loop,
+                                     keepalive_timeout=30.0)
         self.assertEqual(conn._get(1), (None, None))
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
@@ -156,7 +157,8 @@ class TestBaseConnector(unittest.TestCase):
     def test_release(self):
         self.loop.time = mock.Mock(return_value=10)
 
-        conn = aiohttp.BaseConnector(loop=self.loop)
+        conn = aiohttp.BaseConnector(loop=self.loop,
+                                     keepalive_timeout=30.0)
         conn._start_cleanup_task = unittest.mock.Mock()
         req = unittest.mock.Mock()
         resp = req.response = unittest.mock.Mock()
@@ -235,7 +237,8 @@ class TestBaseConnector(unittest.TestCase):
     def test_release_not_started(self):
         self.loop.time = mock.Mock(return_value=10)
 
-        conn = aiohttp.BaseConnector(loop=self.loop)
+        conn = aiohttp.BaseConnector(loop=self.loop,
+                                     keepalive_timeout=30.0)
         req = unittest.mock.Mock()
         req.response = None
 
@@ -269,7 +272,8 @@ class TestBaseConnector(unittest.TestCase):
             ssl = False
             response = unittest.mock.Mock()
 
-        conn = aiohttp.BaseConnector(loop=self.loop)
+        conn = aiohttp.BaseConnector(loop=self.loop,
+                                     keepalive_timeout=30.0)
         key = ('host', 80, False)
         conn._conns[key] = [(tr, proto, self.loop.time())]
         conn._create_connection = unittest.mock.Mock()
@@ -581,7 +585,9 @@ class TestBaseConnector(unittest.TestCase):
             max_connections = 2
             num_connections = 0
 
-            conn = aiohttp.BaseConnector(limit=max_connections, loop=self.loop)
+            conn = aiohttp.BaseConnector(limit=max_connections,
+                                         loop=self.loop,
+                                         keepalive_timeout=30.0)
 
             # Use a real coroutine for _create_connection; a mock would mask
             # problems that only happen when the method yields.
@@ -671,7 +677,7 @@ class TestBaseConnector(unittest.TestCase):
 
     def test_default_force_close(self):
         connector = aiohttp.BaseConnector(loop=self.loop)
-        self.assertFalse(connector.force_close)
+        self.assertTrue(connector.force_close)
 
     def test_limit_property(self):
         conn = aiohttp.BaseConnector(loop=self.loop, limit=15)
@@ -763,7 +769,8 @@ class TestHttpClientConnector(unittest.TestCase):
 
         port = self.find_unused_port()
         conn = aiohttp.TCPConnector(loop=self.loop,
-                                    local_addr=('127.0.0.1', port))
+                                    local_addr=('127.0.0.1', port),
+                                    keepalive_timeout=30.0)
 
         r = self.loop.run_until_complete(
             aiohttp.request(


### PR DESCRIPTION
Fix usage of both keepalive_timeout and force_close for BaseClient initialisation.
This patch addresses #786
