### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -101,11 +101,11 @@ WebSocket utilities
 
    .. attribute:: TEXT
 
-      Text messsage, the value has :class:`str` type.
+      Text message, the value has :class:`str` type.
 
    .. attribute:: BINARY
 
-      Binary messsage, the value has :class:`bytes` type.
+      Binary message, the value has :class:`bytes` type.
 
    .. attribute:: PING
 

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -43,7 +43,7 @@ Other HTTP methods are available as well::
 .. note::
 
    Don't create a session per request. Most likely you need a session
-   per application which perfoms all requests altogether.
+   per application which performs all requests altogether.
 
    A session contains a connection pool inside, connection reusage and
    keep-alives (both are on by default) may speed up total performance.
@@ -179,7 +179,7 @@ But explicit :meth:`~ClientResponse.release` call also may be used::
 
     await resp.release()
 
-Hovewer it's not necessary if you use :meth:`~ClientResponse.read`,
+However it's not necessary if you use :meth:`~ClientResponse.read`,
 :meth:`~ClientResponse.json` and :meth:`~ClientResponse.text` methods.
 They do release connection internally but better don't rely on that
 behavior.
@@ -314,7 +314,7 @@ Or you can provide an :ref:`coroutine<coroutine>` that yields bytes objects::
 .. note::
 
    It is not a standard :ref:`coroutine<coroutine>` as it yields values so it
-   can not be used like ``yield from my_coroutine()``.
+   cannot be used like ``yield from my_coroutine()``.
    :mod:`aiohttp` internally handles such coroutines.
 
 Also it is possible to use a :class:`~aiohttp.streams.StreamReader`
@@ -406,7 +406,7 @@ accepting from URLs with IP address instead of DNS name
 (e.g. `http://127.0.0.1:80/cookie`).
 
 It's good but sometimes for testing we need to enable support for such
-cookies. It should be done by passing `usafe=True` to
+cookies. It should be done by passing `unsafe=True` to
 :class:`aiohttp.CookieJar` constructor::
 
 
@@ -662,7 +662,7 @@ methods::
                break
 
 
-You **must** use the only websocket task for both reading (e.g ``await
+You **must** use the only websocket task for both reading (e.g. ``await
 ws.receive()`` or ``async for msg in ws:``) and writing but may have
 multiple writer tasks which can only send data asynchronously (by
 ``ws.send_str('data')`` for example).

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -534,7 +534,7 @@ Usage::
 
 .. coroutinefunction:: options(url, **kwargs)
 
-   Perform a OPTIONS request.
+   Perform an OPTIONS request.
 
    :param str url: Requested URL.
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -59,7 +59,7 @@
       A concept reflects the HTTP **path**, every resource corresponds
       to *URI*.
 
-      May have an unique name.
+      May have a unique name.
 
       Contains :term:`route`\'s for different HTTP methods.
 

--- a/docs/gunicorn.rst
+++ b/docs/gunicorn.rst
@@ -94,7 +94,7 @@ worker processes.
 More information
 ----------------
 
-The Gunicorn documentation recommends deploying Gunicorn behind a
+The Gunicorn documentation recommends deploying Gunicorn behind an
 Nginx proxy server. See the `official documentation
 <http://docs.gunicorn.org/en/latest/deploy.html>`_ for more
 information about suggested nginx configuration.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,7 +111,7 @@ Continuous Integration.
 Dependencies
 ------------
 
-- Python Python 3.4.1+
+- Python 3.4.1+
 - *chardet* library
 - *multidict* library
 - *Optional* :term:`cchardet` library as faster replacement for

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -9,7 +9,6 @@ cchardet
 cChardet
 charset
 charsetdetect
-criterias
 css
 ctor
 Ctrl

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -214,7 +214,7 @@ conditions that hard to reproduce on real server::
 
 .. warning::
 
-   We don't recommed to apply
+   We don't recommend to apply
    :func:`~aiohttp.test_utils.make_mocked_request` everywhere for
    testing web-handler's business object -- please use test client and
    real networking via 'localhost' as shown in examples before.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -104,7 +104,7 @@ Thus we **suggest** to use the following approach:
    1. Pushing configs as ``yaml`` files (``json`` or ``ini`` is also
       good but ``yaml`` is the best).
 
-   2. Loading ``yaml`` config from a list of predifined locations,
+   2. Loading ``yaml`` config from a list of predefined locations,
       e.g. ``./config/app_cfg.yaml``, ``/etc/app_cfg.yaml``.
 
    3. Keeping ability to override config file by command line
@@ -248,7 +248,7 @@ Let's add more useful views::
                'choices': choices
            }
 
-Templates are very convinient way forweb page writing. We return a
+Templates are very convenient way for web page writing. We return a
 dict with page content, ``aiohttp_jinja2.template`` decorator
 processes it by jinja2 template renderer.
 
