### PR TITLE
Add issue and pull request GitHub templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Long story short
+
+<!-- Please describe your problem and why the fix is important. -->
+
+## Expected behaviour
+
+<!-- What the behaviour did you expect? -->
+
+## Actual behaviour
+
+<!-- What's actually happened? -->
+
+## Steps to reproduce
+
+<!-- Please describe steps to reproduce the issue.
+     If you have a script that does that please include it here within
+     markdown code markup -->
+
+## Your environment
+
+<!-- Describe the environment you have that leed to your issue.
+     This includes project version, OS, proxy server and else bits that
+     are related to your case. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!-- Thank you for your contribution!
+
+     Before submit your Pull Request, make sure you picked
+     the right branch:
+
+     - If you propose a new feature or improvement, select "master"
+       as a target branch;
+     - If this is code bug fix or documentation correction, select
+       the lastest release branch (which looks like "0.xx") -->
+
+## What these changes does?
+
+<!-- Please give a short brief about these changes. -->
+
+## How to test your changes?
+
+<!-- Describe how we can test your changes if they provides
+     any notable behaviour for the end users. -->
+
+## Related issue number
+
+<!-- Is there any issue opened that get fixed by this? -->
+
+## Checklist
+
+- [ ] Code is written and well
+- [ ] Tests for the changes are provided
+- [ ] Documentation reflects the changes


### PR DESCRIPTION
Following the new GitHub [feature](https://github.com/blog/2111-issue-and-pull-request-templates). I didn't found any good or standard content for these (I was like the one that Google Code had, but those get lost by known reasons), so it's open for discussion and improvements (: