### PR TITLE
Remove decode parameter from ClientResponse.read

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -720,7 +720,7 @@ class ClientResponse:
         yield from self.release()
 
     @asyncio.coroutine
-    def read(self, decode=False):
+    def read(self):
         """Read response payload."""
         if self._content is None:
             try:
@@ -731,15 +731,7 @@ class ClientResponse:
             else:
                 yield from self.release()
 
-        data = self._content
-
-        if decode:
-            warnings.warn(
-                '.read(True) is deprecated. use .json() instead',
-                DeprecationWarning)
-            return (yield from self.json())
-
-        return data
+        return self._content
 
     def _get_encoding(self):
         ctype = self.headers.get(hdrs.CONTENT_TYPE, '').lower()

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -117,15 +117,8 @@ class TestClientResponse(unittest.TestCase):
         self.assertIsNone(self.response._connection)
 
     def test_read_decode_deprecated(self):
-        self.response._content = b'data'
-        self.response.json = mock.Mock()
-        self.response.json.return_value = helpers.create_future(self.loop)
-        self.response.json.return_value.set_result('json')
-
-        with self.assertWarns(DeprecationWarning):
-            res = self.loop.run_until_complete(self.response.read(decode=True))
-        self.assertEqual(res, 'json')
-        self.assertTrue(self.response.json.called)
+        with self.assertRaises(TypeError):
+            self.response.read(decode=True)
 
     def test_text(self):
         def side_effect(*args, **kwargs):


### PR DESCRIPTION
It had been deprecated for two years or so, it's time to move on.