### PR TITLE
Lingering close in ServerHttpProtocol (was #927)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,8 @@ CHANGES
 
 - Link header for 451 status code is mandatory
 
+- Implement lingering on server-side trasport closing #1050
+
 
 0.22.5 (08-02-2016)
 -------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -70,6 +70,7 @@ Marco Paolini
 Mariano Anaya
 Martin Richard
 Mathias Fröjdman
+Mathieu Sornay
 Matthieu Hauglustaine
 Michael Ihnatenko
 Mikhail Lukyanchenko

--- a/aiohttp/server.py
+++ b/aiohttp/server.py
@@ -4,12 +4,13 @@ import asyncio
 import http.server
 import socket
 import traceback
+from contextlib import suppress
 from html import escape as html_escape
 from math import ceil
 
 import aiohttp
 from aiohttp import errors, hdrs, helpers, streams
-from aiohttp.helpers import ensure_future
+from aiohttp.helpers import Timeout, ensure_future
 from aiohttp.log import access_logger, server_logger
 
 __all__ = ('ServerHttpProtocol',)
@@ -57,6 +58,14 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
 
     :param int timeout: slow request timeout
 
+    :param float lingering_time: maximum time during which the server
+        reads and ignore additionnal data comming from the client when
+        lingering close is on Use 0 for disabling lintering on server
+        channel closing.
+
+    :param float lingering_timeout: maximum waiting time for more
+        client data to arrive when lingering close is in effect
+
     :param allowed_methods: (optional) List of allowed request methods.
                             Set to empty list to allow all methods.
     :type allowed_methods: tuple
@@ -78,6 +87,7 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
     :param int max_field_size: Optional maximum header field size
 
     :param int max_headers: Optional maximum header size
+
     """
     _request_count = 0
     _request_handler = None
@@ -90,6 +100,8 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
                  keep_alive=75,  # NGINX default value is 75 secs
                  keep_alive_on=True,
                  timeout=0,
+                 lingering_time=30,    # NGINX default value is 30 secs
+                 lingering_timeout=5,  # NGINX default value is 5 secs
                  logger=server_logger,
                  access_log=access_logger,
                  access_log_format=helpers.AccessLogger.LOG_FORMAT,
@@ -106,6 +118,8 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
         self._keep_alive_on = keep_alive_on
         self._keep_alive_period = keep_alive  # number of seconds to keep alive
         self._timeout = timeout  # slow request timeout
+        self._lingering_time = float(lingering_time)
+        self._lingering_timeout = float(lingering_timeout)
         self._loop = loop if loop is not None else asyncio.get_event_loop()
 
         self._request_prefix = aiohttp.HttpPrefixParser()
@@ -307,7 +321,26 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
                 if payload and not payload.is_eof():
                     self.log_debug('Uncompleted request.')
                     self._request_handler = None
-                    self.transport.close()
+
+                    if self._lingering_time:
+                        self.transport.write_eof()
+                        self.log_debug(
+                            'Start lingering close timer for %s sec.',
+                            self._lingering_time)
+
+                        end_time = self._loop.time() + self._lingering_time
+
+                        with suppress(asyncio.TimeoutError,
+                                      errors.ClientDisconnectedError):
+                            while self._loop.time() < end_time:
+                                with Timeout(self._lingering_timeout,
+                                             loop=self._loop):
+                                    # read and ignore
+                                    yield from payload.readany()
+
+                    if self.transport is not None:
+                        self.transport.close()
+
                     return
                 else:
                     reader.unset_parser()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -351,8 +351,17 @@ def test_handle(srv, loop):
     assert transport.close.called
 
 
-def test_handle_uncompleted(srv, loop):
+def test_handle_uncompleted(make_srv, loop):
     transport = mock.Mock()
+    closed = False
+
+    def close():
+        nonlocal closed
+        closed = True
+
+    transport.close = close
+
+    srv = make_srv(lingering_timeout=0)
     srv.connection_made(transport)
     srv.logger.exception = mock.Mock()
 
@@ -366,8 +375,29 @@ def test_handle_uncompleted(srv, loop):
 
     loop.run_until_complete(srv._request_handler)
     assert handle.called
-    assert transport.close.called
+    assert closed
     srv.logger.exception.assert_called_with("Error handling request")
+
+
+@pytest.mark.run_loop
+def test_lingering(srv, loop):
+
+    transport = mock.Mock()
+    srv.connection_made(transport)
+
+    srv.reader.feed_data(
+        b'GET / HTTP/1.0\r\n'
+        b'Host: example.com\r\n'
+        b'Content-Length: 0\r\n\r\n')
+
+    yield from asyncio.sleep(0, loop=loop)
+    assert not transport.close.called
+
+    srv.reader.feed_data(b'123')
+    srv.reader.feed_eof()
+
+    yield from asyncio.sleep(0, loop=loop)
+    transport.close.assert_called_with()
 
 
 def test_handle_coro(srv, loop):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -385,15 +385,18 @@ def test_lingering(srv, loop):
     transport = mock.Mock()
     srv.connection_made(transport)
 
+    yield from asyncio.sleep(0, loop=loop)
+    assert not transport.close.called
+
     srv.reader.feed_data(
         b'GET / HTTP/1.0\r\n'
         b'Host: example.com\r\n'
         b'Content-Length: 0\r\n\r\n')
 
+    srv.reader.feed_data(b'123')
+
     yield from asyncio.sleep(0, loop=loop)
     assert not transport.close.called
-
-    srv.reader.feed_data(b'123')
     srv.reader.feed_eof()
 
     yield from asyncio.sleep(0, loop=loop)


### PR DESCRIPTION
Continuation of #927
## What do these changes do?

Hello,

Quoting [RFC 7230](https://tools.ietf.org/html/rfc7230#page-56) : 

> If a server performs an immediate close of a TCP connection, there is
>    a significant risk that the client will not be able to read the last
>    HTTP response.  If the server receives additional data from the
>    client on a fully closed connection, such as another request that was
>    sent by the client before receiving the server's response, the
>    server's TCP stack will send a reset packet to the client;
>    unfortunately, the reset packet might erase the client's
>    unacknowledged input buffers before they can be read and interpreted
>    by the client's HTTP parser.
> 
>   To avoid the TCP reset problem, servers typically close a connection
>    in stages.  First, the server performs a half-close by closing only
>    the write side of the read/write connection.  The server then
>    continues to read from the connection until it receives a
>    corresponding close by the client, or until the server is reasonably
>    certain that its own TCP stack has received the client's
>    acknowledgement of the packet(s) containing the server's last
>    response.  Finally, the server fully closes the connection.

This is a tentative implementation of a lingering close inspired by [those nginx settings](http://nginx.org/en/docs/http/ngx_http_core_module.html#lingering_close)
## Are there changes in behavior for the user?

The typical use case where the absence of lingering close is worrisome in our application is : 
1. The client starts PUTting a sizeable amount of data ;
2. Server replies with a HTTP 401 Unauthorized after parsing the headers ;
3. The connection  is closed too early for the client to receive / react to the reply. 

It is our experience that some HTTP clients behave badly in front of "early" responses. We believe that having lingerings closes is correct and we are currently investigating how much it will help in practice.
## Checklist
- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
