### PR TITLE
Rename msg.tp -> msg.type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,11 +71,11 @@ This is simple usage example:
         await ws.prepare(request)
 
         async for msg in ws:
-            if msg.tp == web.MsgType.text:
+            if msg.type == web.MsgType.text:
                 ws.send_str("Hello, {}".format(msg.data))
-            elif msg.tp == web.MsgType.binary:
+            elif msg.type == web.MsgType.binary:
                 ws.send_bytes(msg.data)
-            elif msg.tp == web.MsgType.close:
+            elif msg.type == web.MsgType.close:
                 break
 
         return ws

--- a/aiohttp/_ws_impl.py
+++ b/aiohttp/_ws_impl.py
@@ -68,7 +68,7 @@ MSG_SIZE = 2 ** 14
 
 
 _WSMessageBase = collections.namedtuple('_WSMessageBase',
-                                        ['tp', 'data', 'extra'])
+                                        ['type', 'data', 'extra'])
 
 
 class WSMessage(_WSMessageBase):
@@ -78,6 +78,10 @@ class WSMessage(_WSMessageBase):
         .. versionadded:: 0.22
         """
         return loads(self.data)
+
+    @property
+    def tp(self):
+        return self.type
 
 
 CLOSED_MESSAGE = WSMessage(WSMsgType.CLOSED, None, None)

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -106,7 +106,7 @@ class ClientWebSocketResponse:
                     self._response.close()
                     return True
 
-                if msg.tp == WSMsgType.CLOSE:
+                if msg.type == WSMsgType.CLOSE:
                     self._close_code = msg.data
                     self._response.close()
                     return True
@@ -139,16 +139,16 @@ class ClientWebSocketResponse:
                     yield from self.close()
                     return WSMessage(WSMsgType.ERROR, exc, None)
 
-                if msg.tp == WSMsgType.CLOSE:
+                if msg.type == WSMsgType.CLOSE:
                     self._closing = True
                     self._close_code = msg.data
                     if not self._closed and self._autoclose:
                         yield from self.close()
                     return msg
                 elif not self._closed:
-                    if msg.tp == WSMsgType.PING and self._autoping:
+                    if msg.type == WSMsgType.PING and self._autoping:
                         self.pong(msg.data)
-                    elif msg.tp == WSMsgType.PONG and self._autoping:
+                    elif msg.type == WSMsgType.PONG and self._autoping:
                         continue
                     else:
                         return msg
@@ -158,17 +158,18 @@ class ClientWebSocketResponse:
     @asyncio.coroutine
     def receive_str(self):
         msg = yield from self.receive()
-        if msg.tp != WSMsgType.TEXT:
+        if msg.type != WSMsgType.TEXT:
             raise TypeError(
-                "Received message {}:{!r} is not str".format(msg.tp, msg.data))
+                "Received message {}:{!r} is not str".format(msg.type,
+                                                             msg.data))
         return msg.data
 
     @asyncio.coroutine
     def receive_bytes(self):
         msg = yield from self.receive()
-        if msg.tp != WSMsgType.BINARY:
+        if msg.type != WSMsgType.BINARY:
             raise TypeError(
-                "Received message {}:{!r} is not bytes".format(msg.tp,
+                "Received message {}:{!r} is not bytes".format(msg.type,
                                                                msg.data))
         return msg.data
 
@@ -185,6 +186,6 @@ class ClientWebSocketResponse:
         @asyncio.coroutine
         def __anext__(self):
             msg = yield from self.receive()
-            if msg.tp == WSMsgType.CLOSE:
+            if msg.type == WSMsgType.CLOSE:
                 raise StopAsyncIteration  # NOQA
             return msg

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -200,7 +200,7 @@ class WebSocketResponse(StreamResponse):
                     self._exception = exc
                     return True
 
-                if msg.tp == WSMsgType.CLOSE:
+                if msg.type == WSMsgType.CLOSE:
                     self._close_code = msg.data
                     return True
         else:
@@ -241,16 +241,16 @@ class WebSocketResponse(StreamResponse):
                     yield from self.close()
                     return WSMessage(WSMsgType.ERROR, exc, None)
 
-                if msg.tp == WSMsgType.CLOSE:
+                if msg.type == WSMsgType.CLOSE:
                     self._closing = True
                     self._close_code = msg.data
                     if not self._closed and self._autoclose:
                         yield from self.close()
                     return msg
                 elif not self._closed:
-                    if msg.tp == WSMsgType.PING and self._autoping:
+                    if msg.type == WSMsgType.PING and self._autoping:
                         self.pong(msg.data)
-                    elif msg.tp == WSMsgType.PONG and self._autoping:
+                    elif msg.type == WSMsgType.PONG and self._autoping:
                         continue
                     else:
                         return msg
@@ -267,17 +267,18 @@ class WebSocketResponse(StreamResponse):
     @asyncio.coroutine
     def receive_str(self):
         msg = yield from self.receive()
-        if msg.tp != WSMsgType.TEXT:
+        if msg.type != WSMsgType.TEXT:
             raise TypeError(
-                "Received message {}:{!r} is not str".format(msg.tp, msg.data))
+                "Received message {}:{!r} is not str".format(msg.type,
+                                                             msg.data))
         return msg.data
 
     @asyncio.coroutine
     def receive_bytes(self):
         msg = yield from self.receive()
-        if msg.tp != WSMsgType.BINARY:
+        if msg.type != WSMsgType.BINARY:
             raise TypeError(
-                "Received message {}:{!r} is not bytes".format(msg.tp,
+                "Received message {}:{!r} is not bytes".format(msg.type,
                                                                msg.data))
         return msg.data
 
@@ -297,6 +298,6 @@ class WebSocketResponse(StreamResponse):
         @asyncio.coroutine
         def __anext__(self):
             msg = yield from self.receive()
-            if msg.tp == WSMsgType.CLOSE:
+            if msg.type == WSMsgType.CLOSE:
                 raise StopAsyncIteration  # NOQA
             return msg

--- a/demos/chat/aiohttpdemo_chat/views.py
+++ b/demos/chat/aiohttpdemo_chat/views.py
@@ -30,7 +30,7 @@ async def index(request):
     while True:
         msg = await resp.receive()
 
-        if msg.tp == web.MsgType.text:
+        if msg.type == web.MsgType.text:
             for ws in request.app['sockets'].values():
                 if ws is not resp:
                     ws.send_str(json.dumps({'action': 'sent',

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -134,7 +134,7 @@ WebSocket utilities
 
    Websocket message, returned by ``.receive()`` calls.
 
-   .. attribute:: tp
+   .. attribute:: type
 
       Message type, :class:`WSMsgType` instance.
 
@@ -166,6 +166,12 @@ WebSocket utilities
       .. versionadded:: 0.22
 
       :param loads: optional JSON decoder function.
+
+   .. attribute:: tp
+
+      Deprecated alias for :attr:`type`.
+
+      .. deprecated:: 1.0
 
 
 aiohttp.errors module

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -650,15 +650,15 @@ methods::
    async with session.ws_connect('http://example.org/websocket') as ws:
 
        async for msg in ws:
-           if msg.tp == aiohttp.WSMsgType.TEXT:
+           if msg.type == aiohttp.WSMsgType.TEXT:
                if msg.data == 'close cmd':
                    await ws.close()
                    break
                else:
                    ws.send_str(msg.data + '/answer')
-           elif msg.tp == aiohttp.WSMsgType.CLOSED:
+           elif msg.type == aiohttp.WSMsgType.CLOSED:
                break
-           elif msg.tp == aiohttp.WSMsgType.ERROR:
+           elif msg.type == aiohttp.WSMsgType.ERROR:
                break
 
 

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -538,12 +538,12 @@ with the peer::
         await ws.prepare(request)
 
         async for msg in ws:
-            if msg.tp == aiohttp.WSMsgType.TEXT:
+            if msg.type == aiohttp.WSMsgType.TEXT:
                 if msg.data == 'close':
                     await ws.close()
                 else:
                     ws.send_str(msg.data + '/answer')
-            elif msg.tp == aiohttp.WSMsgType.ERROR:
+            elif msg.type == aiohttp.WSMsgType.ERROR:
                 print('ws connection closed with exception %s' %
                       ws.exception())
 

--- a/examples/client_ws.py
+++ b/examples/client_ws.py
@@ -33,20 +33,20 @@ def start_client(loop, url):
         while True:
             msg = yield from ws.receive()
 
-            if msg.tp == aiohttp.WSMsgType.TEXT:
+            if msg.type == aiohttp.WSMsgType.TEXT:
                 print('Text: ', msg.data.strip())
-            elif msg.tp == aiohttp.WSMsgType.BINARY:
+            elif msg.type == aiohttp.WSMsgType.BINARY:
                 print('Binary: ', msg.data)
-            elif msg.tp == aiohttp.WSMsgType.PING:
+            elif msg.type == aiohttp.WSMsgType.PING:
                 ws.pong()
-            elif msg.tp == aiohttp.WSMsgType.PONG:
+            elif msg.type == aiohttp.WSMsgType.PONG:
                 print('Pong received')
             else:
-                if msg.tp == aiohttp.WSMsgType.CLOSE:
+                if msg.type == aiohttp.WSMsgType.CLOSE:
                     yield from ws.close()
-                elif msg.tp == aiohttp.WSMsgType.ERROR:
+                elif msg.type == aiohttp.WSMsgType.ERROR:
                     print('Error during receive %s' % ws.exception())
-                elif msg.tp == aiohttp.WSMsgType.CLOSED:
+                elif msg.type == aiohttp.WSMsgType.CLOSED:
                     pass
 
                 break

--- a/examples/legacy/tcp_protocol_parser.py
+++ b/examples/legacy/tcp_protocol_parser.py
@@ -96,11 +96,11 @@ class EchoServer(asyncio.Protocol):
 
             print('Message received: {}'.format(msg))
 
-            if msg.tp == MSG_PING:
+            if msg.type == MSG_PING:
                 writer.pong()
-            elif msg.tp == MSG_TEXT:
+            elif msg.type == MSG_TEXT:
                 writer.send_text('Re: ' + msg.data)
-            elif msg.tp == MSG_STOP:
+            elif msg.type == MSG_STOP:
                 self.transport.close()
                 break
 
@@ -123,10 +123,10 @@ def start_client(loop, host, port):
             break
 
         print('Message received: {}'.format(msg))
-        if msg.tp == MSG_PONG:
+        if msg.type == MSG_PONG:
             writer.send_text(message)
             print('data sent:', message)
-        elif msg.tp == MSG_TEXT:
+        elif msg.type == MSG_TEXT:
             writer.stop()
             print('stop sent')
             break

--- a/examples/web_ws.py
+++ b/examples/web_ws.py
@@ -27,7 +27,7 @@ async def wshandler(request):
         request.app['sockets'].append(resp)
 
         async for msg in resp:
-            if msg.tp == WSMsgType.TEXT:
+            if msg.type == WSMsgType.TEXT:
                 for ws in request.app['sockets']:
                     if ws is not resp:
                         ws.send_str(msg.data)

--- a/tests/autobahn/client.py
+++ b/tests/autobahn/client.py
@@ -18,11 +18,11 @@ def client(loop, url, name):
         while True:
             msg = yield from ws.receive()
 
-            if msg.tp == aiohttp.MsgType.text:
+            if msg.type == aiohttp.MsgType.text:
                 ws.send_str(msg.data)
-            elif msg.tp == aiohttp.MsgType.binary:
+            elif msg.type == aiohttp.MsgType.binary:
                 ws.send_bytes(msg.data)
-            elif msg.tp == aiohttp.MsgType.close:
+            elif msg.type == aiohttp.MsgType.close:
                 yield from ws.close()
                 break
             else:

--- a/tests/autobahn/server.py
+++ b/tests/autobahn/server.py
@@ -18,11 +18,11 @@ def wshandler(request):
     while True:
         msg = yield from ws.receive()
 
-        if msg.tp == web.MsgType.text:
+        if msg.type == web.MsgType.text:
             ws.send_str(msg.data)
-        elif msg.tp == web.MsgType.binary:
+        elif msg.type == web.MsgType.binary:
             ws.send_bytes(msg.data)
-        elif msg.tp == web.MsgType.close:
+        elif msg.type == web.MsgType.close:
             yield from ws.close()
             break
         else:

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -387,7 +387,8 @@ class TestWebSocketClient(unittest.TestCase):
         reader.read.return_value.set_exception(exc)
 
         msg = self.loop.run_until_complete(resp.receive())
-        self.assertEqual(msg.tp, aiohttp.MsgType.ERROR)
+        self.assertEqual(msg.type, aiohttp.MsgType.ERROR)
+        self.assertIs(msg.type, msg.tp)
         self.assertIs(resp.exception(), exc)
 
     def test_receive_runtime_err(self):

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -153,11 +153,11 @@ def test_ping_pong(create_app_and_client, loop):
     resp.send_bytes(b'ask')
 
     msg = yield from resp.receive()
-    assert msg.tp == aiohttp.WSMsgType.BINARY
+    assert msg.type == aiohttp.WSMsgType.BINARY
     assert msg.data == b'ask/answer'
 
     msg = yield from resp.receive()
-    assert msg.tp == aiohttp.WSMsgType.CLOSE
+    assert msg.type == aiohttp.WSMsgType.CLOSE
 
     yield from resp.close()
     yield from closed
@@ -190,17 +190,17 @@ def test_ping_pong_manual(create_app_and_client, loop):
     resp.send_bytes(b'ask')
 
     msg = yield from resp.receive()
-    assert msg.tp == aiohttp.WSMsgType.PONG
+    assert msg.type == aiohttp.WSMsgType.PONG
 
     msg = yield from resp.receive()
-    assert msg.tp == aiohttp.WSMsgType.PING
+    assert msg.type == aiohttp.WSMsgType.PING
     resp.pong()
 
     msg = yield from resp.receive()
     assert msg.data == b'ask/answer'
 
     msg = yield from resp.receive()
-    assert msg.tp == aiohttp.WSMsgType.CLOSE
+    assert msg.type == aiohttp.WSMsgType.CLOSE
 
     yield from closed
 
@@ -231,7 +231,7 @@ def test_close(create_app_and_client):
     assert resp.close_code == 1000
 
     msg = yield from resp.receive()
-    assert msg.tp == aiohttp.WSMsgType.CLOSED
+    assert msg.type == aiohttp.WSMsgType.CLOSED
 
 
 @pytest.mark.run_loop
@@ -258,11 +258,11 @@ def test_close_from_server(create_app_and_client, loop):
     resp.send_bytes(b'ask')
 
     msg = yield from resp.receive()
-    assert msg.tp == aiohttp.WSMsgType.CLOSE
+    assert msg.type == aiohttp.WSMsgType.CLOSE
     assert resp.closed
 
     msg = yield from resp.receive()
-    assert msg.tp == aiohttp.WSMsgType.CLOSED
+    assert msg.type == aiohttp.WSMsgType.CLOSED
 
     yield from closed
 
@@ -295,7 +295,7 @@ def test_close_manual(create_app_and_client, loop):
     assert msg.data == 'test'
 
     msg = yield from resp.receive()
-    assert msg.tp == aiohttp.WSMsgType.CLOSE
+    assert msg.type == aiohttp.WSMsgType.CLOSE
     assert msg.data == 1000
     assert msg.extra == ''
     assert not resp.closed
@@ -324,7 +324,7 @@ def test_close_timeout(create_app_and_client, loop):
 
     msg = yield from resp.receive()
     assert msg.data == 'test'
-    assert msg.tp == aiohttp.WSMsgType.TEXT
+    assert msg.type == aiohttp.WSMsgType.TEXT
 
     msg = yield from resp.close()
     assert resp.closed
@@ -421,7 +421,7 @@ def test_recv_protocol_error(create_app_and_client):
     resp.send_str('ask')
 
     msg = yield from resp.receive()
-    assert msg.tp == aiohttp.WSMsgType.ERROR
+    assert msg.type == aiohttp.WSMsgType.ERROR
     assert type(msg.data) is aiohttp.WebSocketError
     assert msg.data.args[0] == 'Received frame with non-zero reserved bits'
     assert msg.extra is None

--- a/tests/test_py35/test_web_websocket_35.py
+++ b/tests/test_py35/test_web_websocket_35.py
@@ -12,7 +12,7 @@ async def test_server_ws_async_for(loop, create_server):
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         async for msg in ws:
-            assert msg.tp == aiohttp.MsgType.TEXT
+            assert msg.type == aiohttp.MsgType.TEXT
             s = msg.data
             ws.send_str(s + '/answer')
         await ws.close()
@@ -27,7 +27,7 @@ async def test_server_ws_async_for(loop, create_server):
     for item in items:
         resp.send_str(item)
         msg = await resp.receive()
-        assert msg.tp == aiohttp.MsgType.TEXT
+        assert msg.type == aiohttp.MsgType.TEXT
         assert item + '/answer' == msg.data
 
     await resp.close()

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -21,7 +21,7 @@ def _create_example_app(loop):
         ws = web.WebSocketResponse()
         yield from ws.prepare(request)
         msg = yield from ws.receive()
-        if msg.tp == aiohttp.WSMsgType.TEXT:
+        if msg.type == aiohttp.WSMsgType.TEXT:
             if msg.data == 'close':
                 yield from ws.close()
             else:
@@ -148,11 +148,11 @@ def test_client_websocket(loop, test_client):
     resp = yield from test_client.ws_connect("/websocket")
     resp.send_str("foo")
     msg = yield from resp.receive()
-    assert msg.tp == aiohttp.WSMsgType.TEXT
+    assert msg.type == aiohttp.WSMsgType.TEXT
     assert "foo" in msg.data
     resp.send_str("close")
     msg = yield from resp.receive()
-    assert msg.tp == aiohttp.WSMsgType.CLOSE
+    assert msg.type == aiohttp.WSMsgType.CLOSE
 
 
 @pytest.mark.run_loop

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -333,7 +333,8 @@ def test_receive_exc_in_reader(make_request, loop, reader):
     reader.read = make_mocked_coro(res)
 
     msg = yield from ws.receive()
-    assert msg.tp == WSMsgType.ERROR
+    assert msg.type == WSMsgType.ERROR
+    assert msg.type is msg.tp
     assert msg.data is exc
     assert ws.exception() is exc
 
@@ -379,7 +380,8 @@ def test_receive_client_disconnected(make_request, loop, reader):
 
     msg = yield from ws.receive()
     assert ws.closed
-    assert msg.tp == WSMsgType.CLOSE
+    assert msg.type == WSMsgType.CLOSE
+    assert msg.type is msg.tp
     assert msg.data is None
     assert ws.exception() is None
 

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -133,11 +133,11 @@ def test_send_recv_text(create_app_and_client, loop):
     ws = yield from client.ws_connect('/')
     ws.send_str('ask')
     msg = yield from ws.receive()
-    assert msg.tp == aiohttp.WSMsgType.TEXT
+    assert msg.type == aiohttp.WSMsgType.TEXT
     assert 'ask/answer' == msg.data
 
     msg = yield from ws.receive()
-    assert msg.tp == aiohttp.WSMsgType.CLOSE
+    assert msg.type == aiohttp.WSMsgType.CLOSE
     assert msg.data == 1000
     assert msg.extra == ''
 
@@ -169,11 +169,11 @@ def test_send_recv_bytes(create_app_and_client, loop):
     ws = yield from client.ws_connect('/')
     ws.send_bytes(b'ask')
     msg = yield from ws.receive()
-    assert msg.tp == aiohttp.WSMsgType.BINARY
+    assert msg.type == aiohttp.WSMsgType.BINARY
     assert b'ask/answer' == msg.data
 
     msg = yield from ws.receive()
-    assert msg.tp == aiohttp.WSMsgType.CLOSE
+    assert msg.type == aiohttp.WSMsgType.CLOSE
     assert msg.data == 1000
     assert msg.extra == ''
 
@@ -205,11 +205,11 @@ def test_send_recv_json(create_app_and_client, loop):
     ws.send_str('{"request": "test"}')
     msg = yield from ws.receive()
     data = msg.json()
-    assert msg.tp == aiohttp.WSMsgType.TEXT
+    assert msg.type == aiohttp.WSMsgType.TEXT
     assert data['response'] == 'test'
 
     msg = yield from ws.receive()
-    assert msg.tp == aiohttp.WSMsgType.CLOSE
+    assert msg.type == aiohttp.WSMsgType.CLOSE
     assert msg.data == 1000
     assert msg.extra == ''
 

--- a/tests/test_web_websocket_functional_oldstyle.py
+++ b/tests/test_web_websocket_functional_oldstyle.py
@@ -86,7 +86,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
             yield from ws.receive()
 
             msg = yield from ws.receive()
-            self.assertEqual(msg.tp, WSMsgType.CLOSE)
+            self.assertEqual(msg.type, WSMsgType.CLOSE)
             self.assertEqual(msg.data, 1000)
             self.assertEqual(msg.extra, 'exit message')
             closed.set_result(None)
@@ -100,7 +100,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
             writer.send('ask')
 
             msg = yield from reader.read()
-            self.assertEqual(msg.tp, WSMsgType.PONG)
+            self.assertEqual(msg.type, WSMsgType.PONG)
             writer.close(1000, 'exit message')
             yield from closed
             resp.close()
@@ -126,7 +126,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
             _, _, url = yield from self.create_server('GET', '/', handler)
             resp, reader, writer = yield from self.connect_ws(url)
             msg = yield from reader.read()
-            self.assertEqual(msg.tp, WSMsgType.PING)
+            self.assertEqual(msg.type, WSMsgType.PING)
             self.assertEqual(msg.data, b'data')
             writer.pong()
             writer.close(2, 'exit message')
@@ -154,7 +154,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
             resp, reader, writer = yield from self.connect_ws(url)
             writer.ping('data')
             msg = yield from reader.read()
-            self.assertEqual(msg.tp, WSMsgType.PONG)
+            self.assertEqual(msg.type, WSMsgType.PONG)
             self.assertEqual(msg.data, b'data')
             writer.pong()
             writer.close()
@@ -173,11 +173,11 @@ class TestWebWebSocketFunctional(unittest.TestCase):
             yield from ws.prepare(request)
 
             msg = yield from ws.receive()
-            self.assertEqual(msg.tp, WSMsgType.PING)
+            self.assertEqual(msg.type, WSMsgType.PING)
             ws.pong('data')
 
             msg = yield from ws.receive()
-            self.assertEqual(msg.tp, WSMsgType.CLOSE)
+            self.assertEqual(msg.type, WSMsgType.CLOSE)
             self.assertEqual(msg.data, 1000)
             self.assertEqual(msg.extra, 'exit message')
             closed.set_result(None)
@@ -189,7 +189,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
             resp, reader, writer = yield from self.connect_ws(url)
             writer.ping('data')
             msg = yield from reader.read()
-            self.assertEqual(msg.tp, WSMsgType.PONG)
+            self.assertEqual(msg.type, WSMsgType.PONG)
             self.assertEqual(msg.data, b'data')
             writer.close(1000, 'exit message')
 
@@ -265,7 +265,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
             resp, reader, writer = yield from self.connect_ws(url, 'eggs, bar')
 
             msg = yield from reader.read()
-            self.assertEqual(msg.tp, WSMsgType.CLOSE)
+            self.assertEqual(msg.type, WSMsgType.CLOSE)
             writer.close()
             yield from closed
             resp.close()
@@ -283,14 +283,14 @@ class TestWebWebSocketFunctional(unittest.TestCase):
             yield from ws.prepare(request)
 
             msg = yield from ws.receive()
-            self.assertEqual(msg.tp, WSMsgType.CLOSE)
+            self.assertEqual(msg.type, WSMsgType.CLOSE)
             self.assertFalse(ws.closed)
             yield from ws.close()
             self.assertTrue(ws.closed)
             self.assertEqual(ws.close_code, 1007)
 
             msg = yield from ws.receive()
-            self.assertEqual(msg.tp, WSMsgType.CLOSED)
+            self.assertEqual(msg.type, WSMsgType.CLOSED)
 
             closed.set_result(None)
             return ws
@@ -302,7 +302,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
 
             writer.close(code=1007)
             msg = yield from reader.read()
-            self.assertEqual(msg.tp, WSMsgType.CLOSE)
+            self.assertEqual(msg.type, WSMsgType.CLOSE)
             yield from closed
             resp.close()
 
@@ -327,7 +327,7 @@ class TestWebWebSocketFunctional(unittest.TestCase):
                 url, 'eggs, bar')
 
             msg = yield from reader.read()
-            self.assertEqual(msg.tp, WSMsgType.CLOSE)
+            self.assertEqual(msg.type, WSMsgType.CLOSE)
 
             writer.send('text')
             writer.send(b'bytes', binary=True)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

rename msg.tp field to msg.type

## Are there changes in behavior for the user?

prefer to use msg.type, but user can still use msg.tp

## Related issue number

#1019

## Checklist

- [O] I think the code is well written
- [O] Unit tests for the changes exist
- [O] Documentation reflects the changes

fix #1019 (1)

Signed-off-by: Young Ho Cha <ganadist@gmail.com>