### PR TITLE
__repr__ only returns ascii encodable characters

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -568,8 +568,17 @@ class ClientResponse:
 
     def __repr__(self):
         out = io.StringIO()
+        ascii_encodable_url = self.url.encode('ascii', 'backslashreplace') \
+            .decode('ascii')
+        if self.reason:
+            ascii_encodable_reason = self.reason.encode('ascii',
+                                                        'backslashreplace') \
+                .decode('ascii')
+        else:
+            ascii_encodable_reason = self.reason
         print('<ClientResponse({}) [{} {}]>'.format(
-            self.url, self.status, self.reason), file=out)
+            ascii_encodable_url, self.status, ascii_encodable_reason),
+            file=out)
         print(self.headers, file=out)
         return out.getvalue()
 

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -399,8 +399,10 @@ class Request(dict, HeadersMixin):
         raise NotImplementedError
 
     def __repr__(self):
+        ascii_encodable_path = self.path.encode('ascii', 'backslashreplace') \
+            .decode('ascii')
         return "<{} {} {} >".format(self.__class__.__name__,
-                                    self.method, self.path)
+                                    self.method, ascii_encodable_path)
 
 
 ############################################################

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -69,6 +69,21 @@ class TestClientResponse(unittest.TestCase):
             '<ClientResponse(http://def-cl-resp.org) [200 Ok]>',
             repr(self.response))
 
+    def test_repr_non_ascii_url(self):
+        response = ClientResponse('get', 'http://fake-host.org/\u03bb')
+        self.assertIn(
+            "<ClientResponse(http://fake-host.org/\\u03bb) [None None]>",
+            repr(response))
+        response.close()
+
+    def test_repr_non_ascii_reason(self):
+        response = ClientResponse('get', 'http://fake-host.org/path')
+        response.reason = '\u03bb'
+        self.assertIn(
+            "<ClientResponse(http://fake-host.org/path) [None \\u03bb]>",
+            repr(response))
+        response.close()
+
     def test_read_and_release_connection(self):
         def side_effect(*args, **kwargs):
             fut = asyncio.Future(loop=self.loop)

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -218,6 +218,11 @@ def test___repr__(make_request):
     assert "<Request GET /path/to >" == repr(req)
 
 
+def test___repr___non_ascii_path(make_request):
+    req = make_request('GET', '/path/\U0001f415\U0001f308')
+    assert "<Request GET /path/\\U0001f415\\U0001f308 >" == repr(req)
+
+
 def test_http_scheme(make_request):
     req = make_request('GET', '/')
     assert "http" == req.scheme


### PR DESCRIPTION
## What these changes does?

`Request.__repr__` and `ClientResponse.__repr__` now only contain ascii-encodable characters

Some of the formatting looks pretty gross, but this is how I got it to pass flake8, open to suggestions on how to make it better

## How to test your changes?

I added a test for each case

## Related issue number
Solves #875 

## Checklist

- [ ] Code is written and well
- [ ] Tests for the changes are provided
- [ ] Documentation reflects the changes
