### PR TITLE
Add terminate method to websocket response

### DIFF
--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -79,8 +79,9 @@ class WebSocketResponse(StreamResponse):
         self._writer = writer
         self._protocol = protocol
         self._loop = request.app.loop
-        self._reader_task = weakref.proxy(
-            asyncio.Task.current_task(loop=self._loop))
+        current_task = asyncio.Task.current_task(loop=self._loop)
+        if current_task is not None:
+            self._reader_task = weakref.proxy(current_task)
 
     def start(self, request):
         warnings.warn('use .prepare(request) instead', DeprecationWarning)

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -244,7 +244,6 @@ class WebSocketResponse(StreamResponse):
                     msg = yield from self._reader.read()
                 except (asyncio.CancelledError, asyncio.TimeoutError):
                     if self._terminating:
-                        #self._waiting = False
                         return Message(MsgType.close, None, None)
                     raise
                 except WebSocketError as exc:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -176,7 +176,7 @@ class WebSocketResponse(StreamResponse):
         self._reader_task.cancel()
 
     @property
-    def terminating(self):
+    def terminated(self):
         return self._terminating
 
     def terminate(self):

--- a/aiohttp/websocket.py
+++ b/aiohttp/websocket.py
@@ -89,6 +89,11 @@ class WebSocketError(Exception):
         super().__init__(message)
 
 
+class WebSocketTerminate(Exception):
+    """Server-side websocket termination request"""
+    pass
+
+
 def WebSocketParser(out, buf):
     while True:
         fin, opcode, payload = yield from parse_frame(buf)

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -129,3 +129,59 @@ peer::
                 ws.send_str(answer)
         finally:
             await redis.unsubscribe('channel:1')
+
+
+.. _aiohttp_faq_terminating_websockets:
+
+How to programmatically close websocket server-side?
+----------------------------------------------------
+
+
+For example we have an application with two endpoints:
+
+
+   1. ``/echo`` a websocket echo server that authenticates the user somehow
+   2. ``/logout_user`` that when invoked needs to close all open websockets for that user.
+
+Keep in mind that you can only all ``.close()`` on a websocket from the handler task, while you can
+safely call ``.terminate()`` from different tasks.
+
+The simplest way to perform it is keeping a shared registry of open websocket responses for a user
+in the :class:`aiohttp.web.Application`, then in ``/logout_user`` handler cycle through all the websockets for
+the user and ``terminate()`` them::
+
+    async def echo_handler(request):
+
+        ws = web.WebSocketResponse()
+        user_id = authenticate_user(request)
+        await ws.prepare(request)
+        request.app['websockets'][user_id].add(ws)
+
+        try:
+            async for msg in ws:
+                # handle incoming messages
+                ...
+
+        finally:
+            request.app['websockets'][user_id].pop(ws)
+
+        await ws.close()
+        return ws
+
+    async def logout_handler(request):
+
+        user_id = authenticate_user(request)
+
+        for ws in request.app['websockets'][user_id]:
+            ws.terminate()
+
+        # return response
+        ...
+
+    def main():
+        loop = asyncio.get_event_loop()
+        app = aiohttp.web.Application(loop=loop)
+        app.router.add_route('GET', '/echo', echo_handler)
+        app.router.add_route('POST', '/logout', logout_handler)
+        app['websockets'] = defaultdict(set)
+        aiohttp.web.run_app(app, host='localhost', port=8080)

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -162,9 +162,10 @@ the user and ``terminate()`` them::
                 # handle incoming messages
                 ...
 
+        except asyncio.websocket.WebSocketTerminate:
+            print('websocket terminated')
         finally:
-            request.app['websockets'][user_id].pop(ws)
-
+            request.app['websockets'][user_id].remove(ws)
         await ws.close()
         return ws
 

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -536,9 +536,13 @@ with the peer::
 
         return ws
 
