### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ shoud be replaced by::
 Documentation
 -------------
 
-http://aiohttp.readthedocs.org/
+https://aiohttp.readthedocs.io/
 
 Discussion list
 ---------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,11 +69,11 @@ except ImportError:
 intersphinx_mapping = {
     'python': ('http://docs.python.org/3', None),
     'multidict':
-        ('http://multidict.readthedocs.org/en/stable/', None),
+        ('https://multidict.readthedocs.io/en/stable/', None),
     'aiohttpjinja2':
-        ('http://aiohttp-jinja2.readthedocs.org/en/stable/', None),
+        ('https://aiohttp-jinja2.readthedocs.io/en/stable/', None),
     'aiohttpsession':
-        ('http://aiohttp-session.readthedocs.org/en/stable/', None)}
+        ('https://aiohttp-session.readthedocs.io/en/stable/', None)}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.