### PR TITLE
fix make_mocked_request docstring

### DIFF
--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -566,11 +566,10 @@ def make_mocked_request(method, path, headers=None, *,
     :type method: str
 
     :param path: str, The URL including *PATH INFO* without the host or scheme
-    :type path: multidict.CIMultiDict
+    :type path: str
 
-    :param headers: str, The URL including *PATH INFO* without the host
-        or scheme
-    :type headers: str
+    :param headers: CIMultiDict with all request headers
+    :type headers: multidict.CIMultiDict
 
     :param version: namedtuple with encoded HTTP version
     :type version: aiohttp.protocol.HttpVersion


### PR DESCRIPTION
BTW, I think `make_mocked_request` should accept simple `dict` as `headers` parameters, which is easy to support, but I don't have time right now for that. Lets at least fix current docstring.

Currently if `dict` is passed as `headers` usage fails with something like:

```
test_aio.py:6: in handler
    assert request.headers.get('token') == 'x'
../../../stuff/aio-libs/aiohttp/aiohttp/helpers.py:442: in __get__
    val = self.wrapped(inst)
../../../stuff/aio-libs/aiohttp/aiohttp/web_reqrep.py:214: in headers
    return CIMultiDictProxy(self._message.headers)

TypeError: CIMultiDictProxy requires CIMultiDict instance, not <class 'dict'>
```