### PR TITLE
Relax HTTP method validation in UrlDispatcher.

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -30,6 +30,9 @@ __all__ = ('UrlDispatcher', 'UrlMappingMatchInfo',
 PY_35 = sys.version_info >= (3, 5)
 
 
+HTTP_METHOD_RE = re.compile(r"^[0-9A-Za-z!#\$%&'\*\+\-\.\^_`\|~]+$")
+
+
 class AbstractResource(Sized, Iterable):
 
     def __init__(self, *, name=None):
@@ -63,7 +66,6 @@ class AbstractResource(Sized, Iterable):
 
 
 class AbstractRoute(abc.ABC):
-    METHODS = hdrs.METH_ALL | {hdrs.METH_ANY}
 
     def __init__(self, method, handler, *,
                  expect_handler=None,
@@ -76,7 +78,7 @@ class AbstractRoute(abc.ABC):
             'Coroutine is expected, got {!r}'.format(expect_handler)
 
         method = method.upper()
-        if method not in self.METHODS:
+        if not self.validate_method(method):
             raise ValueError("{} is not allowed HTTP method".format(method))
 
         assert callable(handler), handler
@@ -102,6 +104,9 @@ class AbstractRoute(abc.ABC):
         self._handler = handler
         self._expect_handler = expect_handler
         self._resource = resource
+
+    def validate_method(self, method):
+        return HTTP_METHOD_RE.match(method)
 
     @property
     def method(self):

--- a/demos/chat/aiohttpdemo_chat/main.py
+++ b/demos/chat/aiohttpdemo_chat/main.py
@@ -1,9 +1,9 @@
 import asyncio
 import logging
 
-import aiohttp_jinja2
 import jinja2
 
+import aiohttp_jinja2
 from aiohttp import web
 from aiohttpdemo_chat.views import setup as setup_routes
 

--- a/demos/chat/aiohttpdemo_chat/views.py
+++ b/demos/chat/aiohttpdemo_chat/views.py
@@ -4,7 +4,6 @@ import random
 import string
 
 import aiohttp_jinja2
-
 from aiohttp import web
 
 log = logging.getLogger(__name__)

--- a/demos/polls/aiohttpdemo_polls/main.py
+++ b/demos/polls/aiohttpdemo_polls/main.py
@@ -2,9 +2,9 @@ import asyncio
 import logging
 import pathlib
 
-import aiohttp_jinja2
 import jinja2
 
+import aiohttp_jinja2
 from aiohttp import web
 from aiohttpdemo_polls.db import init_postgres
 from aiohttpdemo_polls.middlewares import setup_middlewares

--- a/demos/polls/aiohttpdemo_polls/middlewares.py
+++ b/demos/polls/aiohttpdemo_polls/middlewares.py
@@ -1,5 +1,4 @@
 import aiohttp_jinja2
-
 from aiohttp import web
 
 async def handle_404(request, response):

--- a/demos/polls/aiohttpdemo_polls/views.py
+++ b/demos/polls/aiohttpdemo_polls/views.py
@@ -1,5 +1,4 @@
 import aiohttp_jinja2
-
 from aiohttp import web
 
 from . import db

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -56,6 +56,24 @@ class TestUrlDispatcher(unittest.TestCase):
                            '/handler/to/path')
         self.router.register_route(route)
 
+    def test_register_uncommon_http_methods(self):
+        handler = self.make_handler()
+
+        uncommon_http_methods = {
+            'PROPFIND',
+            'PROPPATCH',
+            'COPY',
+            'LOCK',
+            'UNLOCK'
+            'MOVE',
+            'SUBSCRIBE',
+            'UNSUBSCRIBE',
+            'NOTIFY'
+        }
+
+        for method in uncommon_http_methods:
+            PlainRoute(method, handler, 'url', '/handler/to/path')
+
     def test_add_route_root(self):
         handler = self.make_handler()
         self.router.add_route('GET', '/', handler)
@@ -585,9 +603,20 @@ class TestUrlDispatcher(unittest.TestCase):
             self.router.add_route('GET', 'invalid_path', handler)
 
     def test_add_route_invalid_method(self):
-        with self.assertRaises(ValueError):
-            handler = self.make_handler()
-            self.router.add_route('INVALID_METHOD', '/path', handler)
+
+        sample_bad_methods = {
+            'BAD METHOD',
+            'B@D_METHOD',
+            '[BAD_METHOD]',
+            '{BAD_METHOD}',
+            '(BAD_METHOD)',
+            'B?D_METHOD',
+        }
+
+        for bad_method in sample_bad_methods:
+            with self.assertRaises(ValueError):
+                handler = self.make_handler()
+                self.router.add_route(bad_method, '/path', handler)
 
     def fill_routes(self):
         route1 = self.router.add_route('GET', '/plain', self.make_handler())


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

This pull request changes the HTTP method validation procedure in AbstractRoute.
Previously only "safe HTTP methods" were allowed which made developing unusual
services communicating over HTTP with custom methods (such as WebDAV and UPnP)
impossible without monkey-patching.

The new method AbstractRoute.validate_method() matches the method against a regex compliant with the RFC 2616 specification of a "token".

## Are there changes in behavior for the user?

The only change in behavior is what input raises a ValueError now, this has not been documented anywhere as far as I could tell hence no changes has been documented in the end-user API docs.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#951 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes

Previously the validation only compared against "safe HTTP methods",
now we validate against the allowed character-set defined in
RFC 2616 section 5.1.1.