### PR TITLE
Add AbstractRequest

### DIFF
--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -68,3 +68,141 @@ class AbstractResolver(ABC):
     @abstractmethod
     def close(self):
         """Release resolver"""
+
+
+class AbstractRequest(ABC):
+
+    @property
+    @abstractmethod
+    def scheme(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def method(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def version(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def host(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def path_qs(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def _splitted_path(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def raw_path(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def path(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def query_string(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def GET(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def POST(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def headers(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def raw_headers(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def if_modified_since(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def keep_alive(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def match_info(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def app(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def transport(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def cookies(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def payload(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def content(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def has_body(self):
+        raise NotImplementedError
+
+    @asyncio.coroutine
+    @abstractmethod
+    def release(self):
+        raise NotImplementedError
+
+    @asyncio.coroutine
+    @abstractmethod
+    def read(self):
+        raise NotImplementedError
+
+    @asyncio.coroutine
+    @abstractmethod
+    def text(self):
+        raise NotImplementedError
+
+    @asyncio.coroutine
+    @abstractmethod
+    def json(self):
+        raise NotImplementedError
+
+    @asyncio.coroutine
+    @abstractmethod
+    def post(self):
+        raise NotImplementedError

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -22,6 +22,7 @@ from multidict import (CIMultiDictProxy,
                        MultiDict)
 
 from . import hdrs
+from .abc import AbstractRequest
 from .helpers import reify
 from .protocol import Response as ResponseImpl, HttpVersion10, HttpVersion11
 from .streams import EOF_MARKER
@@ -94,7 +95,7 @@ class ContentCoding(enum.Enum):
 ############################################################
 
 
-class Request(dict, HeadersMixin):
+class Request(AbstractRequest, dict, HeadersMixin):
 
     POST_METHODS = {hdrs.METH_PATCH, hdrs.METH_POST, hdrs.METH_PUT,
                     hdrs.METH_TRACE, hdrs.METH_DELETE}


### PR DESCRIPTION
Closes (I hope) https://github.com/KeepSafe/aiohttp/issues/771

I've added `abc.AbstractRequest` with the same methods that are defined for `web.Request`
Maybe we should remove some of them, like `_splitted_path` or make it not protected?

I have not added functional tests and no doc changes were made.

Please note which tests should be written.