### PR TITLE
Don't crash logger when transport is None

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -330,7 +330,8 @@ class AccessLogger:
 
     @staticmethod
     def _format_a(args):
-        return args[3].get_extra_info('peername')[0]
+        return args[3].get_extra_info('peername')[0] if args[3] is not None \
+            else '-'
 
     @staticmethod
     def _format_t(args):
@@ -381,7 +382,7 @@ class AccessLogger:
         :param message: Request object. May be None.
         :param environ: Environment dict. May be None.
         :param response: Response object.
-        :param transport: Tansport object.
+        :param transport: Tansport object. May be None
         :param float time: Time taken to serve the request.
         """
         try:


### PR DESCRIPTION
When websocket client closes connection I often get this (on the server)

```
[...]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/marco/src/aiohttp/aiohttp/helpers.py", line 389, in log
    [message, environ, response, transport, time]))
  File "/home/marco/src/aiohttp/aiohttp/helpers.py", line 376, in _format_line
    return tuple(m(args) for m in self._methods)
  File "/home/marco/src/aiohttp/aiohttp/helpers.py", line 376, in <genexpr>
    return tuple(m(args) for m in self._methods)
  File "/home/marco/src/aiohttp/aiohttp/helpers.py", line 333, in _format_a
    return args[3].get_extra_info('peername')[0]
AttributeError: 'NoneType' object has no attribute 'get_extra_info'
```

Could not cook a test, let me know if you need it
