### PR TITLE
Added build_aiohttp_client_response pytest fixture

### DIFF
--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -5,6 +5,7 @@ import pytest
 
 from .test_utils import (TestClient, loop_context, setup_test_loop,
                          teardown_test_loop)
+from .client_reqrep import ClientResponse
 
 
 @contextlib.contextmanager
@@ -65,3 +66,27 @@ def test_client(loop):
 
     if client:
         client.close()
+
+
+@pytest.fixture()
+def build_aiohttp_client_response():
+    """ This is a parametrized fixture for building aiohttp client responses as needed
+
+    An example usage:
+        ```
+        resp = yield from build_aiohttp_client_response(
+            "GET", "http://example.com",
+            b"{'a': 'a', 'b': 'b'},
+            {"CONTENT-TYPE": "application/json"},
+            200)
+        ```
+
+        dict_resp = yield from resp.json()
+    """
+    async def build_response(method, url, content, headers=None, status=200):
+        cr = ClientResponse(method, url)
+        cr._content = content
+        cr.status = status
+        cr.headers = headers or {}
+        return cr
+    return build_response

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -70,9 +70,11 @@ def test_client(loop):
 
 @pytest.fixture()
 def build_aiohttp_client_response():
-    """ This is a parametrized fixture for building aiohttp client responses as needed
+    """
+    This is a parametrized fixture for building aiohttp client responses as
+    needed.
 
-    An example usage:
+    Example usage:
         ```
         resp = yield from build_aiohttp_client_response(
             "GET", "http://example.com",
@@ -83,7 +85,8 @@ def build_aiohttp_client_response():
 
         dict_resp = yield from resp.json()
     """
-    async def build_response(method, url, content, headers=None, status=200):
+    @asyncio.coroutine
+    def build_response(method, url, content, headers=None, status=200):
         cr = ClientResponse(method, url)
         cr._content = content
         cr.status = status

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -77,6 +77,30 @@ app test client::
         assert await resp.text() == 'value: bar'
 
 
+You can list the fixtures provided by the pytest plugin using the --fixtures
+option from pytest::
+
+    py.test --fixtures
+
+    loop
+        no docstring available
+    test_client
+        no docstring available
+    build_aiohttp_client_response
+        This is a parametrized fixture for building aiohttp client responses as needed
+
+        An example usage:
+        ```
+        resp = yield from build_aiohttp_client_response(
+        "GET", "http://example.com",
+        b'{"a": "a", "b": "b"}',
+        {"CONTENT-TYPE": "application/json"},
+        200)
+
+        dict_resp = yield from resp.json()
+        ```
+
+
 .. _framework-agnostic-utilities:
 
 Framework agnostic utilities

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -94,6 +94,22 @@ def test_get_value(cli):
     assert resp.status == 200
     text = yield from resp.text()
     assert text == 'value: bar'
+
+@asyncio.coroutine
+def test_build_aiohttp_response_json(build_aiohttp_client_response):
+    resp = yield from build_aiohttp_client_response(
+        "POST", "https://github.com/python/asyncio",
+        b'{"value": "foo"}', status=200)
+
+    dict_resp = yield from resp.json()
+    text_resp = yield from resp.text()
+
+    assert '{"value": "foo"}' == text_resp
+    assert {"value": "foo"} == dict_resp
+    assert resp.status == 200
+    assert resp.headers == {}
+    assert resp.method == "POST"
+    assert resp.url == "https://github.com/python/asyncio"
 """)
     result = testdir.runpytest('-p', 'no:sugar')
-    result.assert_outcomes(passed=5, failed=1)
+    result.assert_outcomes(passed=6, failed=1)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Adds a parametrized fixture for the pytest_plugin.py which allows build `ClientResponse` with specified parameters such as method, url, content, headers and status.

## Are there changes in behavior for the user?

Adds extra fixture being able to reduce the number of lines needed for testing external services queried with aiohttp.

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes

