### PR TITLE
Implement a gunicorn worker that uses uvloop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ install:
   - pip install -r requirements-ci.txt
   - pip install aiodns
   - pip install coveralls
+  - if python -c "import sys; sys.exit(sys.version_info < (3,5))"; then
+        pip install uvloop;
+    fi
 
 script:
   - flake8 aiohttp

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -9,7 +9,7 @@ import gunicorn.workers.base as base
 
 from aiohttp.helpers import ensure_future
 
-__all__ = ('GunicornWebWorker',)
+__all__ = ('GunicornWebWorker', 'GunicornUVLoopWebWorker')
 
 
 class GunicornWebWorker(base.Worker):
@@ -129,3 +129,20 @@ class GunicornWebWorker(base.Worker):
     def handle_abort(self, sig, frame):
         self.alive = False
         self.exit_code = 1
+
+
+class GunicornUVLoopWebWorker(GunicornWebWorker):
+
+    def init_process(self):
+        import uvloop
+
+        # Close any existing event loop before setting a
+        # new policy.
+        asyncio.get_event_loop().close()
+
+        # Setup uvloop policy, so that every
+        # asyncio.get_event_loop() will create an instance
+        # of uvloop event loop.
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+        super().init_process()

--- a/docs/gunicorn.rst
+++ b/docs/gunicorn.rst
@@ -84,6 +84,12 @@ aiohttp.wsgi applications::
 Gunicorn is now running and ready to serve requests to your app's
 worker processes.
 
+.. note::
+
+   If you want to use an alternative asyncio event loop
+   `uvloop <https://github.com/MagicStack/uvloop>`_, you can use the
+   ``aiohttp.worker.GunicornUVLoopWebWorker`` worker class.
+
 
 More information
 ----------------

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,13 +1,16 @@
 """Tests for aiohttp/worker.py"""
 import asyncio
 import pytest
+import sys
+import unittest
+
 from unittest import mock
 
 
 base_worker = pytest.importorskip('aiohttp.worker')
 
 
-class MyWorker(base_worker.GunicornWebWorker):
+class BaseTestWorker:
 
     def __init__(self):
         self.servers = []
@@ -16,9 +19,24 @@ class MyWorker(base_worker.GunicornWebWorker):
         self.cfg.graceful_timeout = 100
 
 
-@pytest.fixture
-def worker():
-    return MyWorker()
+class AsyncioWorker(BaseTestWorker, base_worker.GunicornWebWorker):
+    pass
+
+
+class UvloopWorker(BaseTestWorker, base_worker.GunicornUVLoopWebWorker):
+
+    def __init__(self):
+        if sys.version_info < (3, 5) \
+                or sys.platform in ('win32', 'cygwin', 'cli'):
+            # uvloop requires Python 3.5 and *nix.
+            raise unittest.SkipTest()
+
+        super().__init__()
+
+
+@pytest.fixture(params=[AsyncioWorker, UvloopWorker])
+def worker(request):
+    return request.param()
 
 
 def test_init_process(worker):


### PR DESCRIPTION
## What does this change do?

This PR provides a gunicorn worker that runs uvloop.  This is something that has to be done at the worker level, since when the app is actually running, it's already too late to set up the uvloop policy.

## How to test your changes?

I've updated `test/test_worker.py` to test the new worker too.  Alternatively, you can run a hello world application using the new worker with

```console
$ gunicorn test:app --worker-class aiohttp.worker.GunicornUVLoopWebWorker --workers 2 --bind localhost:8080
```

## Related issue number

There is no aiohttp issue regarding this, but there is one in the uvloop project: https://github.com/MagicStack/uvloop/issues/26

## Checklist

- [x] Code is written and well
- [x] Tests for the changes are provided
- [x] Documentation reflects the changes
