### PR TITLE
keepalive_timeout and force_close for BaseConnector class

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -99,6 +99,9 @@ class Connection(object):
         return self._transport is None
 
 
+_default = object()
+
+
 class BaseConnector(object):
     """Base connector class.
 
@@ -112,9 +115,19 @@ class BaseConnector(object):
     _closed = True  # prevent AttributeError in __del__ if ctor was failed
     _source_traceback = None
 
-    def __init__(self, *, conn_timeout=None, keepalive_timeout=30,
+    def __init__(self, *, conn_timeout=None, keepalive_timeout=_default,
                  share_cookies=False, force_close=False, limit=None,
                  loop=None):
+
+        if force_close:
+            if keepalive_timeout is not None and \
+               keepalive_timeout is not _default:
+                raise ValueError('keepalive_timeout cannot '
+                                 'be set if force_close is True')
+        else:
+            if keepalive_timeout is _default:
+                keepalive_timeout = 30
+
         if loop is None:
             loop = asyncio.get_event_loop()
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -701,6 +701,19 @@ class TestBaseConnector(unittest.TestCase):
         self.assertIsNone(conn.limit)
         conn.close()
 
+    def test_force_close_and_explicit_keep_alive(self):
+        with self.assertRaises(ValueError):
+            aiohttp.BaseConnector(loop=self.loop, keepalive_timeout=30,
+                                  force_close=True)
+
+        conn = aiohttp.BaseConnector(loop=self.loop, force_close=True,
+                                     keepalive_timeout=None)
+        assert conn
+
+        conn = aiohttp.BaseConnector(loop=self.loop, force_close=True)
+
+        assert conn
+
 
 class TestHttpClientConnector(unittest.TestCase):
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is code bug fix or documentation correction, select
       the lastest release branch (which looks like "0.xx") -->

## What these changes does?

<!-- Please give a short brief about these changes. -->
Checks parameters for BaseConnector constructor to raise a ValueError if force_close is true and keepalive_timeout is explicitly set

## How to test your changes?
<!-- Describe how we can test your changes if they provides
     any notable behaviour for the end users. -->
set force_close=True and keepalive_timeout to some value and expect a value error

## Related issue number
#786
<!-- Is there any issue opened that get fixed by this? -->

## Checklist

- [ x ] Code is written and well
- [ x ] Tests for the changes are provided
- [ x ] Documentation reflects the changes
