### PR TITLE
Gunicorn worker ssl

### DIFF
--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -17,10 +17,6 @@ class GunicornWebWorker(base.Worker):
 
     def __init__(self, *args, **kw):  # pragma: no cover
         super().__init__(*args, **kw)
-        if self.cfg.is_ssl:
-            self.ssl_context = self._create_ssl_context(self.cfg)
-        else:
-            self.ssl_context = None
 
         self.servers = {}
         self.exit_code = 0
@@ -85,10 +81,13 @@ class GunicornWebWorker(base.Worker):
 
     @asyncio.coroutine
     def _run(self):
+
+        ctx = self._create_ssl_context(self.cfg) if self.cfg.is_ssl else None
+
         for sock in self.sockets:
             handler = self.make_handler(self.wsgi)
             srv = yield from self.loop.create_server(handler, sock=sock.sock,
-                                                     ssl=self.ssl_context)
+                                                     ssl=ctx)
             self.servers[srv] = handler
 
         # If our parent changed then we shut down.


### PR DESCRIPTION
## What do these changes do?

`gunicorn` provides SSL support for sync workers and for `gaiohttp` worker for aiohttp.
`aiohttp` provides GunicornWebWorker, but it lacks SSL support.
This PR allows GunicornWebWorker to init SSL from gunicorn config.

## Are there changes in behavior for the user?

No regressions expected

## Related issue number

Nope

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes