### PR TITLE
Skip IPv6 tests when its not available

### DIFF
--- a/tests/test_stream_writer.py
+++ b/tests/test_stream_writer.py
@@ -4,6 +4,17 @@ from aiohttp.parsers import StreamWriter, CORK
 from unittest import mock
 
 
+has_ipv6 = socket.has_ipv6
+if has_ipv6:
+    # The socket.has_ipv6 flag may be True if Python was built with IPv6
+    # support, but the target system still may not have it.
+    # So let's ensure that we really have IPv6 support.
+    try:
+        socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    except OSError:
+        has_ipv6 = False
+
+
 # nodelay
 
 def test_nodelay_default(loop):
@@ -54,7 +65,7 @@ def test_set_nodelay_enable_and_disable(loop):
     assert not s.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
 
 
-@pytest.mark.skipif(not socket.has_ipv6, reason="IPv6 is not available")
+@pytest.mark.skipif(not has_ipv6, reason="IPv6 is not available")
 def test_set_nodelay_enable_ipv6(loop):
     transport = mock.Mock()
     s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
@@ -145,7 +156,7 @@ def test_set_cork_enable_and_disable(loop):
     assert not s.getsockopt(socket.IPPROTO_TCP, CORK)
 
 
-@pytest.mark.skipif(not socket.has_ipv6, reason="IPv6 is not available")
+@pytest.mark.skipif(not has_ipv6, reason="IPv6 is not available")
 @pytest.mark.skipif(CORK is None, reason="TCP_CORK or TCP_NOPUSH required")
 def test_set_cork_enable_ipv6(loop):
     transport = mock.Mock()

--- a/tests/test_stream_writer.py
+++ b/tests/test_stream_writer.py
@@ -54,6 +54,7 @@ def test_set_nodelay_enable_and_disable(loop):
     assert not s.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
 
 
+@pytest.mark.skipif(not socket.has_ipv6, reason="IPv6 is not available")
 def test_set_nodelay_enable_ipv6(loop):
     transport = mock.Mock()
     s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
@@ -144,6 +145,7 @@ def test_set_cork_enable_and_disable(loop):
     assert not s.getsockopt(socket.IPPROTO_TCP, CORK)
 
 
+@pytest.mark.skipif(not socket.has_ipv6, reason="IPv6 is not available")
 @pytest.mark.skipif(CORK is None, reason="TCP_CORK or TCP_NOPUSH required")
 def test_set_cork_enable_ipv6(loop):
     transport = mock.Mock()


### PR DESCRIPTION
This fixes tests for IPv4-only hosts. Also, I found interesting case when Python is build with IPv6 support, but OS actually is not (one case: disabled in kernel). This turns to be undetectable by Python which still thinks IPv6 is ready to go (`socket.has_ipv6 is True`), but it fails meeting the reality.

Obliviously, this is not correct things setup, but we shouldn't bail because of that.