### PR TITLE
Fix test_client fixture to allow multiple clients per test

### DIFF
--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -51,17 +51,17 @@ def loop():
 
 @pytest.yield_fixture
 def test_client(loop):
-    client = None
+    clients = []
 
     @asyncio.coroutine
     def _create_from_app_factory(app_factory, *args, **kwargs):
-        nonlocal client
         app = app_factory(loop, *args, **kwargs)
         client = TestClient(app)
         yield from client.start_server()
+        clients.append(client)
         return client
 
     yield _create_from_app_factory
 
-    if client:
-        client.close()
+    while clients:
+        clients.pop().close()


### PR DESCRIPTION
## What do these changes do?

`test_client` fixture now allows multiple client instances:

```python
from project import frontend, api

async def test_full_app(test_client):
    front_client = await test_client(frontend.make_app)
    api_client = await test_client(api.make_app)
    # test complete application
```   