### PR TITLE
'request.logger' > 'request.app.logger' in StaticFileMixin

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -566,7 +566,7 @@ class StaticRoute(Route):
             raise HTTPNotFound() from error
         except Exception as error:
             # perm error or other kind!
-            request.logger.exception(error)
+            request.app.logger.exception(error)
             raise HTTPNotFound() from error
 
         st = filepath.stat()

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -836,6 +836,10 @@ class StaticFileMixin(WebFunctionalSetupMixin):
             self.assertEqual(404, resp.status)
             resp.close()
 
+            resp = yield from request('GET', url + 'x' * 500, loop=self.loop)
+            self.assertEqual(404, resp.status)
+            resp.close()
+
             resp = yield from request('GET', url + '/../../', loop=self.loop)
             self.assertEqual(404, resp.status)
             resp.close()


### PR DESCRIPTION
(I believe this error exists on master too, but i'm using 0.21 as base as per the instructions).

## What these changes does?

prevent 500 exception with extremely long url requests to the static file router.

This is a slightly ugly way of getting the error to occur, presumably there are other causes of a suitable exception, but this how I found the error and seems to demonstrate the point.

The code causing the error was not previously covered.

## How to test your changes?

see test below

## Checklist

- [ ] Code is written and well
- [ ] Tests for the changes are provided
- [ ] Documentation reflects the changes
