### PR TITLE
Allow to pass None as a timeout value to disable timeout logic

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -477,7 +477,7 @@ class Timeout:
         if self._task is None:
             raise RuntimeError('Timeout context manager should be used '
                                'inside a task')
-        if self._timeout:
+        if self._timeout is not None:
             self._cancel_handler = self._loop.call_later(
                 self._timeout, self._cancel_task)
         return self
@@ -487,7 +487,7 @@ class Timeout:
             self._cancel_handler = None
             self._task = None
             raise asyncio.TimeoutError
-        if self._timeout:
+        if self._timeout is not None:
             self._cancel_handler.cancel()
             self._cancel_handler = None
         self._task = None

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -460,7 +460,7 @@ class Timeout:
     ...         await r.text()
 
 
-    :param timeout: timeout value in seconds
+    :param timeout: timeout value in seconds or None to disable timeout logic
     :param loop: asyncio compatible event loop
     """
     def __init__(self, timeout, *, loop=None):
@@ -477,8 +477,9 @@ class Timeout:
         if self._task is None:
             raise RuntimeError('Timeout context manager should be used '
                                'inside a task')
-        self._cancel_handler = self._loop.call_later(
-            self._timeout, self._cancel_task)
+        if self._timeout:
+            self._cancel_handler = self._loop.call_later(
+                self._timeout, self._cancel_task)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -486,8 +487,9 @@ class Timeout:
             self._cancel_handler = None
             self._task = None
             raise asyncio.TimeoutError
-        self._cancel_handler.cancel()
-        self._cancel_handler = None
+        if self._timeout:
+            self._cancel_handler.cancel()
+            self._cancel_handler = None
         self._task = None
 
     def _cancel_task(self):

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -50,15 +50,14 @@ def test_timeout_global_loop(loop):
     loop.run_until_complete(run())
 
 
-@pytest.mark.parametrize("delay", [None, 0])
 @pytest.mark.run_loop
-def test_timeout_disable(loop, delay):
+def test_timeout_disable(loop):
     @asyncio.coroutine
     def long_running_task():
         yield from asyncio.sleep(0.1, loop=loop)
         return 'done'
 
-    with Timeout(delay, loop=loop):
+    with Timeout(None, loop=loop):
         resp = yield from long_running_task()
     assert resp == 'done'
 

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -50,6 +50,19 @@ def test_timeout_global_loop(loop):
     loop.run_until_complete(run())
 
 
+@pytest.mark.parametrize("delay", [None, 0])
+@pytest.mark.run_loop
+def test_timeout_disable(loop, delay):
+    @asyncio.coroutine
+    def long_running_task():
+        yield from asyncio.sleep(0.1, loop=loop)
+        return 'done'
+
+    with Timeout(delay, loop=loop):
+        resp = yield from long_running_task()
+    assert resp == 'done'
+
+
 @pytest.mark.run_loop
 def test_timeout_not_relevant_exception(loop):
     yield from asyncio.sleep(0, loop=loop)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is code bug fix or documentation correction, select
       the lastest release branch (which looks like "0.xx") -->

## What these changes does?
Allows to pass `None` as a timeout value to disable timeout logic.

In some cases there is needed to disable timeout logic but keep it in convenient code structure without ugly if-branching like this:

```
if delay:
    with aiohttp.Timeout(delay):
        async with session.get(url) as response:
            pass  # ...
else:
    async with session.get(url) as response:
        pass  # ...
```

Now it is able to use the same code for both numerical and `None` timeout values:

```
for delay in [None, 0, 0.1, 1]:
    with aiohttp.Timeout(delay):
        async with session.get(url) as response:
            pass  # ...

```

This behaviour is similar to `asyncio.wait_for(fut, timeout, *, loop=None)` coroutine, which takes `None` as a timeout value to block until the future completes.

## How to test your changes?

There is a test in `test_timeout.py`: `test_timeout_disable`.

## Related issue number

None.

## Checklist

- [x] Code is written and well
- [x] Tests for the changes are provided
- [x] Documentation reflects the changes
