### PR TITLE
Respect CONNECT method to implement a proxy server

### DIFF
--- a/aiohttp/server.py
+++ b/aiohttp/server.py
@@ -252,7 +252,13 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
                     self._timeout_handle = None
 
                 # request may not have payload
-                if (message.headers.get(hdrs.CONTENT_LENGTH, 0) or
+                try:
+                    content_length = int(message.headers.get(hdrs.CONTENT_LENGTH, 0))
+                except ValueError:
+                    content_length = 0
+
+                if (content_length > 0 or
+                    message.method == 'CONNECT' or
                     hdrs.SEC_WEBSOCKET_KEY1 in message.headers or
                     'chunked' in message.headers.get(
                         hdrs.TRANSFER_ENCODING, '')):


### PR DESCRIPTION
To be able to implement an HTTP tunneling proxy the payload received on the app logic should be wired to the actual stream and not the `EMPTY_PAYLOAD` one. Of course it would still need to modify the parser in the same way the WebSocket implementation works.

Also added some hardening for the `Content-Length` header being `"0"` or some other weird value.