### PR TITLE
[Cookie] Check uri-path starts with "/". Fixes #1047

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -741,6 +741,9 @@ class CookieJar(AbstractCookieJar):
     @staticmethod
     def _is_path_match(req_path, cookie_path):
         """Implements path matching adhering to RFC 6265."""
+        if not req_path.startswith("/"):
+            req_path = "/"
+
         if req_path == cookie_path:
             return True
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -625,6 +625,7 @@ class TestCookieJarSafe(TestCookieJarBase):
         test_func = helpers.CookieJar._is_path_match
 
         self.assertTrue(test_func("/", ""))
+        self.assertTrue(test_func("", "/"))
         self.assertTrue(test_func("/file", ""))
         self.assertTrue(test_func("/folder/file", ""))
         self.assertTrue(test_func("/", "/"))


### PR DESCRIPTION
## What do these changes do?

 * If the uri-path is empty or if the first character of the uri-
   path is not a %x2F ("/") character, output %x2F ("/") and skip
   the remaining steps.
   - RFC 6215 5.1.4 "Paths and Path-Match" point 2

## Are there changes in behavior for the user?

No.

## Related issue number

#1047 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes