### PR TITLE
Explicitly return TimeoutError on WebSocketResponse.close() (#1084)

### DIFF
--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -205,6 +205,10 @@ class WebSocketResponse(StreamResponse):
                 if msg.type == WSMsgType.CLOSE:
                     self._close_code = msg.data
                     return True
+
+            self._close_code = 1006
+            self._exception = asyncio.TimeoutError()
+            return True
         else:
             return False
 


### PR DESCRIPTION
## What do these changes do?

Revises `WebSocketResponse.close()` patch by explicitly returning TimeoutError with close code 1006 in #1084 for #1002.

## Are there changes in behavior for the user?

Nothing.

## Related issue number

#1002

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
