### PR TITLE
UrlDispatcher.add_route with partial coroutine handler

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -93,7 +93,13 @@ class AbstractRoute(abc.ABC):
               issubclass(handler, AbstractView)):
             pass
         else:
-            handler = asyncio.coroutine(handler)
+            @asyncio.coroutine
+            def handler_wrapper(*args, **kwargs):
+                result = handler(*args, **kwargs)
+                if asyncio.iscoroutine(result):
+                    result = yield from result
+                return result
+            handler = handler_wrapper
 
         self._method = method
         self._handler = handler

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -95,10 +95,11 @@ class AbstractRoute(abc.ABC):
         else:
             @asyncio.coroutine
             def handler_wrapper(*args, **kwargs):
-                result = handler(*args, **kwargs)
+                result = old_handler(*args, **kwargs)
                 if asyncio.iscoroutine(result):
                     result = yield from result
                 return result
+            old_handler = handler
             handler = handler_wrapper
 
         self._method = method

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -2,6 +2,9 @@ import pytest
 import os
 import shutil
 import tempfile
+import functools
+import asyncio
+import aiohttp.web
 
 
 @pytest.fixture(scope='function')
@@ -43,4 +46,20 @@ def test_access_root_of_static_handler(tmp_dir_path, create_app_and_client):
     r = yield from client.get('/')
     assert r.status == 404
     # data = (yield from r.read())
+    yield from r.release()
+
+
+@pytest.mark.run_loop
+def test_partialy_applied_handler(create_app_and_client):
+    app, client = yield from create_app_and_client()
+
+    @asyncio.coroutine
+    def handler(data, request):
+        return aiohttp.web.Response(body=data)
+
+    app.router.add_route('GET', '/', functools.partial(handler, b'hello'))
+
+    r = yield from client.get('/')
+    data = (yield from r.read())
+    assert data == b'hello'
     yield from r.release()


### PR DESCRIPTION
fix for problem when partialy applied coroutine is used as handler for UrlDispatcher.add_route

similar issue:
http://bugs.python.org/issue23519