### PR TITLE
Added the note about ipdb to CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -60,6 +60,13 @@ After that please install libraries required for development::
 We also recommend to install *ipdb* but it's on your own::
 
    $ pip install ipdb
+   
+.. note:: 
+  If you plan to use ``ipdb`` within the test suite, use::
+  
+    $ make vtest
+  
+  to run the tests. 
 
 Congratulations, you are ready to run the test suite
 


### PR DESCRIPTION
## What do these changes do?

Text note in CONTRIBUTING.rst, to use ``make vtest`` together with ``ipdb``.
It is not obvious why ``ipdb`` with ``make test`` crashes.

## Are there changes in behavior for the user?

No

## Related issue number

No

## Checklist

- [+] I think the code is well written
- [+] Unit tests for the changes exist (not relevant)
- [+] Documentation reflects the changes
