### PR TITLE
Refactored ProxyConnector

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -104,7 +104,9 @@ class ClientSession:
                 compress=None,
                 chunked=None,
                 expect100=False,
-                read_until_eof=True):
+                read_until_eof=True,
+                proxy=None,
+                proxy_auth=None):
         """Perform HTTP request."""
 
         return _RequestContextManager(
@@ -123,7 +125,9 @@ class ClientSession:
                 compress=compress,
                 chunked=chunked,
                 expect100=expect100,
-                read_until_eof=read_until_eof))
+                read_until_eof=read_until_eof,
+                proxy=proxy,
+                proxy_auth=proxy_auth,))
 
     @asyncio.coroutine
     def _request(self, method, url, *,
@@ -139,7 +143,9 @@ class ClientSession:
                  compress=None,
                  chunked=None,
                  expect100=False,
-                 read_until_eof=True):
+                 read_until_eof=True,
+                 proxy=None,
+                 proxy_auth=None):
 
         if version is not None:
             warnings.warn("HTTP version should be specified "
@@ -181,7 +187,8 @@ class ClientSession:
                 cookies=cookies, encoding=encoding,
                 auth=auth, version=version, compress=compress, chunked=chunked,
                 expect100=expect100,
-                loop=self._loop, response_class=self._response_class)
+                loop=self._loop, response_class=self._response_class,
+                proxy=proxy, proxy_auth=proxy_auth,)
 
             conn = yield from self._connector.connect(req)
             try:
