### PR TITLE
Skip resolve on ip

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -405,6 +405,13 @@ _SSL_OP_NO_COMPRESSION = getattr(ssl, "OP_NO_COMPRESSION", 0)
 _marker = object()
 
 
+def host_is_ip(host):
+    try:
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        return False
+
 class TCPConnector(BaseConnector):
     """TCP connector.
 
@@ -555,7 +562,7 @@ class TCPConnector(BaseConnector):
 
     @asyncio.coroutine
     def _resolve_host(self, host, port):
-        if not self._use_resolver or self._host_is_ip(host):
+        if not self._use_resolver or host_is_ip(host):
             return [{'hostname': host, 'host': host, 'port': port,
                      'family': self._family, 'proto': 0, 'flags': 0}]
 
@@ -573,13 +580,6 @@ class TCPConnector(BaseConnector):
             res = yield from self._resolver.resolve(
                 host, port, family=self._family)
             return res
-
-    def _host_is_ip(self, host):
-        try:
-            ipaddress.ip_address(host)
-            return True
-        except ValueError:
-            return False
 
     @asyncio.coroutine
     def _create_connection(self, req):

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1,8 +1,8 @@
 import asyncio
 import aiohttp
-import ipaddress
 import functools
 import http.cookies
+import re
 import ssl
 import sys
 import traceback
@@ -404,13 +404,28 @@ _SSL_OP_NO_COMPRESSION = getattr(ssl, "OP_NO_COMPRESSION", 0)
 
 _marker = object()
 
+ipv4_pattern = ('^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}'
+                '(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$')
+ipv6_pattern = (
+    '^(?:(?:(?:[A-F0-9]{1,4}:){6}|(?=(?:[A-F0-9]{0,4}:){0,6}'
+    '(?:[0-9]{1,3}\.){3}[0-9]{1,3}$)(([0-9A-F]{1,4}:){0,5}|:)'
+    '((:[0-9A-F]{1,4}){1,5}:|:)|::(?:[A-F0-9]{1,4}:){5})'
+    '(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}'
+    '(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])|(?:[A-F0-9]{1,4}:){7}'
+    '[A-F0-9]{1,4}|(?=(?:[A-F0-9]{0,4}:){0,7}[A-F0-9]{0,4}$)'
+    '(([0-9A-F]{1,4}:){1,7}|:)((:[0-9A-F]{1,4}){1,7}|:)|(?:[A-F0-9]{1,4}:){7}'
+    ':|:(:[A-F0-9]{1,4}){7})$')
+ipv4_regex = re.compile(ipv4_pattern)
+ipv6_regex = re.compile(ipv6_pattern)
+
 
 def host_is_ip(host):
-    try:
-        ipaddress.ip_address(host)
+    if re.match(ipv4_pattern, host) or re.match(ipv6_pattern, host,
+                                                flags=re.IGNORECASE):
         return True
-    except ValueError:
+    else:
         return False
+
 
 class TCPConnector(BaseConnector):
     """TCP connector.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1,5 +1,6 @@
 import asyncio
 import aiohttp
+import ipaddress
 import functools
 import http.cookies
 import ssl
@@ -554,7 +555,7 @@ class TCPConnector(BaseConnector):
 
     @asyncio.coroutine
     def _resolve_host(self, host, port):
-        if not self._use_resolver:
+        if not self._use_resolver or self._host_is_ip(host):
             return [{'hostname': host, 'host': host, 'port': port,
                      'family': self._family, 'proto': 0, 'flags': 0}]
 
@@ -572,6 +573,13 @@ class TCPConnector(BaseConnector):
             res = yield from self._resolver.resolve(
                 host, port, family=self._family)
             return res
+
+    def _host_is_ip(self, host):
+        try:
+            ipaddress.ip_address(host)
+            return True
+        except ValueError:
+            return False
 
     @asyncio.coroutine
     def _create_connection(self, req):

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -840,3 +840,18 @@ class TestHttpClientConnector(unittest.TestCase):
         self.assertTrue(conn.use_dns_cache)
         with self.assertWarns(DeprecationWarning):
             self.assertTrue(conn.resolve)
+
+    def test_resolver_not_called_with_address_is_ip(self):
+        resolver = unittest.mock.MagicMock()
+        connector = aiohttp.TCPConnector(resolver=resolver, loop=self.loop)
+
+        class Req:
+            host = '127.0.1.2'
+            port = 63830
+            ssl = False
+            response = unittest.mock.Mock()
+
+        with self.assertRaises(OSError):
+            self.loop.run_until_complete(connector.connect(Req()))
+
+        resolver.resolve.assert_not_called()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -861,6 +861,14 @@ class TestHttpClientConnector(unittest.TestCase):
             '0.0.0.0',
             '127.0.0.1',
             '255.255.255.255',
+            '0:0:0:0:0:0:0:0',
+            'FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF',
+            '00AB:0002:3008:8CFD:00AB:0002:3008:8CFD',
+            '00ab:0002:3008:8cfd:00ab:0002:3008:8cfd',
+            'AB:02:3008:8CFD:AB:02:3008:8CFD',
+            'AB:02:3008:8CFD::02:3008:8CFD',
+            '::',
+            '1::1',
         ]
         for address in ip_addresses:
             assert host_is_ip(address) is True

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -16,7 +16,7 @@ from aiohttp import web
 from aiohttp import client
 from aiohttp import helpers
 from aiohttp.client import ClientResponse
-from aiohttp.connector import Connection
+from aiohttp.connector import Connection, host_is_ip
 
 
 class TestBaseConnector(unittest.TestCase):
@@ -846,8 +846,8 @@ class TestHttpClientConnector(unittest.TestCase):
         connector = aiohttp.TCPConnector(resolver=resolver, loop=self.loop)
 
         class Req:
-            host = '127.0.1.2'
-            port = 63830
+            host = '127.0.0.1'
+            port = 80
             ssl = False
             response = unittest.mock.Mock()
 
@@ -855,3 +855,22 @@ class TestHttpClientConnector(unittest.TestCase):
             self.loop.run_until_complete(connector.connect(Req()))
 
         resolver.resolve.assert_not_called()
+
+    def test_ip_addresses(self):
+        ip_addresses = [
+            '0.0.0.0',
+            '127.0.0.1',
+            '255.255.255.255',
+        ]
+        for address in ip_addresses:
+            assert host_is_ip(address) is True
+
+    def test_host_addresses(self):
+        hosts = [
+            'www.four.part.host'
+            'www.python.org',
+            'foo.bar',
+            'localhost',
+        ]
+        for host in hosts:
+            assert host_is_ip(host) is False


### PR DESCRIPTION
## What these changes does?

This is to finish the work done in PR #874 for the PyCon sprints. I have added using a regex to check if a host is an IP address, which is ~2x more efficient according to `timeit`.

## How to test your changes?

I have added tests for the regex, let me know if these should be more extensive. It is more important to make sure that we do not qualify something that needs a DNS lookup as an IP, than the other way around. I was not concerned about host strings that were neither a valid IP or a domain, as this is an error either way.

## Checklist

- [ ] Code is written and well
- [ ] Tests for the changes are provided
- [ ] Documentation reflects the changes
