### PR TITLE
#921 show directory index [WIP]

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -440,7 +440,8 @@ class StaticRoute(Route):
 
     def __init__(self, name, prefix, directory, *,
                  expect_handler=None, chunk_size=256*1024,
-                 response_factory=StreamResponse):
+                 response_factory=StreamResponse,
+                 show_index=False):
         assert prefix.startswith('/'), prefix
         assert prefix.endswith('/'), prefix
         super().__init__(
@@ -460,6 +461,7 @@ class StaticRoute(Route):
         self._directory = directory
         self._file_sender = FileSender(resp_factory=response_factory,
                                        chunk_size=chunk_size)
+        self._show_index = show_index
 
     def match(self, path):
         if not path.startswith(self._prefix):
@@ -723,7 +725,8 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
                                   expect_handler=expect_handler)
 
     def add_static(self, prefix, path, *, name=None, expect_handler=None,
-                   chunk_size=256*1024, response_factory=StreamResponse):
+                   chunk_size=256*1024, response_factory=StreamResponse,
+                   show_index=False):
         """
         Adds static files view
         :param prefix - url prefix
@@ -735,6 +738,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         route = StaticRoute(name, prefix, path,
                             expect_handler=expect_handler,
                             chunk_size=chunk_size,
-                            response_factory=response_factory)
+                            response_factory=response_factory,
+                            show_index=show_index)
         self.register_route(route)
         return route

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -497,16 +497,15 @@ class StaticRoute(Route):
         # on opening a dir, load it's contents if allowed
         if filepath.is_dir():
             if self._show_index:
-                return Response(text=self._dir_index_html(filepath))
+                ret = Response(text=self._dir_index_html(filepath))
             else:
                 raise HTTPForbidden()
-
-        # on opening a file, load it's contents if they exist
-        if filepath.is_file():
+        elif filepath.is_file():
             ret = yield from self._file_sender.send(request, filepath)
-            return ret
         else:
             raise HTTPNotFound
+
+        return ret
 
     def _dir_index_html(self, filepath):
         "returns directory's index as html"

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -231,7 +231,7 @@ Any web site has static files: images, JavaScript sources, CSS files etc.
 The best way to handle static in production is setting up reverse
 proxy like NGINX or using CDN services.
 
-But for development handling static files by aiohttp server is very convinient.
+But for development handling static files by aiohttp server is very convenient.
 
 Fortunatelly it can be done easy by single call::
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1203,7 +1203,8 @@ Router is any object that implements :class:`AbstractRouter` interface.
       :returns: new :class:`PlainRoute` or :class:`DynamicRoute` instance.
 
    .. method:: add_static(prefix, path, *, name=None, expect_handler=None, \
-                          chunk_size=256*1024, response_factory=StreamResponse)
+                          chunk_size=256*1024, response_factory=StreamResponse \
+                          show_index=False)
 
       Adds a router and a handler for returning static files.
 
@@ -1254,6 +1255,10 @@ Router is any object that implements :class:`AbstractRouter` interface.
                                         expose a compatible API.
 
                                         .. versionadded:: 0.17
+
+      :param bool show_index: flag for allowing to show indexes of a directory,
+                              by default it's not allowed and HTTP/403 will
+                              be returned on directory access.
 
    :returns: new :class:`StaticRoute` instance.
 

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -29,12 +29,15 @@ def tmp_dir_path(request):
     return tmp_dir
 
 
+@pytest.mark.parametrize("show_index,status", [(False, 403), (True, 200)])
 @pytest.mark.run_loop
-def test_access_root_of_static_handler(tmp_dir_path, create_app_and_client):
+def test_access_root_of_static_handler(tmp_dir_path, create_app_and_client,
+                                       show_index, status):
     """
     Tests the operation of static file server.
     Try to access the root of static file server, and make
-    sure that a `HTTP 403 - Forbidden` is returned.
+    sure that correct HTTP statuses are returned depending if we directory
+    index should be shown or not.
     """
     # Put a file inside tmp_dir_path:
     my_file_path = os.path.join(tmp_dir_path, 'my_file')
@@ -44,12 +47,12 @@ def test_access_root_of_static_handler(tmp_dir_path, create_app_and_client):
     app, client = yield from create_app_and_client()
 
     # Register global static route:
-    app.router.add_static('/', tmp_dir_path)
+    app.router.add_static('/', tmp_dir_path, show_index=show_index)
 
     # Request the root of the static directory.
     # Expect an 403 error page.
     r = yield from client.get('/')
-    assert r.status == 403
+    assert r.status == status
     # data = (yield from r.read())
     yield from r.release()
 

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -50,7 +50,6 @@ def test_access_root_of_static_handler(tmp_dir_path, create_app_and_client,
     app.router.add_static('/', tmp_dir_path, show_index=show_index)
 
     # Request the root of the static directory.
-    # Expect an 403 error page.
     r = yield from client.get('/')
     assert r.status == status
     # data = (yield from r.read())

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -34,7 +34,7 @@ def test_access_root_of_static_handler(tmp_dir_path, create_app_and_client):
     """
     Tests the operation of static file server.
     Try to access the root of static file server, and make
-    sure that a proper not found error is returned.
+    sure that a `HTTP 403 - Forbidden` is returned.
     """
     # Put a file inside tmp_dir_path:
     my_file_path = os.path.join(tmp_dir_path, 'my_file')
@@ -47,9 +47,9 @@ def test_access_root_of_static_handler(tmp_dir_path, create_app_and_client):
     app.router.add_static('/', tmp_dir_path)
 
     # Request the root of the static directory.
-    # Expect an 404 error page.
+    # Expect an 403 error page.
     r = yield from client.get('/')
-    assert r.status == 404
+    assert r.status == 403
     # data = (yield from r.read())
     yield from r.release()
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
- By default throws `HTTP 403 - Forbidden` if we access static directory
- If static directory indexing is enabled - lists the static directory contents when we access it

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
`UrlDispatcher.add_static` got new flag - `show_index`, which will show index of a directory if explicitly set to `True`. By default, accessing directory index is forbidden (HTTP/403, `show_index=False`)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#921

## Checklist

- [ ] `StaticRoute._directory_as_html()`:
  - [ ] Maybe it should be outside the class? Unit-testing would be easier that way..
  - [ ] I would want a unit-test for this method to explicitly check that HTML is as we want
  - [ ] Method looks cumbersome and has lots of newlines, so the output would be human readable (is this a priority?)
  - Example output (from a test `test_access_root_of_static_handler`):
```
<html>
<head>
<title>Index of /</title>
</head>
<body>
<h1>Index of /</h1>
<ul>
<li><a href="/my_file">my_file</a></li>
</ul>
</body>
</html>
```
- [ ] There is currently missing coverage for [L506](https://github.com/trimailov/aiohttp/blob/show-dir-index/aiohttp/web_urldispatcher.py#L506) and [L531](https://github.com/trimailov/aiohttp/blob/show-dir-index/aiohttp/web_urldispatcher.py#L531-L532)
- [ ] Documentation should reflect the changes, though I have build problems ATM and cannot check docs as HTML
