### PR TITLE
Compatibility patch for async generator protocol change

### DIFF
--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -7,6 +7,7 @@ import sys
 from ._ws_impl import CLOSED_MESSAGE, WebSocketError, WSMessage, WSMsgType
 
 PY_35 = sys.version_info >= (3, 5)
+PY_352 = sys.version_info >= (3, 5, 2)
 
 
 class ClientWebSocketResponse:
@@ -179,9 +180,13 @@ class ClientWebSocketResponse:
         return loads(data)
 
     if PY_35:
-        @asyncio.coroutine
-        def __aiter__(self):
-            return self
+        if PY_352:
+            def __aiter__(self):
+                return self
+        else:
+            @asyncio.coroutine
+            def __aiter__(self):
+                return self
 
         @asyncio.coroutine
         def __anext__(self):

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -6,6 +6,7 @@ import json
 import mimetypes
 import os
 import re
+import sys
 import uuid
 import warnings
 import zlib
@@ -31,6 +32,8 @@ CTL = set(chr(i) for i in range(0, 32)) | {chr(127), }
 SEPARATORS = {'(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']',
               '?', '=', '{', '}', ' ', chr(9)}
 TOKEN = CHAR ^ CTL ^ SEPARATORS
+
+PY_352 = sys.version_info >= (3, 5, 2)
 
 
 class BadContentDispositionHeader(RuntimeWarning):
@@ -161,9 +164,13 @@ class MultipartResponseWrapper(object):
         self.resp = resp
         self.stream = stream
 
-    @asyncio.coroutine
-    def __aiter__(self):
-        return self
+    if PY_352:
+        def __aiter__(self):
+            return self
+    else:
+        @asyncio.coroutine
+        def __aiter__(self):
+            return self
 
     @asyncio.coroutine
     def __anext__(self):
@@ -211,9 +218,13 @@ class BodyPartReader(object):
         self._prev_chunk = None
         self._content_eof = 0
 
-    @asyncio.coroutine
-    def __aiter__(self):
-        return self
+    if PY_352:
+        def __aiter__(self):
+            return self
+    else:
+        @asyncio.coroutine
+        def __aiter__(self):
+            return self
 
     @asyncio.coroutine
     def __anext__(self):
@@ -507,9 +518,13 @@ class MultipartReader(object):
         self._at_bof = True
         self._unread = []
 
-    @asyncio.coroutine
-    def __aiter__(self):
-        return self
+    if PY_352:
+        def __aiter__(self):
+            return self
+    else:
+        @asyncio.coroutine
+        def __aiter__(self):
+            return self
 
     @asyncio.coroutine
     def __anext__(self):

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -13,6 +13,7 @@ __all__ = (
     'FlowControlDataQueue', 'FlowControlChunksQueue')
 
 PY_35 = sys.version_info >= (3, 5)
+PY_352 = sys.version_info >= (3, 5, 2)
 
 EOF_MARKER = b''
 DEFAULT_LIMIT = 2 ** 16
@@ -27,9 +28,13 @@ class AsyncStreamIterator:
     def __init__(self, read_func):
         self.read_func = read_func
 
-    @asyncio.coroutine
-    def __aiter__(self):
-        return self
+    if PY_352:
+        def __aiter__(self):
+            return self
+    else:
+        @asyncio.coroutine
+        def __aiter__(self):
+            return self
 
     @asyncio.coroutine
     def __anext__(self):
@@ -45,9 +50,13 @@ class AsyncStreamIterator:
 class AsyncStreamReaderMixin:
 
     if PY_35:
-        @asyncio.coroutine
-        def __aiter__(self):
-            return AsyncStreamIterator(self.readline)
+        if PY_352:
+            def __aiter__(self):
+                return AsyncStreamIterator(self.readline)
+        else:
+            @asyncio.coroutine
+            def __aiter__(self):
+                return AsyncStreamIterator(self.readline)
 
         def iter_chunked(self, n):
             """Returns an asynchronous iterator that yields chunks of size n.
@@ -477,9 +486,13 @@ class DataQueue:
                 raise EofStream
 
     if PY_35:
-        @asyncio.coroutine
-        def __aiter__(self):
-            return AsyncStreamIterator(self.read)
+        if PY_352:
+            def __aiter__(self):
+                return AsyncStreamIterator(self.read)
+        else:
+            @asyncio.coroutine
+            def __aiter__(self):
+                return AsyncStreamIterator(self.read)
 
 
 class ChunksQueue(DataQueue):

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -14,6 +14,7 @@ from .web_reqrep import StreamResponse
 __all__ = ('WebSocketResponse',)
 
 PY_35 = sys.version_info >= (3, 5)
+PY_352 = sys.version_info >= (3, 5, 2)
 
 THRESHOLD_CONNLOST_ACCESS = 5
 
@@ -291,9 +292,13 @@ class WebSocketResponse(StreamResponse):
         raise RuntimeError("Cannot call .write() for websocket")
 
     if PY_35:
-        @asyncio.coroutine
-        def __aiter__(self):
-            return self
+        if PY_352:
+            def __aiter__(self):
+                return self
+        else:
+            @asyncio.coroutine
+            def __aiter__(self):
+                return self
 
         @asyncio.coroutine
         def __anext__(self):


### PR DESCRIPTION
## What do these changes do?
Add 3.5.2. version check for __aiter__ method compatibility.

## Are there changes in behavior for the user?
Nope 

## Related issue number
#1082 

## Checklist
[x] I think the code is well written
[] Unit tests for the changes exist 
[] Documentation reflects the changes

I'm not sure this patch needs an unit test. 