@@ -621,7 +628,9 @@ def request(method, url, *,
             loop=None,
             read_until_eof=True,
             request_class=None,
-            response_class=None):
+            response_class=None,
+            proxy=None,
+            proxy_auth=None):
     """Constructs and sends a request. Returns response object.
 
     :param str method: HTTP method
@@ -692,7 +701,9 @@ def request(method, url, *,
                          compress=compress,
                          chunked=chunked,
                          expect100=expect100,
-                         read_until_eof=read_until_eof),
+                         read_until_eof=read_until_eof,
+                         proxy=proxy,
+                         proxy_auth=proxy_auth,),
         session=session)
 
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -67,7 +67,8 @@ class ClientRequest:
                  auth=None, encoding='utf-8',
                  version=aiohttp.HttpVersion11, compress=None,
                  chunked=None, expect100=False,
-                 loop=None, response_class=None):
+                 loop=None, response_class=None,
+                 proxy=None, proxy_auth=None):
 
         if loop is None:
             loop = asyncio.get_event_loop()
@@ -91,6 +92,7 @@ class ClientRequest:
         self.update_cookies(cookies)
         self.update_content_encoding(data)
         self.update_auth(auth)
+        self.update_proxy(proxy, proxy_auth)
 
         self.update_body_from_data(data, skip_auto_headers)
         self.update_transfer_encoding()
@@ -365,6 +367,14 @@ class ClientRequest:
 
         if expect:
             self._continue = helpers.create_future(self.loop)
+
+    def update_proxy(self, proxy, proxy_auth):
+        if proxy and not proxy.startswith('http://'):
+            raise ValueError("Only http proxies are supported")
+        if proxy_auth and not isinstance(proxy_auth, helpers.BasicAuth):
+            raise ValueError("proxy_auth must be None or BasicAuth() tuple")
+        self.proxy = proxy
+        self.proxy_auth = proxy_auth
 
     @asyncio.coroutine
     def write_bytes(self, request, reader):

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -421,8 +421,8 @@ In order to specify the nameservers to when resolving the hostnames,
 aiodns is required.
 
     from aiohttp.resolver import AsyncResolver
-    
-    
+
+
     resolver = AsyncResolver(nameservers=["8.8.8.8", "8.8.4.4"])
     conn = aiohttp.TCPConnector(resolver=resolver)
 
@@ -493,26 +493,27 @@ Proxy support
 -------------
 
 aiohttp supports proxy. You have to use
-:class:`~aiohttp.ProxyConnector`::
+:attr:`proxy`::
 
-   conn = aiohttp.ProxyConnector(proxy="http://some.proxy.com")
-   session = aiohttp.ClientSession(connector=conn)
-   async with session.get('http://python.org') as resp:
-       print(resp.status)
+   async with aiohttp.ClientSession() as session:
+       async with session.get("http://python.org",
+                              proxy="http://some.proxy.com") as resp:
+           print(resp.status)
 
-:class:`~aiohttp.ProxyConnector` also supports proxy authorization::
+it also supports proxy authorization::
 
-   conn = aiohttp.ProxyConnector(
-       proxy="http://some.proxy.com",
-       proxy_auth=aiohttp.BasicAuth('user', 'pass'))
-   session = aiohttp.ClientSession(connector=conn)
-   async with session.get('http://python.org') as r:
-       assert r.status == 200
+
+   async with aiohttp.ClientSession() as session:
+       proxy_auth = aiohttp.BasicAuth('user', 'pass')
+       async with session.get("http://python.org",
+                              proxy="http://some.proxy.com",
+                              proxy_auth=proxy_auth) as resp:
+           print(resp.status)
 
 Authentication credentials can be passed in proxy URL::
 
-   conn = aiohttp.ProxyConnector(
-       proxy="http://user:pass@some.proxy.com")
+   session.get("http://python.org",
+               proxy="http://user:pass@some.proxy.com")
 
 
 Response Status Codes

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -143,7 +143,8 @@ The client session supports the context manager protocol for self closing.
                          max_redirects=10, encoding='utf-8',\
                          version=HttpVersion(major=1, minor=1),\
                          compress=None, chunked=None, expect100=False,\
-                         read_until_eof=True)
+                         read_until_eof=True,\
+                         proxy=None, proxy_auth=None)
       :async-with:
       :coroutine:
 
@@ -209,8 +210,17 @@ The client session supports the context manager protocol for self closing.
                                   does not have Content-Length header.
                                   ``True`` by default (optional).
 
+      :param str proxy: Proxy URL (optional)
+
+      :param aiohttp.BasicAuth proxy_auth: an object that represents proxy HTTP
+                                           Basic Authorization (optional)
+
       :return ClientResponse: a :class:`client response
                               <ClientResponse>` object.
+
+      .. versionadded:: 0.23
+
+         Added :attr:`proxy` and :attr:`proxy_auth` parameters.
 
    .. comethod:: get(url, *, allow_redirects=True, **kwargs)
       :async-with:
@@ -674,7 +684,7 @@ There are standard connectors:
 
 1. :class:`TCPConnector` for regular *TCP sockets* (both *HTTP* and
    *HTTPS* schemes supported).
-2. :class:`ProxyConnector` for connecting via HTTP proxy.
+2. :class:`ProxyConnector` for connecting via HTTP proxy (deprecated).
 3. :class:`UnixConnector` for connecting via UNIX socket (it's used mostly for
    testing purposes).
 
@@ -940,6 +950,11 @@ ProxyConnector
    through *HTTP proxy*.
 
    :class:`ProxyConnector` is inherited from :class:`TCPConnector`.
+
+   .. deprecated:: 0.23
+
+      Use :meth:`ClientSession.request` with :attr:`proxy` and :attr:`proxy_auth`
+      parameters.
 
    Usage::
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -14,7 +14,7 @@ import aiohttp
 from aiohttp import web
 from aiohttp import client
 from aiohttp import helpers
-from aiohttp.client import ClientResponse
+from aiohttp.client import ClientResponse, ClientRequest
 from aiohttp.connector import Connection
 
 
@@ -257,11 +257,9 @@ class TestBaseConnector(unittest.TestCase):
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
         proto.is_connected.return_value = True
 
-        class Req:
-            host = 'host'
-            port = 80
-            ssl = False
-            response = unittest.mock.Mock()
+        req = ClientRequest('GET', 'http://host:80',
+                            loop=self.loop,
+                            response_class=unittest.mock.Mock())
 
         conn = aiohttp.BaseConnector(loop=self.loop)
         key = ('host', 80, False)
@@ -270,7 +268,7 @@ class TestBaseConnector(unittest.TestCase):
         conn._create_connection.return_value = helpers.create_future(self.loop)
         conn._create_connection.return_value.set_result((tr, proto))
 
-        connection = self.loop.run_until_complete(conn.connect(Req()))
+        connection = self.loop.run_until_complete(conn.connect(req))
         self.assertFalse(conn._create_connection.called)
         self.assertEqual(connection._transport, tr)
         self.assertEqual(connection._protocol, proto)
@@ -483,11 +481,9 @@ class TestBaseConnector(unittest.TestCase):
             tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
             proto.is_connected.return_value = True
 
-            class Req:
-                host = 'host'
-                port = 80
-                ssl = False
-                response = unittest.mock.Mock()
+            req = ClientRequest('GET', 'http://host:80',
+                                loop=self.loop,
+                                response_class=unittest.mock.Mock())
 
             conn = aiohttp.BaseConnector(loop=self.loop, limit=1)
             key = ('host', 80, False)
@@ -497,7 +493,7 @@ class TestBaseConnector(unittest.TestCase):
                 self.loop)
             conn._create_connection.return_value.set_result((tr, proto))
 
-            connection1 = yield from conn.connect(Req())
+            connection1 = yield from conn.connect(req)
             self.assertEqual(connection1._transport, tr)
 
             self.assertEqual(1, len(conn._acquired[key]))
@@ -507,7 +503,7 @@ class TestBaseConnector(unittest.TestCase):
             @asyncio.coroutine
             def f():
                 nonlocal acquired
-                connection2 = yield from conn.connect(Req())
+                connection2 = yield from conn.connect(req)
                 acquired = True
                 self.assertEqual(1, len(conn._acquired[key]))
                 connection2.release()
@@ -531,11 +527,9 @@ class TestBaseConnector(unittest.TestCase):
             tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
             proto.is_connected.return_value = True
 
-            class Req:
-                host = 'host'
-                port = 80
-                ssl = False
-                response = unittest.mock.Mock()
+            req = ClientRequest('GET', 'http://host:80',
+                                loop=self.loop,
+                                response_class=unittest.mock.Mock())
 
             conn = aiohttp.BaseConnector(loop=self.loop, limit=1)
             key = ('host', 80, False)
@@ -545,14 +539,14 @@ class TestBaseConnector(unittest.TestCase):
                 self.loop)
             conn._create_connection.return_value.set_result((tr, proto))
 
-            connection = yield from conn.connect(Req())
+            connection = yield from conn.connect(req)
             self.assertEqual(connection._transport, tr)
 
             self.assertEqual(1, len(conn._acquired[key]))
 
             with self.assertRaises(asyncio.TimeoutError):
                 # limit exhausted
-                yield from asyncio.wait_for(conn.connect(Req), 0.01,
+                yield from asyncio.wait_for(conn.connect(req), 0.01,
                                             loop=self.loop)
             connection.close()
         self.loop.run_until_complete(go())
@@ -583,11 +577,10 @@ class TestBaseConnector(unittest.TestCase):
             proto = unittest.mock.Mock()
             proto.is_connected.return_value = True
 
-            class Req:
-                host = 'host'
-                port = 80
-                ssl = False
-                response = unittest.mock.Mock(_should_close=False)
+            req = ClientRequest('GET', 'http://host:80',
+                                loop=self.loop,
+                                response_class=unittest.mock.Mock(
+                                    _should_close=False))
 
             max_connections = 2
             num_connections = 0
@@ -629,7 +622,7 @@ class TestBaseConnector(unittest.TestCase):
                     return
                 num_requests += 1
                 if not start:
-                    connection = yield from conn.connect(Req())
+                    connection = yield from conn.connect(req)
                     yield from asyncio.sleep(0, loop=self.loop)
                     connection.release()
                 tasks = [
@@ -652,11 +645,9 @@ class TestBaseConnector(unittest.TestCase):
             tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
             proto.is_connected.return_value = True
 
-            class Req:
-                host = 'host'
-                port = 80
-                ssl = False
-                response = unittest.mock.Mock()
+            req = ClientRequest('GET', 'http://host:80',
+                                loop=self.loop,
+                                response_class=unittest.mock.Mock())
 
             conn = aiohttp.BaseConnector(loop=self.loop, limit=1)
             key = ('host', 80, False)
@@ -666,7 +657,7 @@ class TestBaseConnector(unittest.TestCase):
                 self.loop)
             conn._create_connection.return_value.set_result((tr, proto))
 
-            connection = yield from conn.connect(Req())
+            connection = yield from conn.connect(req)
 
             self.assertEqual(1, len(conn._acquired))
             conn.close()
@@ -845,14 +836,12 @@ class TestHttpClientConnector(unittest.TestCase):
         resolver = unittest.mock.MagicMock()
         connector = aiohttp.TCPConnector(resolver=resolver, loop=self.loop)
 
-        class Req:
-            host = '127.0.0.1'
-            port = 80
-            ssl = False
-            response = unittest.mock.Mock()
+        req = ClientRequest('GET', 'http://127.0.0.1:80',
+                            loop=self.loop,
+                            response_class=unittest.mock.Mock())
 
         with self.assertRaises(OSError):
-            self.loop.run_until_complete(connector.connect(Req()))
+            self.loop.run_until_complete(connector.connect(req))
 
         resolver.resolve.assert_not_called()
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -6,7 +6,7 @@ from aiohttp.client_reqrep import ClientRequest, ClientResponse
 from unittest import mock
 
 
-class TestProxyConnector(unittest.TestCase):
+class TestProxy(unittest.TestCase):
 
     def setUp(self):
         self.loop = asyncio.new_event_loop()
@@ -28,27 +28,19 @@ class TestProxyConnector(unittest.TestCase):
             yield  # pragma: no cover
         mock.side_effect = coro
 
-    def test_ctor(self):
-        with self.assertRaises(AssertionError):
-            aiohttp.ProxyConnector('https://localhost:8118', loop=self.loop)
-
-    def test_ctor2(self):
-        connector = aiohttp.ProxyConnector('http://localhost:8118',
-                                           loop=self.loop)
-
-        self.assertEqual('http://localhost:8118', connector.proxy)
-        self.assertTrue(connector.force_close)
-
     @unittest.mock.patch('aiohttp.connector.ClientRequest')
     def test_connect(self, ClientRequestMock):
-        req = ClientRequest('GET', 'http://www.python.org', loop=self.loop)
-        self.assertEqual(req.path, '/')
+        req = ClientRequest(
+            'GET', 'http://www.python.org',
+            proxy='http://proxy.example.com',
+            loop=self.loop
+        )
+        self.assertEqual(req.proxy, 'http://proxy.example.com')
 
+        # mock all the things!
         loop_mock = unittest.mock.Mock()
-        connector = aiohttp.ProxyConnector('http://proxy.example.com',
-                                           loop=loop_mock)
+        connector = aiohttp.TCPConnector(loop=loop_mock)
         self.assertIs(loop_mock, connector._loop)
-
         resolve_host = unittest.mock.Mock()
         self._fake_coroutine(resolve_host, [unittest.mock.MagicMock()])
         connector._resolve_host = resolve_host
@@ -60,32 +52,34 @@ class TestProxyConnector(unittest.TestCase):
         self.assertIs(conn._transport, tr)
         self.assertIs(conn._protocol, proto)
 
-        # resolve_host.assert_called_once_with('proxy.example.com', 80)
-        tr.get_extra_info.assert_called_once_with('sslcontext')
-
         ClientRequestMock.assert_called_with(
             'GET', 'http://proxy.example.com',
             auth=None,
             headers={'HOST': 'www.python.org'},
             loop=loop_mock)
-        conn.close()
 
     def test_proxy_auth(self):
-        with self.assertRaises(AssertionError) as ctx:
-            aiohttp.ProxyConnector('http://proxy.example.com',
-                                   proxy_auth=('user', 'pass'),
-                                   loop=unittest.mock.Mock())
-        self.assertEqual(ctx.exception.args[0],
-                         ("proxy_auth must be None or BasicAuth() tuple",
-                          ('user', 'pass')))
+        with self.assertRaises(ValueError) as ctx:
+            ClientRequest(
+                'GET', 'http://python.org',
+                proxy='http://proxy.example.com',
+                proxy_auth=('user', 'pass'),
+                loop=unittest.mock.Mock())
+        self.assertEqual(
+            ctx.exception.args[0],
+            "proxy_auth must be None or BasicAuth() tuple",
+        )
 
     def test_proxy_connection_error(self):
-        connector = aiohttp.ProxyConnector('http://proxy.example.com',
-                                           loop=self.loop)
+        connector = aiohttp.TCPConnector(loop=self.loop)
         connector._resolve_host = resolve_mock = unittest.mock.Mock()
         self._fake_coroutine(resolve_mock, OSError('dont take it serious'))
 
-        req = ClientRequest('GET', 'http://www.python.org', loop=self.loop)
+        req = ClientRequest(
+            'GET', 'http://www.python.org',
+            proxy='http://proxy.example.com',
+            loop=self.loop,
+        )
         expected_headers = dict(req.headers)
         with self.assertRaises(aiohttp.ProxyConnectionError):
             self.loop.run_until_complete(connector.connect(req))
@@ -94,25 +88,29 @@ class TestProxyConnector(unittest.TestCase):
 
     @unittest.mock.patch('aiohttp.connector.ClientRequest')
     def test_auth(self, ClientRequestMock):
-        proxy_req = ClientRequest('GET', 'http://proxy.example.com',
-                                  auth=aiohttp.helpers.BasicAuth('user',
-                                                                 'pass'),
-                                  loop=self.loop)
+        proxy_req = ClientRequest(
+            'GET', 'http://proxy.example.com',
+            auth=aiohttp.helpers.BasicAuth('user', 'pass'),
+            loop=self.loop
+        )
         ClientRequestMock.return_value = proxy_req
         self.assertIn('AUTHORIZATION', proxy_req.headers)
         self.assertNotIn('PROXY-AUTHORIZATION', proxy_req.headers)
 
         loop_mock = unittest.mock.Mock()
-        connector = aiohttp.ProxyConnector(
-            'http://proxy.example.com', loop=loop_mock,
-            proxy_auth=aiohttp.helpers.BasicAuth('user', 'pass'))
+        connector = aiohttp.TCPConnector(loop=loop_mock)
         connector._resolve_host = resolve_mock = unittest.mock.Mock()
         self._fake_coroutine(resolve_mock, [unittest.mock.MagicMock()])
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
         self._fake_coroutine(loop_mock.create_connection, (tr, proto))
 
-        req = ClientRequest('GET', 'http://www.python.org', loop=self.loop)
+        req = ClientRequest(
+            'GET', 'http://www.python.org',
+            proxy='http://proxy.example.com',
+            proxy_auth=aiohttp.helpers.BasicAuth('user', 'pass'),
+            loop=self.loop,
+        )
         self.assertNotIn('AUTHORIZATION', req.headers)
         self.assertNotIn('PROXY-AUTHORIZATION', req.headers)
         conn = self.loop.run_until_complete(connector.connect(req))
@@ -145,15 +143,18 @@ class TestProxyConnector(unittest.TestCase):
         self.assertNotIn('PROXY-AUTHORIZATION', proxy_req.headers)
 
         loop_mock = unittest.mock.Mock()
-        connector = aiohttp.ProxyConnector(
-            'http://user:pass@proxy.example.com', loop=loop_mock)
+        connector = aiohttp.TCPConnector(loop=loop_mock)
         connector._resolve_host = resolve_mock = unittest.mock.Mock()
         self._fake_coroutine(resolve_mock, [unittest.mock.MagicMock()])
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
         self._fake_coroutine(loop_mock.create_connection, (tr, proto))
 
-        req = ClientRequest('GET', 'http://www.python.org', loop=self.loop)
+        req = ClientRequest(
+            'GET', 'http://www.python.org',
+            proxy='http://user:pass@proxy.example.com',
+            loop=self.loop,
+        )
         self.assertNotIn('AUTHORIZATION', req.headers)
         self.assertNotIn('PROXY-AUTHORIZATION', req.headers)
         conn = self.loop.run_until_complete(connector.connect(req))
@@ -177,12 +178,15 @@ class TestProxyConnector(unittest.TestCase):
         proxy_req_headers = dict(proxy_req.headers)
 
         loop_mock = unittest.mock.Mock()
-        connector = aiohttp.ProxyConnector(
-            'http://user:pass@proxy.example.com', loop=loop_mock)
+        connector = aiohttp.TCPConnector(loop=loop_mock)
         connector._resolve_host = resolve_mock = unittest.mock.Mock()
         self._fake_coroutine(resolve_mock, OSError('nothing personal'))
 
-        req = ClientRequest('GET', 'http://www.python.org', loop=self.loop)
+        req = ClientRequest(
+            'GET', 'http://www.python.org',
+            proxy='http://user:pass@proxy.example.com',
+            loop=self.loop,
+        )
         req_headers = dict(req.headers)
         with self.assertRaises(aiohttp.ProxyConnectionError):
             self.loop.run_until_complete(connector.connect(req))
@@ -204,13 +208,16 @@ class TestProxyConnector(unittest.TestCase):
         proxy_resp.start = start_mock = unittest.mock.Mock()
         self._fake_coroutine(start_mock, unittest.mock.Mock(status=200))
 
-        connector = aiohttp.ProxyConnector(
-            'http://proxy.example.com', loop=loop_mock)
+        connector = aiohttp.TCPConnector(loop=loop_mock)
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
         self._fake_coroutine(loop_mock.create_connection, (tr, proto))
 
-        req = ClientRequest('GET', 'https://www.python.org', loop=self.loop)
+        req = ClientRequest(
+            'GET', 'https://www.python.org',
+            proxy='http://proxy.example.com',
+            loop=self.loop,
+        )
         self.loop.run_until_complete(connector._create_connection(req))
 
         self.assertEqual(req.path, '/')
@@ -237,14 +244,17 @@ class TestProxyConnector(unittest.TestCase):
         proxy_resp.start = start_mock = unittest.mock.Mock()
         self._fake_coroutine(start_mock, unittest.mock.Mock(status=200))
 
-        connector = aiohttp.ProxyConnector(
-            'http://proxy.example.com', loop=loop_mock)
+        connector = aiohttp.TCPConnector(loop=loop_mock)
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
         tr.get_extra_info.return_value = None
         self._fake_coroutine(loop_mock.create_connection, (tr, proto))
 
-        req = ClientRequest('GET', 'https://www.python.org', loop=self.loop)
+        req = ClientRequest(
+            'GET', 'https://www.python.org',
+            proxy='http://proxy.example.com',
+            loop=self.loop,
+        )
         with self.assertRaisesRegex(
                 RuntimeError, "Transport does not expose socket instance"):
             self.loop.run_until_complete(connector._create_connection(req))
@@ -268,14 +278,17 @@ class TestProxyConnector(unittest.TestCase):
         self._fake_coroutine(
             start_mock, unittest.mock.Mock(status=400, reason='bad request'))
 
-        connector = aiohttp.ProxyConnector(
-            'http://proxy.example.com', loop=loop_mock)
+        connector = aiohttp.TCPConnector(loop=loop_mock)
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
         tr.get_extra_info.return_value = None
         self._fake_coroutine(loop_mock.create_connection, (tr, proto))
 
-        req = ClientRequest('GET', 'https://www.python.org', loop=self.loop)
+        req = ClientRequest(
+            'GET', 'https://www.python.org',
+            proxy='http://proxy.example.com',
+            loop=self.loop,
+        )
         with self.assertRaisesRegex(
                 aiohttp.HttpProxyError, "400, message='bad request'"):
             self.loop.run_until_complete(connector._create_connection(req))
@@ -298,14 +311,17 @@ class TestProxyConnector(unittest.TestCase):
         proxy_resp.start = start_mock = unittest.mock.Mock()
         self._fake_coroutine(start_mock, OSError("error message"))
 
-        connector = aiohttp.ProxyConnector(
-            'http://proxy.example.com', loop=loop_mock)
+        connector = aiohttp.TCPConnector(loop=loop_mock)
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
         tr.get_extra_info.return_value = None
         self._fake_coroutine(loop_mock.create_connection, (tr, proto))
 
-        req = ClientRequest('GET', 'https://www.python.org', loop=self.loop)
+        req = ClientRequest(
+            'GET', 'https://www.python.org',
+            proxy='http://proxy.example.com',
+            loop=self.loop,
+        )
         with self.assertRaisesRegex(OSError, "error message"):
             self.loop.run_until_complete(connector._create_connection(req))
 
@@ -316,31 +332,34 @@ class TestProxyConnector(unittest.TestCase):
         ClientRequestMock.return_value = proxy_req
 
         loop_mock = unittest.mock.Mock()
-        connector = aiohttp.ProxyConnector('http://proxy.example.com',
-                                           loop=loop_mock)
+        connector = aiohttp.TCPConnector(loop=loop_mock)
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
         tr.get_extra_info.return_value = None
         self._fake_coroutine(loop_mock.create_connection, (tr, proto))
 
-        req = ClientRequest('GET', 'http://localhost:1234/path',
-                            loop=self.loop)
+        req = ClientRequest(
+            'GET', 'http://localhost:1234/path',
+            proxy='http://proxy.example.com',
+            loop=self.loop,
+        )
         self.loop.run_until_complete(connector._create_connection(req))
         self.assertEqual(req.path, 'http://localhost:1234/path')
 
     def test_proxy_auth_property(self):
-        connector = aiohttp.ProxyConnector(
-            'http://proxy.example.com',
+        req = aiohttp.ClientRequest(
+            'GET', 'http://localhost:1234/path',
+            proxy='http://proxy.example.com',
             proxy_auth=aiohttp.helpers.BasicAuth('user', 'pass'),
             loop=self.loop)
-        self.assertEqual(('user', 'pass', 'latin1'), connector.proxy_auth)
-        connector.close()
+        self.assertEqual(('user', 'pass', 'latin1'), req.proxy_auth)
 
     def test_proxy_auth_property_default(self):
-        connector = aiohttp.ProxyConnector('http://proxy.example.com',
-                                           loop=self.loop)
-        self.assertIsNone(connector.proxy_auth)
-        connector.close()
+        req = aiohttp.ClientRequest(
+            'GET', 'http://localhost:1234/path',
+            proxy='http://proxy.example.com',
+            loop=self.loop)
+        self.assertIsNone(req.proxy_auth)
 
     @unittest.mock.patch('aiohttp.connector.ClientRequest')
     def test_https_connect_pass_ssl_context(self, ClientRequestMock):
@@ -356,13 +375,16 @@ class TestProxyConnector(unittest.TestCase):
         proxy_resp.start = start_mock = unittest.mock.Mock()
         self._fake_coroutine(start_mock, unittest.mock.Mock(status=200))
 
-        connector = aiohttp.ProxyConnector(
-            'http://proxy.example.com', loop=loop_mock)
+        connector = aiohttp.TCPConnector(loop=loop_mock)
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
         self._fake_coroutine(loop_mock.create_connection, (tr, proto))
 
-        req = ClientRequest('GET', 'https://www.python.org', loop=self.loop)
+        req = ClientRequest(
+            'GET', 'https://www.python.org',
+            proxy='http://proxy.example.com',
+            loop=self.loop,
+        )
         self.loop.run_until_complete(connector._create_connection(req))
 
         loop_mock.create_connection.assert_called_with(
@@ -397,8 +419,7 @@ class TestProxyConnector(unittest.TestCase):
         proxy_resp.start = start_mock = unittest.mock.Mock()
         self._fake_coroutine(start_mock, unittest.mock.Mock(status=200))
 
-        connector = aiohttp.ProxyConnector(
-            'http://proxy.example.com', loop=loop_mock)
+        connector = aiohttp.TCPConnector(loop=loop_mock)
 
         tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
         self._fake_coroutine(loop_mock.create_connection, (tr, proto))
@@ -406,7 +427,11 @@ class TestProxyConnector(unittest.TestCase):
         self.assertIn('AUTHORIZATION', proxy_req.headers)
         self.assertNotIn('PROXY-AUTHORIZATION', proxy_req.headers)
 
-        req = ClientRequest('GET', 'https://www.python.org', loop=self.loop)
+        req = ClientRequest(
+            'GET', 'https://www.python.org',
+            proxy='http://proxy.example.com',
+            loop=self.loop
+        )
         self.assertNotIn('AUTHORIZATION', req.headers)
         self.assertNotIn('PROXY-AUTHORIZATION', req.headers)
         self.loop.run_until_complete(connector._create_connection(req))
@@ -420,3 +445,75 @@ class TestProxyConnector(unittest.TestCase):
         self.loop.run_until_complete(proxy_req.close())
         proxy_resp.close()
         self.loop.run_until_complete(req.close())
+
+
+class TestProxyConnector(unittest.TestCase):
+
+    """
+    Backward compatibility simple test. Most testing happens in TextProxy.
+    """
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+
+    def tearDown(self):
+        # just in case if we have transport close callbacks
+        self.loop.stop()
+        self.loop.run_forever()
+        self.loop.close()
+        gc.collect()
+
+    def _fake_coroutine(self, mock, return_value):
+
+        def coro(*args, **kw):
+            if isinstance(return_value, Exception):
+                raise return_value
+            return return_value
+            yield  # pragma: no cover
+        mock.side_effect = coro
+
+    def test_ctor(self):
+        connector = aiohttp.ProxyConnector(
+            'http://localhost:8118',
+            proxy_auth=aiohttp.helpers.BasicAuth('user', 'pass'),
+            loop=self.loop,
+        )
+
+        self.assertEqual('http://localhost:8118', connector.proxy)
+        self.assertEqual(
+            aiohttp.helpers.BasicAuth('user', 'pass'),
+            connector.proxy_auth
+        )
+        self.assertTrue(connector.force_close)
+
+    @unittest.mock.patch('aiohttp.connector.ClientRequest')
+    def test_connect(self, ClientRequestMock):
+        req = ClientRequest('GET', 'http://www.python.org', loop=self.loop)
+        self.assertEqual(req.path, '/')
+
+        loop_mock = unittest.mock.Mock()
+        connector = aiohttp.ProxyConnector('http://proxy.example.com',
+                                           loop=loop_mock)
+        self.assertIs(loop_mock, connector._loop)
+
+        resolve_host = unittest.mock.Mock()
+        self._fake_coroutine(resolve_host, [unittest.mock.MagicMock()])
+        connector._resolve_host = resolve_host
+
+        tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
+        self._fake_coroutine(loop_mock.create_connection, (tr, proto))
+        conn = self.loop.run_until_complete(connector.connect(req))
+        self.assertEqual(req.path, 'http://www.python.org/')
+        self.assertIs(conn._transport, tr)
+        self.assertIs(conn._protocol, proto)
+
+        # resolve_host.assert_called_once_with('proxy.example.com', 80)
+        tr.get_extra_info.assert_called_once_with('sslcontext')
+
+        ClientRequestMock.assert_called_with(
+            'GET', 'http://proxy.example.com',
+            auth=None,
+            headers={'HOST': 'www.python.org'},
+            loop=loop_mock)
+        conn.close()


### PR DESCRIPTION
## What do these changes do?

1. Proxy request logic is moved from ProxyConnector to TCPConnector
2. Proxy now is set in ClientSession.request() and can be changed for each subsequent request, e.g `session.get("http://httpbin.org/get", proxy="http://localhost:8020")`
3. ProxyConnector stays for backwards compatibility, however now it is just a thin wrapper around TCPConnector.

## Are there changes in behavior for the user?

Old ProxyConnector code still works, however new way is preferred. 
Documentation is updated to reflect that change.

## Related issue number

#985 

## Checklist

- [+] I think the code is well written
- [+] Unit tests for the changes exist
- [+] Documentation reflects the changes
