### PR TITLE
Fix #976: Add support for websocket send_json and receive_json

### DIFF
--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -154,6 +154,13 @@ class WebSocketResponse(StreamResponse):
                             type(data))
         self._writer.send(data, binary=True)
 
+    def send_json(self, data, *, dumps=json.dumps):
+        if self._writer is None:
+            raise RuntimeError('Call .prepare() first')
+        if self._closed:
+            raise RuntimeError('websocket connection is closing')
+        self._writer.send(dumps(data), binary=False)
+
     @asyncio.coroutine
     def wait_closed(self):  # pragma: no cover
         warnings.warn(

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -159,7 +159,7 @@ class WebSocketResponse(StreamResponse):
             raise RuntimeError('Call .prepare() first')
         if self._closed:
             raise RuntimeError('websocket connection is closing')
-        self._writer.send(dumps(data), binary=False)
+        self.send_str(dumps(data))
 
     @asyncio.coroutine
     def wait_closed(self):  # pragma: no cover

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -291,12 +291,8 @@ class WebSocketResponse(StreamResponse):
 
     @asyncio.coroutine
     def receive_json(self, *, loads=json.loads):
-        msg = yield from self.receive()
-        if msg.tp != MsgType.text:
-            raise TypeError(
-                "Received message {}:{!r} is not str".format(msg.tp, msg.data)
-            )
-        return msg.json(loads=loads)
+        data = yield from self.receive_str()
+        return loads(data)
 
     def write(self, data):
         raise RuntimeError("Cannot call .write() for websocket")

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -155,10 +155,6 @@ class WebSocketResponse(StreamResponse):
         self._writer.send(data, binary=True)
 
     def send_json(self, data, *, dumps=json.dumps):
-        if self._writer is None:
-            raise RuntimeError('Call .prepare() first')
-        if self._closed:
-            raise RuntimeError('websocket connection is closing')
         self.send_str(dumps(data))
 
     @asyncio.coroutine

--- a/aiohttp/websocket_client.py
+++ b/aiohttp/websocket_client.py
@@ -92,7 +92,7 @@ class ClientWebSocketResponse:
     def send_json(self, data, *, dumps=json.dumps):
         if self._closed:
             raise RuntimeError('websocket connection is closed')
-        self._writer.send(dumps(data), binary=False)
+        self.send_str(dumps(data))
 
     @asyncio.coroutine
     def close(self, *, code=1000, message=b''):

--- a/aiohttp/websocket_client.py
+++ b/aiohttp/websocket_client.py
@@ -194,12 +194,8 @@ class ClientWebSocketResponse:
 
     @asyncio.coroutine
     def receive_json(self, *, loads=json.loads):
-        msg = yield from self.receive()
-        if msg.tp != MsgType.text:
-            raise TypeError(
-                "Received message {}:{!r} is not str".format(msg.tp, msg.data)
-            )
-        return msg.json(loads=loads)
+        data = yield from self.receive_str()
+        return loads(data)
 
     if PY_35:
         @asyncio.coroutine

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1322,9 +1322,8 @@ manually.
 
    .. coroutinemethod:: receive_json(*, loads=json.loads)
 
-      A :ref:`coroutine<coroutine>` that calls :meth:`receive`, asserts the
-      message type is :const:`~aiohttp.websocket.MSG_TEXT`, and loads the JSON
-      string to a Python dict.
+      A :ref:`coroutine<coroutine>` that calls :meth:`receive_str` and loads
+      the JSON string to a Python dict.
 
       :param callable loads: any :term:`callable` that accepts
                               :class:`str` and returns :class:`dict`

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1255,6 +1255,22 @@ manually.
       :raise TypeError: if data is not :class:`bytes`,
                         :class:`bytearray` or :class:`memoryview`.
 
+   .. method:: send_json(data, *, dumps=json.loads)
+
+      Send *data* to peer as JSON string.
+
+      :param data: data to send.
+
+      :param callable dumps: any :term:`callable` that accepts an object and
+                             returns a JSON string
+                             (:func:`json.dumps` by default).
+
+      :raise RuntimeError: if connection is not started or closing
+
+      :raise ValueError: if data is not serializable object
+
+      :raise TypeError: if value returned by :term:`dumps` is not :class:`str`
+
    .. comethod:: close(*, code=1000, message=b'')
 
       A :ref:`coroutine<coroutine>` that initiates closing handshake by sending
@@ -1284,6 +1300,41 @@ manually.
       :return: :class:`~aiohttp.websocket.Message`, `tp` is types of
          `~aiohttp.MsgType`
 
+   .. coroutinemethod:: receive_str()
+
+      A :ref:`coroutine<coroutine>` that calls :meth:`receive` but
+      also asserts the message type is
+      :const:`~aiohttp.websocket.MSG_TEXT`.
+
+      :return str: peer's message content.
+
+      :raise TypeError: if message is :const:`~aiohttp.websocket.MSG_BINARY`.
+
+   .. coroutinemethod:: receive_bytes()
+
+      A :ref:`coroutine<coroutine>` that calls :meth:`receive` but
+      also asserts the message type is
+      :const:`~aiohttp.websocket.MSG_BINARY`.
+
+      :return bytes: peer's message content.
+
+      :raise TypeError: if message is :const:`~aiohttp.websocket.MSG_TEXT`.
+
+   .. coroutinemethod:: receive_json(*, loads=json.loads)
+
+      A :ref:`coroutine<coroutine>` that calls :meth:`receive`, asserts the
+      message type is :const:`~aiohttp.websocket.MSG_TEXT`, and loads the JSON
+      string to a Python dict.
+
+      :param callable loads: any :term:`callable` that accepts
+                              :class:`str` and returns :class:`dict`
+                              with parsed JSON (:func:`json.loads` by
+                              default).
+
+      :return dict: loaded JSON content
+
+      :raise TypeError: if message is :const:`~aiohttp.websocket.MSG_BINARY`.
+      :raise ValueError: if message is not valid JSON.
 
 Utilities
 ---------

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -825,6 +825,22 @@ WebSocketResponse
       :raise TypeError: if data is not :class:`bytes`,
                         :class:`bytearray` or :class:`memoryview`.
 
+   .. method:: send_json(data, *, dumps=json.loads)
+
+      Send *data* to peer as JSON string.
+
+      :param data: data to send.
+
+      :param callable dumps: any :term:`callable` that accepts an object and
+                             returns a JSON string
+                             (:func:`json.dumps` by default).
+
+      :raise RuntimeError: if connection is not started or closing
+
+      :raise ValueError: if data is not serializable object
+
+      :raise TypeError: if value returned by :term:`dumps` is not :class:`str`
+
    .. coroutinemethod:: close(*, code=1000, message=b'')
 
       A :ref:`coroutine<coroutine>` that initiates closing

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -899,9 +899,8 @@ WebSocketResponse
 
    .. coroutinemethod:: receive_json(*, loads=json.loads)
 
-      A :ref:`coroutine<coroutine>` that calls :meth:`receive`, asserts the
-      message type is :const:`~aiohttp.websocket.MSG_TEXT`, and loads the JSON
-      string to a Python dict.
+      A :ref:`coroutine<coroutine>` that calls :meth:`receive_str` and loads the
+      JSON string to a Python dict.
 
       :param callable loads: any :term:`callable` that accepts
                               :class:`str` and returns :class:`dict`

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -1,6 +1,5 @@
 import asyncio
 import unittest
-import json
 from unittest import mock
 from aiohttp import CIMultiDict, helpers
 from aiohttp.web import (
@@ -141,25 +140,6 @@ class TestWebWebSocket(unittest.TestCase):
 
             with self.assertRaises(TypeError):
                 yield from ws.receive_bytes()
-
-        self.loop.run_until_complete(go())
-
-    def test_receive_json_nonjson(self):
-
-        @asyncio.coroutine
-        def go():
-            req = self.make_request('GET', '/')
-            ws = WebSocketResponse()
-            yield from ws.prepare(req)
-
-            @asyncio.coroutine
-            def receive():
-                return websocket.Message(websocket.MSG_TEXT, 'data', b'')
-
-            ws.receive = receive
-
-            with self.assertRaises(json.decoder.JSONDecodeError):
-                yield from ws.receive_json()
 
         self.loop.run_until_complete(go())
 

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -38,14 +38,12 @@ def test_websocket_json_invalid_message(create_app_and_client):
     def handler(request):
         ws = web.WebSocketResponse()
         yield from ws.prepare(request)
-        msg = yield from ws.receive()
-
         try:
-            msg.json()
+            yield from ws.receive_json()
         except ValueError:
-            ws.send_str("ValueError raised: '%s'" % msg.data)
+            ws.send_str('ValueError was raised')
         else:
-            raise Exception("No ValueError was raised")
+            raise Exception('No Exception')
         finally:
             yield from ws.close()
         return ws
@@ -57,8 +55,8 @@ def test_websocket_json_invalid_message(create_app_and_client):
     payload = 'NOT A VALID JSON STRING'
     ws.send_str(payload)
 
-    resp = yield from ws.receive()
-    assert payload in resp.data
+    data = yield from ws.receive_str()
+    assert 'ValueError was raised' in data
 
 
 @pytest.mark.run_loop

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -62,6 +62,30 @@ def test_websocket_json_invalid_message(create_app_and_client):
 
 
 @pytest.mark.run_loop
+def test_websocket_send_json(create_app_and_client):
+    @asyncio.coroutine
+    def handler(request):
+        ws = web.WebSocketResponse()
+        yield from ws.prepare(request)
+
+        data = yield from ws.receive_json()
+        ws.send_json(data)
+
+        yield from ws.close()
+        return ws
+
+    app, client = yield from create_app_and_client()
+    app.router.add_route('GET', '/', handler)
+
+    ws = yield from client.ws_connect('/')
+    expected_value = 'value'
+    ws.send_json({'test': expected_value})
+
+    data = yield from ws.receive_json()
+    assert data['test'] == expected_value
+
+
+@pytest.mark.run_loop
 def test_websocket_receive_json(create_app_and_client):
     @asyncio.coroutine
     def handler(request):

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -334,6 +334,7 @@ class TestWebSocketClient(unittest.TestCase):
         self.assertRaises(RuntimeError, resp.pong)
         self.assertRaises(RuntimeError, resp.send_str, 's')
         self.assertRaises(RuntimeError, resp.send_bytes, b'b')
+        self.assertRaises(RuntimeError, resp.send_json, {})
 
     @mock.patch('aiohttp.client.WebSocketWriter')
     @mock.patch('aiohttp.client.os')
@@ -357,6 +358,7 @@ class TestWebSocketClient(unittest.TestCase):
 
         self.assertRaises(TypeError, resp.send_str, b's')
         self.assertRaises(TypeError, resp.send_bytes, 'b')
+        self.assertRaises(TypeError, resp.send_json, set())
 
     @mock.patch('aiohttp.client.WebSocketWriter')
     @mock.patch('aiohttp.client.os')

--- a/tests/test_websocket_client_functional.py
+++ b/tests/test_websocket_client_functional.py
@@ -22,8 +22,8 @@ def test_send_recv_text(create_app_and_client):
     resp = yield from client.ws_connect('/')
     resp.send_str('ask')
 
-    msg = yield from resp.receive()
-    assert msg.data == 'ask/answer'
+    data = yield from resp.receive_str()
+    assert data == 'ask/answer'
     yield from resp.close()
 
 
@@ -46,8 +46,8 @@ def test_send_recv_bytes(create_app_and_client):
 
     resp.send_bytes(b'ask')
 
-    msg = yield from resp.receive()
-    assert msg.data == b'ask/answer'
+    data = yield from resp.receive_bytes()
+    assert data == b'ask/answer'
 
     yield from resp.close()
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Add support for websocket server to send json and for websocket client to send and receive json

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
User can use methods:
`send_json` and `receive_json` both on websocket server and client
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#976 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes

