### PR TITLE
Lingering close in ServerHttpProtocol 

### DIFF
--- a/aiohttp/server.py
+++ b/aiohttp/server.py
@@ -58,6 +58,14 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
 
     :param int timeout: slow request timeout
 
+    :param bool lingering_on: enable lingering close
+
+    :param int lingering_time: maximum time during which the server reads and
+    ignore additionnal data comming from the client when lingering close is on
+
+    :param int lingering_timeout: maximum waiting time for more client data to
+    arrive when lingering close is in effect
+
     :param allowed_methods: (optional) List of allowed request methods.
                             Set to empty list to allow all methods.
     :type allowed_methods: tuple
@@ -73,6 +81,7 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
     :param str access_log_format: access log format string
 
     :param loop: Optional event loop
+
     """
     _request_count = 0
     _request_handler = None
@@ -88,6 +97,9 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
                  keep_alive=75,  # NGINX default value is 75 secs
                  keep_alive_on=True,
                  timeout=0,
+                 lingering_on=True,
+                 lingering_time=30,    # NGINX default value is 30 secs
+                 lingering_timeout=5,  # NGINX default value is 5 secs
                  logger=server_logger,
                  access_log=access_logger,
                  access_log_format=helpers.AccessLogger.LOG_FORMAT,
@@ -101,6 +113,9 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
         self._keep_alive_on = keep_alive_on
         self._keep_alive_period = keep_alive  # number of seconds to keep alive
         self._timeout = timeout  # slow request timeout
+        self._lingering_on = lingering_on  # lingering close
+        self._lingering_time = lingering_time
+        self._lingering_timeout = lingering_timeout
         self._loop = loop if loop is not None else asyncio.get_event_loop()
 
         self.logger = log or logger
@@ -289,7 +304,34 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
                 if payload and not payload.is_eof():
                     self.log_debug('Uncompleted request.')
                     self._request_handler = None
-                    self.transport.close()
+
+                    if self._lingering_on:
+                        self.transport.write_eof()
+                        self.log_debug(
+                            'Start lingering close timer for %s sec.',
+                            self._lingering_time)
+
+                        now = self._loop.time()
+                        lingering_handle = self._loop.call_at(
+                            ceil(now+self._lingering_time),
+                            self.transport.close)
+
+                        while True:
+                            try:
+                                # read and ignore
+                                yield from asyncio.wait_for(
+                                    payload.readany(),
+                                    timeout=self._lingering_timeout,
+                                    loop=self._loop)
+                            except (asyncio.TimeoutError,
+                                    errors.ClientDisconnectedError):
+                                break
+
+                        lingering_handle.cancel()
+
+                    if self.transport is not None:
+                        self.transport.close()
+
                     return
                 else:
                     reader.unset_parser()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -393,19 +393,18 @@ def test_lingering(srv, loop):
         srv.reader.feed_data(
             b'GET / HTTP/1.0\r\n'
             b'Host: example.com\r\n'
-            b'Content-Length: 3\r\n\r\n')
+            b'Content-Length: 4\r\n\r\n')
         yield from asyncio.sleep(0, loop=loop)
         srv.reader.feed_data(b'123')
         srv.reader.feed_eof()
 
     srv.handle_request = mock.Mock()
 
-    req = asyncio.ensure_future(srv._request_handler, loop=loop)
-    ling = asyncio.ensure_future(linger(), loop=loop)
+    req = helpers.ensure_future(srv._request_handler, loop=loop)
+    ling = helpers.ensure_future(linger(), loop=loop)
 
     done, pending = yield from asyncio.wait(
         [req, ling], loop=loop, return_when=asyncio.FIRST_COMPLETED)
-
     assert ling in done
     assert req in pending
 


### PR DESCRIPTION
## What do these changes do?

Hello,
 
Quoting [RFC 7230](https://tools.ietf.org/html/rfc7230#page-56) : 

> If a server performs an immediate close of a TCP connection, there is
   a significant risk that the client will not be able to read the last
   HTTP response.  If the server receives additional data from the
   client on a fully closed connection, such as another request that was
   sent by the client before receiving the server's response, the
   server's TCP stack will send a reset packet to the client;
   unfortunately, the reset packet might erase the client's
   unacknowledged input buffers before they can be read and interpreted
   by the client's HTTP parser.

>   To avoid the TCP reset problem, servers typically close a connection
   in stages.  First, the server performs a half-close by closing only
   the write side of the read/write connection.  The server then
   continues to read from the connection until it receives a
   corresponding close by the client, or until the server is reasonably
   certain that its own TCP stack has received the client's
   acknowledgement of the packet(s) containing the server's last
   response.  Finally, the server fully closes the connection.

This is a tentative implementation of a lingering close inspired by [those nginx settings](http://nginx.org/en/docs/http/ngx_http_core_module.html#lingering_close)

## Are there changes in behavior for the user?

The typical use case where the absence of lingering close is worrisome in our application is : 
1. The client starts PUTting a sizeable amount of data ;
2. Server replies with a HTTP 401 Unauthorized after parsing the headers ;
3. The connection  is closed too early for the client to receive / react to the reply. 

It is our experience that some HTTP clients behave badly in front of "early" responses. We believe that having lingerings closes is correct and we are currently investigating how much it will help in practice.

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes

First aiohttp contribution, any input welcome !
