### PR TITLE
URL encode problem:quote url first in order to encode unreserve characters

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -83,7 +83,7 @@ class ClientRequest:
             self._source_traceback = traceback.extract_stack(sys._getframe(1))
 
         self.update_version(version)
-        self.update_host(self.url)
+        self.update_host(url)
         self.update_path(params)
         self.update_headers(headers)
         self.update_auto_headers(skip_auto_headers)

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -71,7 +71,7 @@ class ClientRequest:
         if loop is None:
             loop = asyncio.get_event_loop()
 
-        self.url = url
+        self.url = helpers.requote_uri(url)
         self.method = method.upper()
         self.encoding = encoding
         self.chunked = chunked
@@ -83,7 +83,7 @@ class ClientRequest:
             self._source_traceback = traceback.extract_stack(sys._getframe(1))
 
         self.update_version(version)
-        self.update_host(url)
+        self.update_host(self.url)
         self.update_path(params)
         self.update_headers(headers)
         self.update_auto_headers(skip_auto_headers)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is code bug fix or documentation correction, select
       the lastest release branch (which looks like "0.xx") -->

## What these changes does?
  Just change two line in client_reqrep.py, the 74 and 86 line to quote url 
<!-- Please give a short brief about these changes. -->

## How to test your changes?
Before my change, it's unable to get the 
```
http://www.gilt.com/search?q.query=Sam Edelman&q.rows=48&q.category=womens-coats&q.start=-48
```
because the url contains blank. After it can.  the simple testfile can be found in my [issue808](https://github.com/KeepSafe/aiohttp/issues/808)
<!-- Describe how we can test your changes if they provides
     any notable behaviour for the end users. -->

## Related issue number
 [issue808](https://github.com/KeepSafe/aiohttp/issues/808)
<!-- Is there any issue opened that get fixed by this? -->

## Checklist

- [ ] Code is written and well
- [ ] Tests for the changes are provided
Tests for the changes are provided
- [ ] Documentation reflects the changes

