### PR TITLE
Skip the preamble in MultipartReader.

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -510,6 +510,7 @@ class MultipartReader(object):
         self._content = content
         self._last_part = None
         self._at_eof = False
+        self._at_bof = True
         self._unread = []
 
     @asyncio.coroutine
@@ -544,10 +545,15 @@ class MultipartReader(object):
     @asyncio.coroutine
     def next(self):
         """Emits the next multipart body part."""
+        # So, if we're at BOF, we need to skip till the boundary.
         if self._at_eof:
             return
         yield from self._maybe_release_last_part()
-        yield from self._read_boundary()
+        if self._at_bof:
+            yield from self._read_until_first_boundary()
+            self._at_bof = False
+        else:
+            yield from self._read_boundary()
         if self._at_eof:  # we just read the last boundary, nothing to do there
             return
         self._last_part = yield from self.fetch_next_part()
@@ -604,6 +610,20 @@ class MultipartReader(object):
         if self._unread:
             return self._unread.pop()
         return (yield from self._content.readline())
+
+    @asyncio.coroutine
+    def _read_until_first_boundary(self):
+        while True:
+            chunk = yield from self._readline()
+            if chunk == b'':
+                raise ValueError("Could not find starting boundary %r"
+                                 % (self._boundary))
+            chunk = chunk.rstrip()
+            if chunk == self._boundary:
+                return
+            elif chunk == self._boundary + b'--':
+                self._at_eof = True
+                return
 
     @asyncio.coroutine
     def _read_boundary(self):


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is code bug fix or documentation correction, select
       the lastest release branch (which looks like "0.xx") -->

## What these changes does?

This updates the MultipartReader to ignore the preamble of a multipart
message.  To quote the RFC:

> There appears to be room for additional information prior to the first
> boundary delimiter line and following the final boundary delimiter line.
> These areas should generally be left blank, and implementations must
> ignore anything that appears before the first boundary delimiter line or
> after the last one.

To do this, the MultipartReader now acts slightly differently at the
beginning of the file.  Instead of looking for a boundary and excepting
if it doesn't find one, it will skip over the initial data looking for
the first boundary and start reading from there.

If it doesn't find any boundary, it will except similar to how it did
before.

## How to test your changes?

Parse some multipart responses.

## Related issue number

Fixes #880 

## Checklist

- [x] Code is written and well
- [x] Tests for the changes are provided
- [x] Documentation reflects the changes