-Reading from the *WebSocket* (``await ws.receive()``) **must only** be
-done inside the request handler *task*; however, writing
-(``ws.send_str(...)``) to the *WebSocket* may be delegated to other tasks.
+.. _aiohttp-web-websocket-read-same-task:
+
+Reading from the *WebSocket* (``await ws.receive()``) and closing it (``await ws.close()``)
+**must only** be done inside the request handler *task*; however, writing
+(``ws.send_str(...)``) to the *WebSocket* and terminating in (``ws.terminate()``)
+may be delegated to other tasks. See also :ref:`FAQ section <aiohttp_faq_terminating_websockets>`.
+
 *aiohttp.web* creates an implicit :class:`asyncio.Task` for handling every
 incoming request.
 
@@ -556,6 +560,7 @@ incoming request.
 
    Parallel reads from websocket are forbidden, there is no
    possibility to call :meth:`aiohttp.web.WebSocketResponse.receive`
+   or :meth:`aiohttp.web.WebSocketResponse.close`
    from two tasks.
 
    See :ref:`FAQ section <aiohttp_faq_parallel_event_sources>` for

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -859,7 +859,19 @@ WebSocketResponse
 
       :raise RuntimeError: if connection is not started or closing
 
-   .. coroutinemethod:: receive()
+   .. method:: terminate()
+
+      Kill a websocket from a task that is not the request handler.
+
+      This method does not close the websocket, it only cancels the ongoing read tasks.
+
+   .. attribute:: terminated
+
+      Read-only property, ``True`` if connection has been terminated server-side.
+
+      A terminated connection has to be explicitly closed by the handler function.
+
+    .. coroutinemethod:: receive()
 
       A :ref:`coroutine<coroutine>` that waits upcoming *data*
       message from peer and returns it.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -861,15 +861,15 @@ WebSocketResponse
 
    .. method:: terminate()
 
-      Kill a websocket from a task that is not the request handler.
+      Kill a *Websocket* from a *task* that is not the request handler.
 
-      This method does not close the websocket, it only cancels the ongoing read tasks.
+      This method does not close the *Websocket*, it only cancels the ongoing read tasks.
 
    .. attribute:: terminated
 
       Read-only property, ``True`` if connection has been terminated server-side.
 
-      A terminated connection has to be explicitly closed by the handler function.
+      A terminated connection has to be explicitly closed by the request handler *task*.
 
     .. coroutinemethod:: receive()
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -16,6 +16,7 @@ from aiohttp import client
 from aiohttp import helpers
 from aiohttp.client import ClientResponse, ClientRequest
 from aiohttp.connector import Connection
+from aiohttp.test_utils import unused_port
 
 
 class TestBaseConnector(unittest.TestCase):

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -16,7 +16,6 @@ from aiohttp import client
 from aiohttp import helpers
 from aiohttp.client import ClientResponse, ClientRequest
 from aiohttp.connector import Connection
-from aiohttp.test_utils import unused_port
 
 
 class TestBaseConnector(unittest.TestCase):

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -447,3 +447,16 @@ class TestWebWebSocket(unittest.TestCase):
         ws = WebSocketResponse(protocols=('chat',))
         with self.assertWarns(DeprecationWarning):
             self.assertEqual((True, 'chat'), ws.can_start(req))
+
+    @asyncio.coroutine
+    def _prepare_and_read(self, request, ws):
+        yield from ws.prepare(request)
+        while True:
+            yield from ws.receive()
+
+    def test_terminate_raises_exception_outside_reading(self):
+        req = self.make_request('GET', '/')
+        ws = WebSocketResponse()
+        ws.terminate()
+        with self.assertRaises(websocket.WebSocketTerminate):
+            self.loop.run_until_complete(self._prepare_and_read(req, ws))

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -435,6 +435,13 @@ class TestWebWebSocket(unittest.TestCase):
             impl2 = ws.start(req)
             self.assertIs(impl1, impl2)
 
+    def test_prepare_twice_idempotent(self):
+        req = self.make_request('GET', '/')
+        ws = WebSocketResponse()
+        impl1 = self.loop.run_until_complete(ws.prepare(req))
+        impl2 = self.loop.run_until_complete(ws.prepare(req))
+        self.assertIs(impl1, impl2)
+
     def test_can_start_ok(self):
         req = self.make_request('GET', '/', protocols=True)
         ws = WebSocketResponse(protocols=('chat',))


### PR DESCRIPTION
See #922 

Add a clean way for closing websockets server-side

## Related issue number

#922 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes

