### PR TITLE
Skip DNS resolving if provided host is already an ip address

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1,5 +1,6 @@
 import asyncio
 import aiohttp
+import ipaddress
 import functools
 import http.cookies
 import ssl
@@ -554,7 +555,7 @@ class TCPConnector(BaseConnector):
 
     @asyncio.coroutine
     def _resolve_host(self, host, port):
-        if not self._use_resolver:
+        if not self._use_resolver or self._host_is_ip(host):
             return [{'hostname': host, 'host': host, 'port': port,
                      'family': self._family, 'proto': 0, 'flags': 0}]
 
@@ -572,6 +573,13 @@ class TCPConnector(BaseConnector):
             res = yield from self._resolver.resolve(
                 host, port, family=self._family)
             return res
+
+    def _host_is_ip(self, host):
+        try:
+            ipaddress.ip_address(host)
+            return True
+        except ValueError:
+            return False
 
     @asyncio.coroutine
     def _create_connection(self, req):

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -839,3 +839,18 @@ class TestHttpClientConnector(unittest.TestCase):
         self.assertTrue(conn.use_dns_cache)
         with self.assertWarns(DeprecationWarning):
             self.assertTrue(conn.resolve)
+
+    def test_resolver_not_called_with_address_is_ip(self):
+        resolver = unittest.mock.MagicMock()
+        connector = aiohttp.TCPConnector(resolver=resolver, loop=self.loop)
+
+        class Req:
+            host = '127.0.1.2'
+            port = 63830
+            ssl = False
+            response = unittest.mock.Mock()
+
+        with self.assertRaises(OSError):
+            self.loop.run_until_complete(connector.connect(Req()))
+
+        resolver.resolve.assert_not_called()


### PR DESCRIPTION
When using the AsyncResolver, there is a DNSError when trying to access a url where the host is an ip address.

This patch skips the resolver step if the host is an ip address.

An alternative would have been to move the same patch to the AsyncResolver, but other resolvers would likely have the same issue. Also, there was also a condition formatting the result properly in the TCPConnector.