### PR TITLE
Avoid use mutable CIMultiDict kw param in make_mocked_request

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -113,3 +113,4 @@ Yury Selivanov
 Yusuke Tsutsumi
 Марк Коренберг
 Семён Марьясин
+Pau Freixes

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -561,7 +561,7 @@ def _create_transport(sslcontext=None):
 _not_set = object()
 
 
-def make_mocked_request(method, path, headers=CIMultiDict(), *,
+def make_mocked_request(method, path, headers=None, *,
                         version=HttpVersion(1, 1), closing=False,
                         app=None,
                         reader=_not_set,
@@ -616,10 +616,17 @@ def make_mocked_request(method, path, headers=CIMultiDict(), *,
 
     if version < HttpVersion(1, 1):
         closing = True
-    message = RawRequestMessage(method, path, version, headers,
-                                [(k.encode('utf-8'), v.encode('utf-8'))
-                                 for k, v in headers.items()],
-                                closing, False)
+
+    if headers:
+        hdrs = headers
+        raw_hdrs = [
+            (k.encode('utf-8'), v.encode('utf-8')) for k, v in headers.items()]
+    else:
+        hdrs = CIMultiDict()
+        raw_hdrs = []
+
+    message = RawRequestMessage(method, path, version, hdrs,
+                                raw_hdrs, closing, False)
     if app is None:
         app = _create_app_mock()
 

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -20,6 +20,8 @@ def test_ctor(make_request, warning):
     assert '/path/to?a=1&b=2' == req.path_qs
     assert '/path/to' == req.path
     assert 'a=1&b=2' == req.query_string
+    assert CIMultiDict() == req.headers
+    assert () == req.raw_headers
 
     get = req.GET
     assert MultiDict([('a', '1'), ('b', '2')]) == get
@@ -29,18 +31,22 @@ def test_ctor(make_request, warning):
     assert req.keep_alive
 
     # just make sure that all lines of make_mocked_request covered
+    headers = CIMultiDict(FOO='bar')
     reader = mock.Mock()
     writer = mock.Mock()
     payload = mock.Mock()
     transport = mock.Mock()
     app = mock.Mock()
-    req = make_request('GET', '/path/to?a=1&b=2', writer=writer, reader=reader,
-                       payload=payload, transport=transport, app=app)
+    req = make_request('GET', '/path/to?a=1&b=2', headers=headers,
+                       writer=writer, reader=reader, payload=payload,
+                       transport=transport, app=app)
     assert req.app is app
     assert req.content is payload
     assert req.transport is transport
     assert req._reader is reader
     assert req._writer is writer
+    assert req.headers == headers
+    assert req.raw_headers == ((b'FOO', b'bar'),)
 
 
 def test_doubleslashes(make_request):


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Avoid use mutable `CIMultiDict` kw param in make_mocked_request

Even though is hard to get an issue, there is still chances to get
unwished behaviors as a side effect because of that.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes

