### PR TITLE
Use a create_future compatibility wrapper instead of creating Futures directly

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -17,7 +17,7 @@ from .client_reqrep import ClientRequest, ClientResponse
 from .errors import WSServerHandshakeError
 from .websocket import WS_KEY, WebSocketParser, WebSocketWriter
 from .websocket_client import ClientWebSocketResponse
-from . import hdrs
+from . import hdrs, helpers
 
 
 __all__ = ('ClientSession', 'request', 'get', 'options', 'head',
@@ -432,7 +432,7 @@ class ClientSession:
         if not self.closed:
             self._connector.close()
             self._connector = None
-        ret = asyncio.Future(loop=self._loop)
+        ret = helpers.create_future(self._loop)
         ret.set_result(None)
         return ret
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -363,7 +363,7 @@ class ClientRequest:
             expect = True
 
         if expect:
-            self._continue = asyncio.Future(loop=self.loop)
+            self._continue = helpers.create_future(self.loop)
 
     @asyncio.coroutine
     def write_bytes(self, request, reader):

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -13,7 +13,7 @@ from itertools import chain
 from math import ceil
 from types import MappingProxyType
 
-from . import hdrs
+from . import hdrs, helpers
 from .client import ClientRequest
 from .errors import ServerDisconnectedError
 from .errors import HttpProxyError, ProxyConnectionError
@@ -222,7 +222,7 @@ class BaseConnector(object):
 
     def close(self):
         """Close all opened transports."""
-        ret = asyncio.Future(loop=self._loop)
+        ret = helpers.create_future(self._loop)
         ret.set_result(None)
         if self._closed:
             return ret
@@ -282,7 +282,7 @@ class BaseConnector(object):
 
         limit = self._limit
         if limit is not None:
-            fut = asyncio.Future(loop=self._loop)
+            fut = helpers.create_future(self._loop)
             waiters = self._waiters[key]
 
             # The limit defines the maximum number of concurrent connections

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -23,7 +23,8 @@ except ImportError:
     ensure_future = asyncio.async
 
 
-__all__ = ('BasicAuth', 'FormData', 'parse_mimetype', 'Timeout')
+__all__ = ('BasicAuth', 'create_future', 'FormData', 'parse_mimetype',
+           'Timeout')
 
 
 class BasicAuth(namedtuple('BasicAuth', ['login', 'password', 'encoding'])):
@@ -68,6 +69,15 @@ class BasicAuth(namedtuple('BasicAuth', ['login', 'password', 'encoding'])):
         """Encode credentials."""
         creds = ('%s:%s' % (self.login, self.password)).encode(self.encoding)
         return 'Basic %s' % base64.b64encode(creds).decode(self.encoding)
+
+
+def create_future(loop):
+    """Compatiblity wrapper for the loop.create_future() call introduced in
+    3.5.2."""
+    if hasattr(loop, 'create_future'):
+        return loop.create_future()
+    else:
+        return asyncio.Future(loop=loop)
 
 
 class FormData:

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -5,6 +5,7 @@ import functools
 import traceback
 
 from .log import internal_logger
+from . import helpers
 
 __all__ = (
     'EofStream', 'StreamReader', 'DataQueue', 'ChunksQueue',
@@ -150,7 +151,7 @@ class StreamReader(asyncio.StreamReader, AsyncStreamReaderMixin):
             return
 
         assert self._eof_waiter is None
-        self._eof_waiter = asyncio.Future(loop=self._loop)
+        self._eof_waiter = helpers.create_future(self._loop)
         try:
             yield from self._eof_waiter
         finally:
@@ -192,7 +193,7 @@ class StreamReader(asyncio.StreamReader, AsyncStreamReaderMixin):
         if self._waiter is not None:
             raise RuntimeError('%s() called while another coroutine is '
                                'already waiting for incoming data' % func_name)
-        return asyncio.Future(loop=self._loop)
+        return helpers.create_future(self._loop)
 
     @asyncio.coroutine
     def readline(self):
@@ -441,7 +442,7 @@ class DataQueue:
                 raise self._exception
 
             assert not self._waiter
-            self._waiter = asyncio.Future(loop=self._loop)
+            self._waiter = helpers.create_future(self._loop)
             try:
                 yield from self._waiter
             except (asyncio.CancelledError, asyncio.TimeoutError):

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -121,7 +121,7 @@ def run_server(loop, *, listen_addr=('127.0.0.1', 0),
                 listen_addr, ssl=sslcontext)
         server = thread_loop.run_until_complete(server_coroutine)
 
-        waiter = asyncio.Future(loop=thread_loop)
+        waiter = helpers.create_future(thread_loop)
         loop.call_soon_threadsafe(
             fut.set_result, (thread_loop, waiter,
                              server.sockets[0].getsockname()))
@@ -143,7 +143,7 @@ def run_server(loop, *, listen_addr=('127.0.0.1', 0),
             thread_loop.close()
             gc.collect()
 
-    fut = asyncio.Future(loop=loop)
+    fut = helpers.create_future(loop)
     server_thread = threading.Thread(target=run, args=(loop, fut))
     server_thread.start()
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -17,7 +17,7 @@ from types import MappingProxyType
 
 from multidict import upstr
 
-from . import hdrs
+from . import hdrs, helpers
 from .abc import AbstractRouter, AbstractMatchInfo, AbstractView
 from .protocol import HttpVersion11
 from .web_exceptions import (HTTPMethodNotAllowed, HTTPNotFound,
@@ -528,7 +528,7 @@ class StaticRoute(Route):
         loop = req.app.loop
         out_fd = transport.get_extra_info("socket").fileno()
         in_fd = fobj.fileno()
-        fut = asyncio.Future(loop=loop)
+        fut = helpers.create_future(loop)
 
         self._sendfile_cb(fut, out_fd, in_fd, 0, count, loop, False)
 

--- a/tests/test_client_functional_oldstyle.py
+++ b/tests/test_client_functional_oldstyle.py
@@ -635,7 +635,7 @@ class TestHttpClientFunctional(unittest.TestCase):
             with open(fname, 'rb') as f:
                 data = f.read()
 
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
 
             @asyncio.coroutine
             def stream():

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -16,6 +16,7 @@ from multidict import CIMultiDict, CIMultiDictProxy, upstr
 import pytest
 import aiohttp
 from aiohttp import BaseConnector
+from aiohttp import helpers
 from aiohttp.client_reqrep import ClientRequest, ClientResponse
 
 import os.path
@@ -716,7 +717,7 @@ class TestClientRequest(unittest.TestCase):
         self.loop.run_until_complete(req.close())
 
     def test_data_stream_exc(self):
-        fut = asyncio.Future(loop=self.loop)
+        fut = helpers.create_future(self.loop)
 
         def gen():
             yield b'binary data'
@@ -756,7 +757,7 @@ class TestClientRequest(unittest.TestCase):
         resp.close()
 
     def test_data_stream_exc_chain(self):
-        fut = asyncio.Future(loop=self.loop)
+        fut = helpers.create_future(self.loop)
 
         def gen():
             yield from fut

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -7,6 +7,7 @@ import unittest
 import unittest.mock
 
 import aiohttp
+from aiohttp import helpers
 from aiohttp.client_reqrep import ClientResponse
 
 
@@ -71,7 +72,7 @@ class TestClientResponse(unittest.TestCase):
 
     def test_read_and_release_connection(self):
         def side_effect(*args, **kwargs):
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
             fut.set_result(b'payload')
             return fut
         content = self.response.content = unittest.mock.Mock()
@@ -83,7 +84,7 @@ class TestClientResponse(unittest.TestCase):
 
     def test_read_and_release_connection_with_error(self):
         content = self.response.content = unittest.mock.Mock()
-        content.read.return_value = asyncio.Future(loop=self.loop)
+        content.read.return_value = helpers.create_future(self.loop)
         content.read.return_value.set_exception(ValueError)
 
         self.assertRaises(
@@ -92,7 +93,7 @@ class TestClientResponse(unittest.TestCase):
         self.assertTrue(self.response._closed)
 
     def test_release(self):
-        fut = asyncio.Future(loop=self.loop)
+        fut = helpers.create_future(self.loop)
         fut.set_result(b'')
         content = self.response.content = unittest.mock.Mock()
         content.readany.return_value = fut
@@ -103,7 +104,7 @@ class TestClientResponse(unittest.TestCase):
     def test_read_decode_deprecated(self):
         self.response._content = b'data'
         self.response.json = unittest.mock.Mock()
-        self.response.json.return_value = asyncio.Future(loop=self.loop)
+        self.response.json.return_value = helpers.create_future(self.loop)
         self.response.json.return_value.set_result('json')
 
         with self.assertWarns(DeprecationWarning):
@@ -113,7 +114,7 @@ class TestClientResponse(unittest.TestCase):
 
     def test_text(self):
         def side_effect(*args, **kwargs):
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
             fut.set_result('{"тест": "пройден"}'.encode('cp1251'))
             return fut
         self.response.headers = {
@@ -127,7 +128,7 @@ class TestClientResponse(unittest.TestCase):
 
     def test_text_custom_encoding(self):
         def side_effect(*args, **kwargs):
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
             fut.set_result('{"тест": "пройден"}'.encode('cp1251'))
             return fut
         self.response.headers = {
@@ -144,7 +145,7 @@ class TestClientResponse(unittest.TestCase):
 
     def test_text_detect_encoding(self):
         def side_effect(*args, **kwargs):
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
             fut.set_result('{"тест": "пройден"}'.encode('cp1251'))
             return fut
         self.response.headers = {'CONTENT-TYPE': 'application/json'}
@@ -158,7 +159,7 @@ class TestClientResponse(unittest.TestCase):
 
     def test_text_after_read(self):
         def side_effect(*args, **kwargs):
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
             fut.set_result('{"тест": "пройден"}'.encode('cp1251'))
             return fut
         self.response.headers = {
@@ -172,7 +173,7 @@ class TestClientResponse(unittest.TestCase):
 
     def test_json(self):
         def side_effect(*args, **kwargs):
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
             fut.set_result('{"тест": "пройден"}'.encode('cp1251'))
             return fut
         self.response.headers = {
@@ -209,7 +210,7 @@ class TestClientResponse(unittest.TestCase):
 
     def test_json_override_encoding(self):
         def side_effect(*args, **kwargs):
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
             fut.set_result('{"тест": "пройден"}'.encode('cp1251'))
             return fut
         self.response.headers = {
@@ -226,7 +227,7 @@ class TestClientResponse(unittest.TestCase):
 
     def test_json_detect_encoding(self):
         def side_effect(*args, **kwargs):
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
             fut.set_result('{"тест": "пройден"}'.encode('cp1251'))
             return fut
         self.response.headers = {'CONTENT-TYPE': 'application/json'}

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -14,6 +14,7 @@ from unittest import mock
 import aiohttp
 from aiohttp import web
 from aiohttp import client
+from aiohttp import helpers
 from aiohttp.client import ClientResponse
 from aiohttp.connector import Connection
 
@@ -273,7 +274,7 @@ class TestBaseConnector(unittest.TestCase):
         key = ('host', 80, False)
         conn._conns[key] = [(tr, proto, self.loop.time())]
         conn._create_connection = unittest.mock.Mock()
-        conn._create_connection.return_value = asyncio.Future(loop=self.loop)
+        conn._create_connection.return_value = helpers.create_future(self.loop)
         conn._create_connection.return_value.set_result((tr, proto))
 
         connection = self.loop.run_until_complete(conn.connect(Req()))
@@ -286,7 +287,7 @@ class TestBaseConnector(unittest.TestCase):
     def test_connect_timeout(self):
         conn = aiohttp.BaseConnector(loop=self.loop)
         conn._create_connection = unittest.mock.Mock()
-        conn._create_connection.return_value = asyncio.Future(loop=self.loop)
+        conn._create_connection.return_value = helpers.create_future(self.loop)
         conn._create_connection.return_value.set_exception(
             asyncio.TimeoutError())
 
@@ -297,7 +298,7 @@ class TestBaseConnector(unittest.TestCase):
     def test_connect_oserr(self):
         conn = aiohttp.BaseConnector(loop=self.loop)
         conn._create_connection = unittest.mock.Mock()
-        conn._create_connection.return_value = asyncio.Future(loop=self.loop)
+        conn._create_connection.return_value = helpers.create_future(self.loop)
         err = OSError(1, 'permission error')
         conn._create_connection.return_value.set_exception(err)
 
@@ -499,8 +500,8 @@ class TestBaseConnector(unittest.TestCase):
             key = ('host', 80, False)
             conn._conns[key] = [(tr, proto, self.loop.time())]
             conn._create_connection = unittest.mock.Mock()
-            conn._create_connection.return_value = asyncio.Future(
-                loop=self.loop)
+            conn._create_connection.return_value = helpers.create_future(
+                self.loop)
             conn._create_connection.return_value.set_result((tr, proto))
 
             connection1 = yield from conn.connect(Req())
@@ -547,8 +548,8 @@ class TestBaseConnector(unittest.TestCase):
             key = ('host', 80, False)
             conn._conns[key] = [(tr, proto, self.loop.time())]
             conn._create_connection = unittest.mock.Mock()
-            conn._create_connection.return_value = asyncio.Future(
-                loop=self.loop)
+            conn._create_connection.return_value = helpers.create_future(
+                self.loop)
             conn._create_connection.return_value.set_result((tr, proto))
 
             connection = yield from conn.connect(Req())
@@ -569,7 +570,7 @@ class TestBaseConnector(unittest.TestCase):
             conn = aiohttp.BaseConnector(limit=1, loop=self.loop)
             conn._create_connection = unittest.mock.Mock()
             conn._create_connection.return_value = \
-                asyncio.Future(loop=self.loop)
+                helpers.create_future(self.loop)
             conn._create_connection.return_value.set_exception(err)
 
             with self.assertRaises(Exception):
@@ -668,8 +669,8 @@ class TestBaseConnector(unittest.TestCase):
             key = ('host', 80, False)
             conn._conns[key] = [(tr, proto, self.loop.time())]
             conn._create_connection = unittest.mock.Mock()
-            conn._create_connection.return_value = asyncio.Future(
-                loop=self.loop)
+            conn._create_connection.return_value = helpers.create_future(
+                self.loop)
             conn._create_connection.return_value.set_result((tr, proto))
 
             connection = yield from conn.connect(Req())

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -226,3 +226,26 @@ def test_requote_uri_properly_requotes():
     # Ensure requoting doesn't break expectations.
     quoted = 'http://example.com/fiz?buz=%25ppicture'
     assert quoted == helpers.requote_uri(quoted)
+
+
+def test_create_future_with_new_loop():
+    # We should use the new create_future() if it's available.
+    mock_loop = mock.Mock()
+    expected = 'hello'
+    mock_loop.create_future.return_value = expected
+    assert expected == helpers.create_future(mock_loop)
+
+
+@mock.patch('asyncio.Future')
+def test_create_future_with_old_loop(MockFuture):
+    # The old loop (without create_future()) should just have a Future object
+    # wrapped around it.
+    mock_loop = mock.Mock()
+    del mock_loop.create_future
+
+    expected = 'hello'
+    MockFuture.return_value = expected
+
+    future = helpers.create_future(mock_loop)
+    MockFuture.assert_called_with(loop=mock_loop)
+    assert expected == future

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -7,6 +7,7 @@ import unittest.mock as mock
 import zlib
 
 import aiohttp.multipart
+from aiohttp import helpers
 from aiohttp.helpers import parse_mimetype
 from aiohttp.hdrs import (
     CONTENT_DISPOSITION,
@@ -48,7 +49,7 @@ class TestCase(unittest.TestCase, metaclass=MetaAioTestCase):
         self.loop.close()
 
     def future(self, obj):
-        fut = asyncio.Future(loop=self.loop)
+        fut = helpers.create_future(self.loop)
         fut.set_result(obj)
         return fut
 
@@ -175,7 +176,7 @@ class PartReaderTestCase(TestCase):
         stream = Stream(b'')
 
         def prepare(data):
-            f = asyncio.Future(loop=self.loop)
+            f = helpers.create_future(self.loop)
             f.set_result(data)
             return f
 
@@ -216,7 +217,7 @@ class PartReaderTestCase(TestCase):
         stream = Stream(b'')
 
         def prepare(data):
-            f = asyncio.Future(loop=self.loop)
+            f = helpers.create_future(self.loop)
             f.set_result(data)
             return f
 

--- a/tests/test_py35/test_web_websocket_35.py
+++ b/tests/test_py35/test_web_websocket_35.py
@@ -1,14 +1,13 @@
 import pytest
 
-import asyncio
-
 import aiohttp
 from aiohttp import web
+from aiohttp import helpers
 
 
 @pytest.mark.run_loop
 async def test_server_ws_async_for(loop, create_server):
-    closed = asyncio.Future(loop=loop)
+    closed = helpers.create_future(loop)
 
     async def handler(request):
         ws = web.WebSocketResponse()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 from aiohttp import server
 from aiohttp import errors
+from aiohttp import helpers
 
 
 @pytest.yield_fixture
@@ -507,7 +508,7 @@ def test_keep_alive_close_existing(make_srv, loop):
     srv._keep_alive_period = 15
     keep_alive_handle = srv._keep_alive_handle = mock.Mock()
     srv.handle_request = mock.Mock()
-    srv.handle_request.return_value = asyncio.Future(loop=loop)
+    srv.handle_request.return_value = helpers.create_future(loop)
     srv.handle_request.return_value.set_result(1)
 
     srv.data_received(

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 from aiohttp import streams
 from aiohttp import test_utils
+from aiohttp import helpers
 
 
 class TestStreamReader(unittest.TestCase):
@@ -24,7 +25,7 @@ class TestStreamReader(unittest.TestCase):
 
     def test_create_waiter(self):
         stream = self._make_one()
-        stream._waiter = asyncio.Future(loop=self.loop)
+        stream._waiter = helpers.create_future(self.loop)
         self.assertRaises(RuntimeError, stream._create_waiter, 'test')
 
     @mock.patch('aiohttp.streams.asyncio')

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -3,7 +3,7 @@ import os
 import time
 
 import pytest
-from aiohttp.helpers import ensure_future, Timeout
+from aiohttp.helpers import create_future, ensure_future, Timeout
 
 
 @pytest.mark.run_loop
@@ -95,7 +95,7 @@ def test_timeout_blocking_loop(loop):
 
 @pytest.mark.run_loop
 def test_for_race_conditions(loop):
-    fut = asyncio.Future(loop=loop)
+    fut = create_future(loop)
     loop.call_later(0.1, fut.set_result('done'))
     with Timeout(0.2, loop=loop):
         resp = yield from fut
@@ -151,7 +151,7 @@ def test_outer_coro_is_not_cancelled(loop):
 
 @pytest.mark.run_loop
 def test_cancel_outer_coro(loop):
-    fut = asyncio.Future(loop=loop)
+    fut = create_future(loop)
 
     @asyncio.coroutine
     def outer():

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -8,7 +8,7 @@ from unittest import mock
 from urllib.parse import unquote
 from multidict import CIMultiDict
 import aiohttp.web
-from aiohttp import hdrs
+from aiohttp import hdrs, helpers
 from aiohttp.web import (UrlDispatcher, Request, Response,
                          HTTPMethodNotAllowed, HTTPNotFound,
                          HTTPCreated)
@@ -583,7 +583,7 @@ class TestUrlDispatcher(unittest.TestCase):
         with mock.patch('aiohttp.web_urldispatcher.os') as m_os:
             out_fd = 30
             in_fd = 31
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
             m_os.sendfile.return_value = 0
             route._sendfile_cb(fut, out_fd, in_fd, 0, 100, loop, False)
             m_os.sendfile.assert_called_with(out_fd, in_fd, 0, 100)
@@ -599,7 +599,7 @@ class TestUrlDispatcher(unittest.TestCase):
         with mock.patch('aiohttp.web_urldispatcher.os') as m_os:
             out_fd = 30
             in_fd = 31
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
             m_os.sendfile.side_effect = BlockingIOError()
             route._sendfile_cb(fut, out_fd, in_fd, 0, 100, loop, False)
             m_os.sendfile.assert_called_with(out_fd, in_fd, 0, 100)
@@ -616,7 +616,7 @@ class TestUrlDispatcher(unittest.TestCase):
         with mock.patch('aiohttp.web_urldispatcher.os') as m_os:
             out_fd = 30
             in_fd = 31
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
             exc = OSError()
             m_os.sendfile.side_effect = exc
             route._sendfile_cb(fut, out_fd, in_fd, 0, 100, loop, False)

--- a/tests/test_web_application.py
+++ b/tests/test_web_application.py
@@ -1,7 +1,7 @@
 import asyncio
 import pytest
 
-from aiohttp import web, log
+from aiohttp import web, log, helpers
 from unittest import mock
 
 
@@ -44,7 +44,7 @@ def test_app_register_on_finish(loop):
 def test_app_register_coro(loop):
     app = web.Application(loop=loop)
 
-    fut = asyncio.Future(loop=loop)
+    fut = helpers.create_future(loop)
 
     @asyncio.coroutine
     def cb(app):

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -1,7 +1,7 @@
 import asyncio
 import unittest
 from unittest import mock
-from aiohttp import CIMultiDict
+from aiohttp import CIMultiDict, helpers
 from aiohttp.web import (
     MsgType, Request, WebSocketResponse, HTTPMethodNotAllowed, HTTPBadRequest)
 from aiohttp.protocol import RawRequestMessage, HttpVersion11
@@ -277,7 +277,7 @@ class TestWebWebSocket(unittest.TestCase):
         self.loop.run_until_complete(ws.prepare(req))
 
         exc = ValueError()
-        res = asyncio.Future(loop=self.loop)
+        res = helpers.create_future(self.loop)
         res.set_exception(exc)
         ws._reader.read.return_value = res
 
@@ -295,7 +295,7 @@ class TestWebWebSocket(unittest.TestCase):
         ws = WebSocketResponse()
         self.loop.run_until_complete(ws.prepare(req))
 
-        res = asyncio.Future(loop=self.loop)
+        res = helpers.create_future(self.loop)
         res.set_exception(asyncio.CancelledError())
         ws._reader.read.return_value = res
 
@@ -308,7 +308,7 @@ class TestWebWebSocket(unittest.TestCase):
         ws = WebSocketResponse()
         self.loop.run_until_complete(ws.prepare(req))
 
-        res = asyncio.Future(loop=self.loop)
+        res = helpers.create_future(self.loop)
         res.set_exception(asyncio.TimeoutError())
         ws._reader.read.return_value = res
 
@@ -322,7 +322,7 @@ class TestWebWebSocket(unittest.TestCase):
         self.loop.run_until_complete(ws.prepare(req))
 
         exc = errors.ClientDisconnectedError()
-        res = asyncio.Future(loop=self.loop)
+        res = helpers.create_future(self.loop)
         res.set_exception(exc)
         ws._reader.read.return_value = res
 
@@ -365,7 +365,7 @@ class TestWebWebSocket(unittest.TestCase):
         self.loop.run_until_complete(ws.prepare(req))
 
         exc = ValueError()
-        reader.read.return_value = asyncio.Future(loop=self.loop)
+        reader.read.return_value = helpers.create_future(self.loop)
         reader.read.return_value.set_exception(exc)
 
         self.loop.run_until_complete(ws.close())
@@ -373,7 +373,7 @@ class TestWebWebSocket(unittest.TestCase):
         self.assertIs(ws.exception(), exc)
 
         ws._closed = False
-        reader.read.return_value = asyncio.Future(loop=self.loop)
+        reader.read.return_value = helpers.create_future(self.loop)
         reader.read.return_value.set_exception(asyncio.CancelledError())
         self.assertRaises(asyncio.CancelledError,
                           self.loop.run_until_complete, ws.close())

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -6,7 +6,7 @@ import socket
 import unittest
 
 import aiohttp
-from aiohttp import web, websocket
+from aiohttp import helpers, web, websocket
 
 
 WS_KEY = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
@@ -84,7 +84,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
 
     def test_send_recv_text(self):
 
-        closed = asyncio.Future(loop=self.loop)
+        closed = helpers.create_future(self.loop)
 
         @asyncio.coroutine
         def handler(request):
@@ -119,7 +119,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
 
     def test_send_recv_bytes(self):
 
-        closed = asyncio.Future(loop=self.loop)
+        closed = helpers.create_future(self.loop)
 
         @asyncio.coroutine
         def handler(request):
@@ -154,7 +154,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
 
     def test_auto_pong_with_closing_by_peer(self):
 
-        closed = asyncio.Future(loop=self.loop)
+        closed = helpers.create_future(self.loop)
 
         @asyncio.coroutine
         def handler(request):
@@ -186,7 +186,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
 
     def test_ping(self):
 
-        closed = asyncio.Future(loop=self.loop)
+        closed = helpers.create_future(self.loop)
 
         @asyncio.coroutine
         def handler(request):
@@ -214,7 +214,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
 
     def test_client_ping(self):
 
-        closed = asyncio.Future(loop=self.loop)
+        closed = helpers.create_future(self.loop)
 
         @asyncio.coroutine
         def handler(request):
@@ -242,7 +242,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
 
     def test_pong(self):
 
-        closed = asyncio.Future(loop=self.loop)
+        closed = helpers.create_future(self.loop)
 
         @asyncio.coroutine
         def handler(request):
@@ -277,7 +277,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
 
     def test_change_status(self):
 
-        closed = asyncio.Future(loop=self.loop)
+        closed = helpers.create_future(self.loop)
 
         @asyncio.coroutine
         def handler(request):
@@ -302,7 +302,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
 
     def test_handle_protocol(self):
 
-        closed = asyncio.Future(loop=self.loop)
+        closed = helpers.create_future(self.loop)
 
         @asyncio.coroutine
         def handler(request):
@@ -326,7 +326,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
 
     def test_server_close_handshake(self):
 
-        closed = asyncio.Future(loop=self.loop)
+        closed = helpers.create_future(self.loop)
 
         @asyncio.coroutine
         def handler(request):
@@ -351,7 +351,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
 
     def test_client_close_handshake(self):
 
-        closed = asyncio.Future(loop=self.loop)
+        closed = helpers.create_future(self.loop)
 
         @asyncio.coroutine
         def handler(request):
@@ -387,7 +387,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
 
     def test_server_close_handshake_server_eats_client_messages(self):
 
-        closed = asyncio.Future(loop=self.loop)
+        closed = helpers.create_future(self.loop)
 
         @asyncio.coroutine
         def handler(request):

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -6,7 +6,7 @@ import unittest
 from unittest import mock
 
 import aiohttp
-from aiohttp import errors, hdrs, websocket, websocket_client
+from aiohttp import errors, hdrs, helpers, websocket, websocket_client
 
 
 class TestWebSocketClient(unittest.TestCase):
@@ -35,7 +35,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_PROTOCOL: 'chat'
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
 
         res = self.loop.run_until_complete(
@@ -54,7 +54,7 @@ class TestWebSocketClient(unittest.TestCase):
         resp = mock.Mock()
         resp.status = 403
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
 
         origin = 'https://example.org/page.html'
@@ -84,7 +84,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: self.ws_key,
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
 
         res = self.loop.run_until_complete(
@@ -108,7 +108,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: self.ws_key
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
 
         resp = self.loop.run_until_complete(
@@ -128,7 +128,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: self.ws_key
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
 
         with self.assertRaises(errors.WSServerHandshakeError) as ctx:
@@ -151,7 +151,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: self.ws_key
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
 
         with self.assertRaises(errors.WSServerHandshakeError) as ctx:
@@ -174,7 +174,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: self.ws_key
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
 
         with self.assertRaises(errors.WSServerHandshakeError) as ctx:
@@ -197,7 +197,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: 'asdfasdfasdfasdfasdfasdf'
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
 
         with self.assertRaises(errors.WSServerHandshakeError) as ctx:
@@ -221,7 +221,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: self.ws_key,
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
         writer = WebSocketWriter.return_value = mock.Mock()
         reader = resp.connection.reader.set_parser.return_value = mock.Mock()
@@ -231,7 +231,7 @@ class TestWebSocketClient(unittest.TestCase):
         self.assertFalse(resp.closed)
 
         msg = websocket.Message(websocket.MSG_CLOSE, b'', b'')
-        reader.read.return_value = asyncio.Future(loop=self.loop)
+        reader.read.return_value = helpers.create_future(self.loop)
         reader.read.return_value.set_result(msg)
 
         res = self.loop.run_until_complete(resp.close())
@@ -257,7 +257,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: self.ws_key,
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
         WebSocketWriter.return_value = mock.Mock()
         reader = resp.connection.reader.set_parser.return_value = mock.Mock()
@@ -268,7 +268,7 @@ class TestWebSocketClient(unittest.TestCase):
         self.assertFalse(resp.closed)
 
         exc = ValueError()
-        reader.read.return_value = asyncio.Future(loop=self.loop)
+        reader.read.return_value = helpers.create_future(self.loop)
         reader.read.return_value.set_exception(exc)
 
         self.loop.run_until_complete(resp.close())
@@ -287,7 +287,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: self.ws_key,
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
         writer = WebSocketWriter.return_value = mock.Mock()
         resp.connection.reader.set_parser.return_value = mock.Mock()
@@ -321,7 +321,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: self.ws_key,
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
         WebSocketWriter.return_value = mock.Mock()
 
@@ -347,7 +347,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: self.ws_key,
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
         WebSocketWriter.return_value = mock.Mock()
 
@@ -370,7 +370,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: self.ws_key,
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(hresp)
         WebSocketWriter.return_value = mock.Mock()
         reader = hresp.connection.reader.set_parser.return_value = mock.Mock()
@@ -380,7 +380,7 @@ class TestWebSocketClient(unittest.TestCase):
                 'http://test.org', loop=self.loop))
 
         exc = ValueError()
-        reader.read.return_value = asyncio.Future(loop=self.loop)
+        reader.read.return_value = helpers.create_future(self.loop)
         reader.read.return_value.set_exception(exc)
 
         msg = self.loop.run_until_complete(resp.receive())
@@ -407,7 +407,7 @@ class TestWebSocketClient(unittest.TestCase):
             hdrs.SEC_WEBSOCKET_ACCEPT: self.ws_key
         }
         m_os.urandom.return_value = self.key_data
-        m_req.return_value = asyncio.Future(loop=self.loop)
+        m_req.return_value = helpers.create_future(self.loop)
         m_req.return_value.set_result(resp)
 
         with self.assertRaises(errors.WSServerHandshakeError):

--- a/tests/test_websocket_client_functional.py
+++ b/tests/test_websocket_client_functional.py
@@ -1,7 +1,7 @@
 import aiohttp
 import asyncio
 import pytest
-from aiohttp import web
+from aiohttp import helpers, web
 
 
 @pytest.mark.run_loop
@@ -55,7 +55,7 @@ def test_send_recv_bytes(create_app_and_client):
 @pytest.mark.run_loop
 def test_ping_pong(create_app_and_client, loop):
 
-    closed = asyncio.Future(loop=loop)
+    closed = helpers.create_future(loop)
 
     @asyncio.coroutine
     def handler(request):
@@ -92,7 +92,7 @@ def test_ping_pong(create_app_and_client, loop):
 @pytest.mark.run_loop
 def test_ping_pong_manual(create_app_and_client, loop):
 
-    closed = asyncio.Future(loop=loop)
+    closed = helpers.create_future(loop)
 
     @asyncio.coroutine
     def handler(request):
@@ -163,7 +163,7 @@ def test_close(create_app_and_client):
 @pytest.mark.run_loop
 def test_close_from_server(create_app_and_client, loop):
 
-    closed = asyncio.Future(loop=loop)
+    closed = helpers.create_future(loop)
 
     @asyncio.coroutine
     def handler(request):
@@ -196,7 +196,7 @@ def test_close_from_server(create_app_and_client, loop):
 @pytest.mark.run_loop
 def test_close_manual(create_app_and_client, loop):
 
-    closed = asyncio.Future(loop=loop)
+    closed = helpers.create_future(loop)
 
     @asyncio.coroutine
     def handler(request):

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -10,6 +10,7 @@ import aiohttp
 from aiohttp import multidict
 from aiohttp import wsgi
 from aiohttp import protocol
+from aiohttp import helpers
 
 
 class TestHttpWsgiServerProtocol(unittest.TestCase):
@@ -156,9 +157,9 @@ class TestHttpWsgiServerProtocol(unittest.TestCase):
 
         def wsgi_app(env, start):
             start('200 OK', [('Content-Type', 'text/plain')])
-            f1 = asyncio.Future(loop=self.loop)
+            f1 = helpers.create_future(self.loop)
             f1.set_result(b'data')
-            fut = asyncio.Future(loop=self.loop)
+            fut = helpers.create_future(self.loop)
             fut.set_result([f1])
             return fut
 


### PR DESCRIPTION
## What these changes does?

Adds the `create_future` compat wrapper (and tests) discussed at the PyCon 2016 sprint.

## How to test your changes?

The `make test` suite includes mock tests to ensure the wrapper is functioning.

## Related issue number

Issue #893 

## Checklist

- [x] Code is written and well
- [x] Tests for the changes are provided
- [ ] Documentation reflects the changes **(not sure if this is applicable?)**
