### PR TITLE
Fixed URL matching against quoted characters

### DIFF
--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -174,7 +174,7 @@ class Request(dict, HeadersMixin):
     @reify
     def raw_path(self):
         """ The URL including raw *PATH INFO* without the host or scheme.
-        Warning, the path is unquoted and may contains non valid URL characters
+        Warning, the path is unquoted and may contain non valid URL characters
 
         E.g., ``/my%2Fpath%7Cwith%21some%25strange%24characters``
         """

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -708,7 +708,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
 
     @asyncio.coroutine
     def resolve(self, request):
-        path = request.raw_path
+        path = request.path
         method = request.method
         allowed_methods = set()
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -5,7 +5,7 @@ import re
 import unittest
 from collections.abc import Sized, Container, Iterable, Mapping, MutableMapping
 from unittest import mock
-from urllib.parse import unquote
+from urllib.parse import quote
 import aiohttp.web
 from aiohttp import hdrs
 from aiohttp.web import (UrlDispatcher, Request, Response,
@@ -556,12 +556,12 @@ class TestUrlDispatcher(unittest.TestCase):
         def go():
             handler = self.make_handler()
             self.router.add_route('GET', '/{path}/{subpath}', handler)
-            resource_id = 'my%2Fpath%7Cwith%21some%25strange%24characters'
-            req = self.make_request('GET', '/path/{0}'.format(resource_id))
+            resource_id = 'my path|with!some%strànge$characters'
+            req = self.make_request('GET', '/path/{0}'.format(quote(resource_id)))
             match_info = yield from self.router.resolve(req)
             self.assertEqual(match_info, {
                 'path': 'path',
-                'subpath': unquote(resource_id)
+                'subpath': resource_id
             })
 
         self.loop.run_until_complete(go())

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -557,7 +557,7 @@ class TestUrlDispatcher(unittest.TestCase):
             handler = self.make_handler()
             self.router.add_route('GET', '/{path}/{subpath}', handler)
             resource_id = 'my path|with!some%strànge$characters'
-            req = self.make_request('GET', '/path/{0}'.format(quote(resource_id)))
+            req = self.make_request('GET', quote('/path/' + resource_id))
             match_info = yield from self.router.resolve(req)
             self.assertEqual(match_info, {
                 'path': 'path',

--- a/tests/unicode ünd spaces.txt
+++ b/tests/unicode ünd spaces.txt
@@ -1,0 +1,1 @@
+file with unicode chars and spaces in the file name


### PR DESCRIPTION
## What do these changes do?

The patch fixes URL matching against ümlauts, spaces and other chars that become URL-quoted.
In particular, this fixes `StaticRoute` not being able to deliver static files with non-ASCII filenames.

It also fixes the incorrect test which expected the successful match of raw `/path/my%2Fpath` against `/{path}/{subpath}`, which contradicted the documentation.

## Are there changes in behavior for the user?

This is backwards compatible, unless users adapted to the old (incorrect) behaviour and, for example, renamed their static files to use %XX URL-quoting notation (which is unlikely), or expected `{}` pattern to match an inner `/` (while the documentation clearly says it won't).

## Related issue number

There is no related issue, I decided to come up with a PR right away.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation doesn't need to reflect the change