### PR TITLE
Issue 1069/document explicit loop for tests

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -356,7 +356,8 @@ in its signature. An example would be the following::
   class TestAcceptance:
 
       async def test_get(self, test_client, loop):
-          with patch("main.AioESService", MagicMock(return_value=AioESService(loop=loop))):
+          with patch("main.AioESService", MagicMock(
+                  side_effect=lambda *args, **kwargs: AioESService(*args, **kwargs, loop=loop))):
               client = await test_client(create_app)
               resp = await client.get("/")
               assert resp.status == 200


### PR DESCRIPTION
Added the lambda example in the first `TestAcceptance` for consistency with the last full tests file example