### PR TITLE
Remove fragment string in request path

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -177,9 +177,9 @@ class ClientRequest:
                 query = params
 
         self.path = urllib.parse.urlunsplit(('', '', helpers.requote_uri(path),
-                                             query, fragment))
+                                             query, ''))
         self.url = urllib.parse.urlunsplit(
-            (scheme, netloc, self.path, '', ''))
+            (scheme, netloc, self.path, '', fragment))
 
     def update_headers(self, headers):
         """Update request headers."""

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -312,13 +312,23 @@ def test_path_safe_chars_preserved(make_request):
 def test_params_are_added_before_fragment1(make_request):
     req = make_request('GET', "http://example.com/path#fragment",
                        params={"a": "b"})
-    assert req.path == "/path?a=b#fragment"
+    assert req.url == "http://example.com/path?a=b#fragment"
 
 
 def test_params_are_added_before_fragment2(make_request):
     req = make_request('GET', "http://example.com/path?key=value#fragment",
                        params={"a": "b"})
-    assert req.path == "/path?key=value&a=b#fragment"
+    assert req.url == "http://example.com/path?key=value&a=b#fragment"
+
+
+def test_path_not_contain_fragment1(make_request):
+    req = make_request('GET', "http://example.com/path#fragment")
+    assert req.path == "/path"
+
+
+def test_path_not_contain_fragment2(make_request):
+    req = make_request('GET', "http://example.com/path?key=value#fragment")
+    assert req.path == "/path?key=value"
 
 
 def test_cookies(make_request):


### PR DESCRIPTION
## What these changes does?

It remove the fragment string begin with `#` in request.path.
This should not be sent to the server with the url

The request.url still keeps the original format.

## How to test your changes?

Sample code:
```python
import asyncio
import aiohttp

async def test_request():
    with aiohttp.ClientSession() as session:
        async with session.get('http://127.0.0.1:8000/test#123') as resp:
            print(resp)

loop = asyncio.get_event_loop()
loop.run_until_complete(test_request())
```

1. Run a local server first: `python3 -m http.server`
2. Run the sample code above.
3. Check the message of the server, original will be `127.0.0.1 - - ... "GET /test#123 HTTP/1.1" 404 -`, fixed will be `127.0.0.1 - - ... "GET /test HTTP/1.1" 404 -`

## Related issue number

#824 

## Checklist

- [x] Code is written and well
- [x] Tests for the changes are provided
- [x] Documentation reflects the changes
