### PR TITLE
Prevent infinite hang on WebSocket response.close() (#1002)

### DIFF
--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -187,7 +187,8 @@ class WebSocketResponse(StreamResponse):
             if self._closing:
                 return True
 
-            while True:
+            begin = self._loop.time()
+            while self._loop.time() - begin < self._timeout:
                 try:
                     with Timeout(timeout=self._timeout,
                                  loop=self._loop):

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -216,3 +216,45 @@ def test_send_recv_json(create_app_and_client, loop):
     yield from ws.close()
 
     yield from closed
+
+
+@pytest.mark.run_loop
+def test_close_timeout(create_app_and_client, loop):
+    closed = helpers.create_future(loop)
+
+    @asyncio.coroutine
+    def handler(request):
+        ws = web.WebSocketResponse(timeout=0.1)
+        yield from ws.prepare(request)
+        assert 'request' == (yield from ws.receive_str())
+        ws.send_str('reply')
+        begin = ws._loop.time()
+        yield from ws.close()
+        elapsed = ws._loop.time() - begin
+        assert elapsed < 0.201, 'close() should have returned before at most 2x timeout.'
+        closed.set_result(1)
+        return ws
+
+    app, client = yield from create_app_and_client()
+    app.router.add_route('GET', '/', handler)
+
+    ws = yield from client.ws_connect('/')
+    ws.send_str('request')
+    assert 'reply' == (yield from ws.receive_str())
+
+    # The server closes here.
+    # The client send bogus messages with an internval
+    # shorter than server-side close timeout, to make
+    # the server hanging indefinitely.
+    yield from asyncio.sleep(0.04, loop=loop)
+    ws.send_str('hang')
+    yield from asyncio.sleep(0.04, loop=loop)
+    ws.send_str('hang')
+    yield from asyncio.sleep(0.04, loop=loop)
+    ws.send_str('hang')
+    yield from asyncio.sleep(0.04, loop=loop)
+    ws.send_str('hang')
+    yield from asyncio.sleep(0.04, loop=loop)
+    # The server should have been closed now.
+    assert 1 == (yield from closed)
+    yield from ws.close()

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -231,7 +231,9 @@ def test_close_timeout(create_app_and_client, loop):
         begin = ws._loop.time()
         yield from ws.close()
         elapsed = ws._loop.time() - begin
-        assert elapsed < 0.201, 'close() should have returned before at most 2x timeout.'
+        assert elapsed < 0.201, \
+            'close() should have returned before ' \
+            'at most 2x timeout.'
         closed.set_result(1)
         return ws
 
@@ -242,10 +244,9 @@ def test_close_timeout(create_app_and_client, loop):
     ws.send_str('request')
     assert 'reply' == (yield from ws.receive_str())
 
-    # The server closes here.
-    # The client send bogus messages with an internval
-    # shorter than server-side close timeout, to make
-    # the server hanging indefinitely.
+    # The server closes here.  Then the client sends bogus messages with an
+    # internval shorter than server-side close timeout, to make the server
+    # hanging indefinitely.
     yield from asyncio.sleep(0.04, loop=loop)
     ws.send_str('hang')
     yield from asyncio.sleep(0.04, loop=loop)


### PR DESCRIPTION
## What do these changes do?

`WebSocketResponse.close()` would no longer block indefinitely even when a malicious client sends bogus messages with an interval shorter than server-side close timeout.

## Are there changes in behavior for the user?

No changes.

## Related issue number

#1002 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes

* The close() method now checks the time elapsed since the original
   starting time as well as the timeout for each iteration.

* Now close() should wait no more than at most twice of the timeout
   given to WebSocketResponse.