### PR TITLE
Drop initial query parameters on redirects

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -234,6 +234,7 @@ class ClientSession:
                     r_url = urllib.parse.urljoin(url, r_url)
 
                 url = r_url
+                params = None
                 yield from resp.release()
                 continue
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -133,7 +133,8 @@ The client session supports context manager protocol for self closing.
 
       :param params: Mapping, iterable of tuple of *key*/*value* pairs or
                      string to be sent as parameters in the query
-                     string of the new request (optional)
+                     string of the new request. Ignored for subsequent
+                     redirected requests (optional)
 
                      Allowed values are:
 


### PR DESCRIPTION
## What these changes does?

This drops query parameters specified in the `params` keyword argument when following a redirect so that the redirected URL is not mistakenly modified.

## How to test your changes?
Test case is included: 
`test_drop_params_on_redirect` (tests/test_client_functional.py)

## Checklist
- [x] Code is written and well
- [x] Tests for the changes are provided
- [x] Documentation reflects the changes

