### PR TITLE
Don't send body in response to HEAD request

### DIFF
--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -851,11 +851,15 @@ class Response(StreamResponse):
 
         self.body = text.encode(self.charset)
 
+    def should_send_body(self):
+        return (self._req.method.lower() != 'head' and
+                self._status not in [204, 304])
+
     @asyncio.coroutine
     def write_eof(self):
         try:
             body = self._body
-            if body is not None:
+            if body is not None and self.should_send_body():
                 self.write(body)
         finally:
             self.set_tcp_nodelay(True)

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -852,7 +852,7 @@ class Response(StreamResponse):
         self.body = text.encode(self.charset)
 
     def should_send_body(self):
-        return (self._req.method.lower() != 'head' and
+        return (self._req.method != hdrs.METH_HEAD and
                 self._status not in [204, 304])
 
     @asyncio.coroutine


### PR DESCRIPTION
## What these changes does?

Skips sending Response body when request method is HEAD or status code is 204 or 304. Satisfies requirements of RFC7230 an RFC7231 that server MUST NOT send message body in such responses.

## How to test your changes?

Test case is included: 
test_head_returns_empty_body (tests/test_web_functional.py)

## Related issue number

Problems with HEAD responses #820 

## Checklist

- [x] Code is written and well
- [x] Tests for the changes are provided
- [ ] Documentation reflects the changes

