### PR TITLE
Fix the code to use event loop signaling API

### DIFF
--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -109,14 +109,26 @@ class GunicornWebWorker(base.Worker):
 
         yield from self.close()
 
-    def init_signal(self):
-        # init new signaling
-        self.loop.add_signal_handler(signal.SIGQUIT, self.handle_quit)
-        self.loop.add_signal_handler(signal.SIGTERM, self.handle_exit)
-        self.loop.add_signal_handler(signal.SIGINT, self.handle_quit)
-        self.loop.add_signal_handler(signal.SIGWINCH, self.handle_winch)
-        self.loop.add_signal_handler(signal.SIGUSR1, self.handle_usr1)
-        self.loop.add_signal_handler(signal.SIGABRT, self.handle_abort)
+    def init_signals(self):
+        # Set up signals through the event loop API.
+
+        self.loop.add_signal_handler(signal.SIGQUIT, self.handle_quit,
+                                     signal.SIGQUIT, None)
+
+        self.loop.add_signal_handler(signal.SIGTERM, self.handle_exit,
+                                     signal.SIGTERM, None)
+
+        self.loop.add_signal_handler(signal.SIGINT, self.handle_quit,
+                                     signal.SIGINT, None)
+
+        self.loop.add_signal_handler(signal.SIGWINCH, self.handle_winch,
+                                     signal.SIGWINCH, None)
+
+        self.loop.add_signal_handler(signal.SIGUSR1, self.handle_usr1,
+                                     signal.SIGUSR1, None)
+
+        self.loop.add_signal_handler(signal.SIGABRT, self.handle_abort,
+                                     signal.SIGABRT, None)
 
         # Don't let SIGTERM and SIGUSR1 disturb active requests
         # by interrupting system calls

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -61,9 +61,9 @@ def test_handle_abort(worker):
     assert worker.exit_code == 1
 
 
-def test_init_signal(worker):
+def test_init_signals(worker):
     worker.loop = mock.Mock()
-    worker.init_signal()
+    worker.init_signals()
     assert worker.loop.add_signal_handler.called
 
 


### PR DESCRIPTION
## What does this change do?

This PR fixes how gunicorn workers set up signals.  In the current version, `GunicornWebWorker` implements an `init_signal` method, but `gunicorn.Worker` doesn't have it!  It has an `init_signals` method.

Everything did work by a pure chance -- `gunicorn.Worker` called its own `init_signals`, which used `signal` module to set up signal handlers (instead of using `loop.add_signal_handler`), which `asyncio` actually doesn't mind (*but it's a bad thing, nevertheless!*)

The existing unit-test is synthetic, it manually calls the wring `init_signal`.

## Related issue number

No related issue, but I've discovered this while investigating https://github.com/MagicStack/uvloop/issues/26.

## Checklist

- [x] Code is written and well
- [x] Tests for the changes are provided
- [x] Documentation reflects the changes
