### PR TITLE
Choose an unused port in tests

### DIFF
--- a/tests/test_client_functional_oldstyle.py
+++ b/tests/test_client_functional_oldstyle.py
@@ -7,7 +7,6 @@ import os.path
 import json
 import http.cookies
 import asyncio
-import socket
 import unittest
 from unittest import mock
 
@@ -17,14 +16,7 @@ import aiohttp
 from aiohttp import client, helpers
 from aiohttp import test_utils
 from aiohttp.multipart import MultipartWriter
-
-
-def find_unused_port():
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(('127.0.0.1', 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
+from aiohttp.test_utils import unused_port
 
 
 class TestHttpClientFunctional(unittest.TestCase):
@@ -952,7 +944,7 @@ class TestHttpClientFunctional(unittest.TestCase):
         @asyncio.coroutine
         def go():
             server = yield from self.loop.create_server(
-                Proto, '127.0.0.1', find_unused_port())
+                Proto, '127.0.0.1', unused_port())
 
             addr = server.sockets[0].getsockname()
 
@@ -995,7 +987,7 @@ class TestHttpClientFunctional(unittest.TestCase):
         @asyncio.coroutine
         def go():
             server = yield from self.loop.create_server(
-                Proto, '127.0.0.1', find_unused_port())
+                Proto, '127.0.0.1', unused_port())
 
             addr = server.sockets[0].getsockname()
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -16,6 +16,7 @@ from aiohttp import client
 from aiohttp import helpers
 from aiohttp.client import ClientResponse, ClientRequest
 from aiohttp.connector import Connection
+from aiohttp.test_utils import unused_port
 
 
 class TestBaseConnector(unittest.TestCase):
@@ -840,7 +841,7 @@ class TestHttpClientConnector(unittest.TestCase):
         resolver = unittest.mock.MagicMock()
         connector = aiohttp.TCPConnector(resolver=resolver, loop=self.loop)
 
-        req = ClientRequest('GET', 'http://127.0.0.1:80',
+        req = ClientRequest('GET', 'http://127.0.0.1:{}'.format(unused_port()),
                             loop=self.loop,
                             response_class=unittest.mock.Mock())
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -719,19 +719,12 @@ class TestHttpClientConnector(unittest.TestCase):
         self.loop.close()
         gc.collect()
 
-    def find_unused_port(self):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(('127.0.0.1', 0))
-        port = s.getsockname()[1]
-        s.close()
-        return port
-
     @asyncio.coroutine
     def create_server(self, method, path, handler):
         app = web.Application(loop=self.loop)
         app.router.add_route(method, path, handler)
 
-        port = self.find_unused_port()
+        port = unused_port()
         self.handler = app.make_handler(keep_alive_on=False)
         srv = yield from self.loop.create_server(
             self.handler, '127.0.0.1', port)
@@ -781,7 +774,7 @@ class TestHttpClientConnector(unittest.TestCase):
             self.create_server('get', '/', handler)
         )
 
-        port = self.find_unused_port()
+        port = unused_port()
         conn = aiohttp.TCPConnector(loop=self.loop,
                                     local_addr=('127.0.0.1', port))
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -3,7 +3,6 @@ import gc
 import json
 import os
 import os.path
-import socket
 import unittest
 import zlib
 from multidict import MultiDict
@@ -11,6 +10,7 @@ from aiohttp import log, web, request, FormData, ClientSession, TCPConnector
 from aiohttp.file_sender import FileSender
 from aiohttp.protocol import HttpVersion, HttpVersion10, HttpVersion11
 from aiohttp.streams import EOF_MARKER
+from aiohttp.test_utils import unused_port
 
 from unittest import mock
 
@@ -35,13 +35,6 @@ class WebFunctionalSetupMixin:
         self.loop.close()
         gc.collect()
 
-    def find_unused_port(self):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(('127.0.0.1', 0))
-        port = s.getsockname()[1]
-        s.close()
-        return port
-
     @asyncio.coroutine
     def create_server(self, method, path, handler=None, ssl_ctx=None,
                       logger=log.server_logger, handler_kwargs=None):
@@ -50,7 +43,7 @@ class WebFunctionalSetupMixin:
         if handler:
             app.router.add_route(method, path, handler)
 
-        port = self.find_unused_port()
+        port = unused_port()
         self.handler = app.make_handler(
             keep_alive_on=False,
             access_log=log.access_logger,

--- a/tests/test_web_websocket_functional_oldstyle.py
+++ b/tests/test_web_websocket_functional_oldstyle.py
@@ -2,8 +2,8 @@ import asyncio
 import base64
 import hashlib
 import os
-import socket
 import unittest
+from aiohttp.test_utils import unused_port
 
 import aiohttp
 from aiohttp import helpers, web, websocket
@@ -21,19 +21,12 @@ class TestWebWebSocketFunctional(unittest.TestCase):
     def tearDown(self):
         self.loop.close()
 
-    def find_unused_port(self):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(('127.0.0.1', 0))
-        port = s.getsockname()[1]
-        s.close()
-        return port
-
     @asyncio.coroutine
     def create_server(self, method, path, handler):
         app = web.Application(loop=self.loop)
         app.router.add_route(method, path, handler)
 
-        port = self.find_unused_port()
+        port = unused_port()
         srv = yield from self.loop.create_server(
             app.make_handler(), '127.0.0.1', port)
         url = "http://127.0.0.1:{}".format(port) + path


### PR DESCRIPTION
When running test locally, I get a failure just because I have a web server running on my machine.

This fixes it