### PR TITLE
fixed request.json() method to properly return json object

### DIFF
--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -332,7 +332,12 @@ class Request(dict, HeadersMixin):
                 DeprecationWarning)
             loads = loader
         body = yield from self.text()
-        return loads(body)
+        parsed_body = parse_qs(body)
+        # parsed_body is null if body is not a querystring, i.e. client sends json object
+        if not parsed_body:
+            return loads(body)
+        else:
+            return loads(json.dumps(parsed_body))
 
     @asyncio.coroutine
     def post(self):

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -333,7 +333,8 @@ class Request(dict, HeadersMixin):
             loads = loader
         body = yield from self.text()
         parsed_body = parse_qs(body)
-        # parsed_body is null if body is not a querystring, i.e. client sends json object
+        # parsed_body is null if body is not a querystring
+        #i.e. client sends json object
         if not parsed_body:
             return loads(body)
         else:

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -14,7 +14,7 @@ import enum
 
 from email.utils import parsedate
 from types import MappingProxyType
-from urllib.parse import urlsplit, parse_qsl, unquote
+from urllib.parse import urlsplit, parse_qsl, parse_qs, unquote
 
 from multidict import (CIMultiDictProxy,
                        CIMultiDict,


### PR DESCRIPTION
previously request.json() failed because request.text() returned a querystring from form data and json.loads expects a proper json string