### PR TITLE
Remove pyenchant and sphinxcontrib-spelling dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,6 @@
 ipdb
 pytest-sugar
 ipython
-pyenchant
-sphinxcontrib-spelling
 sphinxcontrib-asyncio
 isort
 aiodns


### PR DESCRIPTION
On Mac OSX pychant can't be install by pip, resulting in the following error:
"ImportError: The 'enchant' C library was not found. Please install it via your OS package manager, or use a pre-built binary wheel from PyPI."