### PR TITLE
Fix empty ALLOW Response header for cls based View

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -655,7 +655,8 @@ class View(AbstractView):
             return (yield from self.__iter__())
 
     def _raise_allowed_methods(self):
-        allowed_methods = {m for m in hdrs.METH_ALL if hasattr(self, m)}
+        allowed_methods = {
+            m for m in hdrs.METH_ALL if hasattr(self, m.lower())}
         raise HTTPMethodNotAllowed(self.request.method, allowed_methods)
 
 

--- a/tests/test_classbasedview.py
+++ b/tests/test_classbasedview.py
@@ -34,11 +34,13 @@ def test_render_unknown_method():
         @asyncio.coroutine
         def get(self):
             return web.Response(text='OK')
+        options = get
 
     request = mock.Mock()
     request.method = 'UNKNOWN'
     with pytest.raises(web.HTTPMethodNotAllowed) as ctx:
         yield from MyView(request)
+    assert ctx.value.headers['allow'] == 'GET,OPTIONS'
     assert ctx.value.status == 405
 
 
@@ -49,9 +51,11 @@ def test_render_unsupported_method():
         @asyncio.coroutine
         def get(self):
             return web.Response(text='OK')
+        options = delete = get
 
     request = mock.Mock()
     request.method = 'POST'
     with pytest.raises(web.HTTPMethodNotAllowed) as ctx:
         yield from MyView(request)
+    assert ctx.value.headers['allow'] == 'DELETE,GET,OPTIONS'
     assert ctx.value.status == 405


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Fix empty ALLOW Response header for cls based View

We must check existing lower http method names for assembling
ALLOW header and passing into web.HTTPMethodNotAllowed.

## Are there changes in behavior for the user?

yes

## Related issue number

No issue

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
