### PR TITLE
Call `Application.startup` in GunicornWebWorker

### DIFF
--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -31,12 +31,11 @@ class GunicornWebWorker(base.Worker):
         super().init_process()
 
     def run(self):
+        self.loop.run_until_complete(self.wsgi.startup())
         self._runner = ensure_future(self._run(), loop=self.loop)
 
         try:
-            self.loop.run_until_complete(asyncio.gather(self._runner,
-                                                        self.wsgi.startup(),
-                                                        loop=self.loop))
+            self.loop.run_until_complete(self._runner)
         finally:
             self.loop.close()
 

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -34,7 +34,9 @@ class GunicornWebWorker(base.Worker):
         self._runner = ensure_future(self._run(), loop=self.loop)
 
         try:
-            self.loop.run_until_complete(self._runner)
+            self.loop.run_until_complete(asyncio.gather(self._runner,
+                                                        self.wsgi.startup(),
+                                                        loop=self.loop))
         finally:
             self.loop.close()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -59,8 +59,7 @@ def test_run(worker, loop):
     worker.loop = loop
     worker._run = mock.Mock(
         wraps=asyncio.coroutine(lambda: None))
-    worker.wsgi.startup = mock.Mock(
-        wraps=asyncio.coroutine(lambda: None))
+    worker.wsgi.startup = make_mocked_coro(None)
     with pytest.raises(SystemExit):
         worker.run()
     assert worker._run.called

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -54,13 +54,17 @@ def test_init_process(worker):
 
 
 def test_run(worker, loop):
+    worker.wsgi = mock.Mock()
+
     worker.loop = loop
     worker._run = mock.Mock(
         wraps=asyncio.coroutine(lambda: None))
+    worker.wsgi.startup = mock.Mock(
+        wraps=asyncio.coroutine(lambda: None))
     with pytest.raises(SystemExit):
         worker.run()
-
     assert worker._run.called
+    worker.wsgi.startup.assert_called_once_with()
     assert loop.is_closed()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- Introduced the same behavior as in `web.run_app()` to call `Application.startup()` along with the request handler.
- Extended test case to check `worker.wsgi.startup` has been called once.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
None
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#1092 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
