### PR TITLE
Fixed bug in serving static directory

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -571,7 +571,7 @@ class StaticRoute(Route):
 
         # Make sure that filepath is a file
         if not filepath.is_file():
-            raise HTTPNotFound() 
+            raise HTTPNotFound()
 
         st = filepath.stat()
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -569,6 +569,10 @@ class StaticRoute(Route):
             request.logger.exception(error)
             raise HTTPNotFound() from error
 
+        # Make sure that filepath is a file
+        if not filepath.is_file():
+            raise HTTPNotFound() 
+
         st = filepath.stat()
 
         modsince = request.if_modified_since

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -1,0 +1,103 @@
+import pytest
+import tempfile
+import aiohttp
+from aiohttp import web
+import os
+import shutil
+import asyncio
+
+SERVER_HOST = '127.0.0.1'
+SERVER_PORT = 8080
+
+# Timeout in seconds for an asynchronous test:
+ASYNC_TEST_TIMEOUT = 1
+
+class ExceptAsyncTestTimeout(Exception): pass
+
+def run_timeout(cor,loop,timeout=ASYNC_TEST_TIMEOUT):
+    """
+    Run a given coroutine with timeout.
+    """
+    task_with_timeout = asyncio.wait_for(cor,timeout,loop=loop)
+    try:
+        return loop.run_until_complete(task_with_timeout)
+    except asyncio.futures.TimeoutError:
+        # Timeout:
+        raise ExceptAsyncTestTimeout()
+
+
+@pytest.fixture(scope='function')
+def tloop(request):
+    """
+    Obtain a test loop. We want each test case to have its own loop.
+    """
+    # Create a new test loop:
+    tloop = asyncio.new_event_loop()
+    asyncio.set_event_loop(None)
+
+    def teardown():
+        # Close the test loop:
+        tloop.close()
+
+    request.addfinalizer(teardown)
+    return tloop
+
+
+@pytest.fixture(scope='function')
+def tmp_dir_path(request):
+    """
+    Give a path for a temporary directory
+    The directory is destroyed at the end of the test.
+    """
+    # Temporary directory.
+    tmp_dir = tempfile.mkdtemp()
+
+    def teardown():
+        # Delete the whole directory:
+        shutil.rmtree(tmp_dir)
+
+    request.addfinalizer(teardown)
+    return tmp_dir
+
+
+def test_access_root_of_static_handler(tloop,tmp_dir_path):
+    """
+    Tests the operation of static file server.
+    Try to access the root of static file server, and make
+    sure that a proper not found error is returned.
+    """
+    # Put a file inside tmp_dir_path:
+    my_file_path = os.path.join(tmp_dir_path,'my_file')
+    with open(my_file_path,'w') as fw:
+        fw.write('hello')
+
+    asyncio.set_event_loop(None)
+    app = web.Application(loop=tloop)
+    # Register global static route:
+    app.router.add_static('/', tmp_dir_path)
+
+    @asyncio.coroutine
+    def inner_cor():
+        handler = app.make_handler()
+        srv = yield from tloop.create_server(handler,\
+                SERVER_HOST,SERVER_PORT ,reuse_address=True) 
+
+        # Request the root of the static directory.
+        # Expect an 404 error page.
+        url = 'http://{}:{}/'.format(\
+                SERVER_HOST,SERVER_PORT) 
+
+        r = ( yield from aiohttp.get(url,loop=tloop) )
+        assert r.status == 404
+        # data = (yield from r.read())
+        yield from r.release()
+
+        srv.close()
+        yield from srv.wait_closed()
+
+        yield from app.shutdown()
+        yield from handler.finish_connections(10.0)
+        yield from app.cleanup()
+
+
+    run_timeout(inner_cor(),tloop,timeout=5)

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -6,9 +6,6 @@ import os
 import shutil
 import asyncio
 
-SERVER_HOST = '127.0.0.1'
-SERVER_PORT = 8080
-
 # Timeout in seconds for an asynchronous test:
 ASYNC_TEST_TIMEOUT = 1
 
@@ -60,12 +57,15 @@ def tmp_dir_path(request):
     return tmp_dir
 
 
-def test_access_root_of_static_handler(tloop,tmp_dir_path):
+def test_access_root_of_static_handler(tloop, tmp_dir_path, unused_port):
     """
     Tests the operation of static file server.
     Try to access the root of static file server, and make
     sure that a proper not found error is returned.
     """
+    SERVER_PORT = unused_port()
+    SERVER_HOST = 'localhost'
+
     # Put a file inside tmp_dir_path:
     my_file_path = os.path.join(tmp_dir_path,'my_file')
     with open(my_file_path,'w') as fw:

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -9,13 +9,16 @@ import asyncio
 # Timeout in seconds for an asynchronous test:
 ASYNC_TEST_TIMEOUT = 1
 
-class ExceptAsyncTestTimeout(Exception): pass
 
-def run_timeout(cor,loop,timeout=ASYNC_TEST_TIMEOUT):
+class ExceptAsyncTestTimeout(Exception):
+    pass
+
+
+def run_timeout(cor, loop, timeout=ASYNC_TEST_TIMEOUT):
     """
     Run a given coroutine with timeout.
     """
-    task_with_timeout = asyncio.wait_for(cor,timeout,loop=loop)
+    task_with_timeout = asyncio.wait_for(cor, timeout, loop=loop)
     try:
         return loop.run_until_complete(task_with_timeout)
     except asyncio.futures.TimeoutError:
@@ -67,8 +70,8 @@ def test_access_root_of_static_handler(tloop, tmp_dir_path, unused_port):
     SERVER_HOST = 'localhost'
 
     # Put a file inside tmp_dir_path:
-    my_file_path = os.path.join(tmp_dir_path,'my_file')
-    with open(my_file_path,'w') as fw:
+    my_file_path = os.path.join(tmp_dir_path, 'my_file')
+    with open(my_file_path, 'w') as fw:
         fw.write('hello')
 
     asyncio.set_event_loop(None)
@@ -79,15 +82,14 @@ def test_access_root_of_static_handler(tloop, tmp_dir_path, unused_port):
     @asyncio.coroutine
     def inner_cor():
         handler = app.make_handler()
-        srv = yield from tloop.create_server(handler,\
-                SERVER_HOST,SERVER_PORT ,reuse_address=True) 
+        srv = yield from tloop.create_server(
+            handler, SERVER_HOST, SERVER_PORT, reuse_address=True)
 
         # Request the root of the static directory.
         # Expect an 404 error page.
-        url = 'http://{}:{}/'.format(\
-                SERVER_HOST,SERVER_PORT) 
+        url = 'http://{}:{}/'.format(SERVER_HOST, SERVER_PORT)
 
-        r = ( yield from aiohttp.get(url,loop=tloop) )
+        r = (yield from aiohttp.get(url, loop=tloop))
         assert r.status == 404
         # data = (yield from r.read())
         yield from r.release()
@@ -99,5 +101,4 @@ def test_access_root_of_static_handler(tloop, tmp_dir_path, unused_port):
         yield from handler.finish_connections(10.0)
         yield from app.cleanup()
 
-
-    run_timeout(inner_cor(),tloop,timeout=5)
+    run_timeout(inner_cor(), tloop, timeout=5)


### PR DESCRIPTION
When using app.add_static(...) to serve a directory, if the root of the directory is requested, the connection between the server and client is crashed.
This happens because the server tries to read a directory using open with 'rb' and fails.

The fix first makes sure that the requested resource is a file. If it is not a file, it returns a 404 error. I think this is the correct behaviour, feel free to change it if you think it should be something else.

I also include a relevant test case, to avoid regressions with this problem.