@@ -282,9 +282,9 @@ Any web site has static files: images, JavaScript sources, CSS files etc.
 The best way to handle static in production is setting up reverse
 proxy like NGINX or using CDN services.
 
-But for development handling static files by aiohttp server is very convinient.
+But for development handling static files by aiohttp server is very convenient.
 
-Fortunatelly it can be done easy by single call::
+Fortunately it can be done easy by single call::
 
     app.router.add_static('/static/',
                           path=str(project_root / 'static'),

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -485,7 +485,7 @@ browser.
 
 First, make sure that the HTML ``<form>`` element has its *enctype* attribute
 set to ``enctype="multipart/form-data"``. As an example, here is a form that
-accepts a MP3 file:
+accepts an MP3 file:
 
 .. code-block:: html
 
@@ -700,7 +700,7 @@ Data Sharing
 ------------
 
 :mod:`aiohttp.web` discourages the use of *global variables*, aka *singletons*.
-Every variable should have it's own context that is *not global*.
+Every variable should have its own context that is *not global*.
 
 So, :class:`aiohttp.web.Application` and :class:`aiohttp.web.Request`
 support a :class:`collections.abc.MutableMapping` interface (i.e. they are
@@ -732,7 +732,7 @@ choose a unique key name for storing data.
 
 If your code is published on PyPI, then the project name is most likely unique
 and safe to use as the key.
-Otherwise, something based on your company name/url would be satisfactory (i.e
+Otherwise, something based on your company name/url would be satisfactory (i.e.
 ``org.company.app``).
 
 
@@ -986,7 +986,7 @@ CORS support
 
 :mod:`aiohttp.web` itself does not support `Cross-Origin Resource
 Sharing <https://en.wikipedia.org/wiki/Cross-origin_resource_sharing>`_, but
-there is a aiohttp plugin for it:
+there is an aiohttp plugin for it:
 `aiohttp_cors <https://github.com/aio-libs/aiohttp_cors>`_.
 
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -66,7 +66,7 @@ like one using :meth:`Request.copy`.
 
    .. attribute:: path_qs
 
-      The URL including PATH_INFO and the query string. e.g, ``/app/blog?id=10``
+      The URL including PATH_INFO and the query string. e.g., ``/app/blog?id=10``
 
       Read-only :class:`str` property.
 
@@ -1214,7 +1214,7 @@ Router is any object that implements :class:`AbstractRouter` interface.
 
       *path* may be either *constant* string like ``'/a/b/c'`` or
       *variable rule* like ``'/a/{var}'`` (see
-      :ref:`handling variable pathes<aiohttp-web-variable-handler>`)
+      :ref:`handling variable paths <aiohttp-web-variable-handler>`)
 
       :param str path: resource path spec.
 
@@ -1230,7 +1230,7 @@ Router is any object that implements :class:`AbstractRouter` interface.
 
       *path* may be either *constant* string like ``'/a/b/c'`` or
        *variable rule* like ``'/a/{var}'`` (see
-       :ref:`handling variable pathes<aiohttp-web-variable-handler>`)
+       :ref:`handling variable paths <aiohttp-web-variable-handler>`)
 
       Pay attention please: *handler* is converted to coroutine internally when
       it is a regular function.
@@ -1343,7 +1343,7 @@ Router is any object that implements :class:`AbstractRouter` interface.
 
    :returns: new :class:`StaticRoute` instance.
 
-   .. coroutinemethod:: resolve(requst)
+   .. coroutinemethod:: resolve(request)
 
       A :ref:`coroutine<coroutine>` that returns
       :class:`AbstractMatchInfo` for *request*.
@@ -1397,7 +1397,7 @@ Router is any object that implements :class:`AbstractRouter` interface.
       Returns a :obj:`dict`-like :class:`types.MappingProxyType` *view* over
       *all* named **resources**.
 
-      The view maps every named resources's **name** to the
+      The view maps every named resource's **name** to the
       :class:`BaseResource` instance. It supports the usual
       :obj:`dict`-like operations, except for any mutable operations
       (i.e. it's **read-only**)::
@@ -1792,7 +1792,7 @@ Utilities
                       shutdown_timeout=60.0, ssl_context=None, \
                       print=print, backlog=128)
 
-   An utility function for running an application, serving it until
+   A utility function for running an application, serving it until
    keyboard interrupt and performing a
    :ref:`aiohttp-web-graceful-shutdown`.
 
@@ -1844,10 +1844,10 @@ Constants
 
    .. attribute:: gzip
 
-      *GZIP comression*
+      *GZIP compression*
 
    .. attribute:: identity
 
-      *no comression*
+      *no compression*
 
 .. disqus::


### PR DESCRIPTION
Found using [mwic](http://jwilk.net/software/mwic) and [anorack](https://github.com/jwilk/anorack).