### PR TITLE
Fix access_log_format in `GunicornWebWorker`

### DIFF
--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -2,18 +2,23 @@
 
 import asyncio
 import os
+import re
 import signal
 import ssl
 import sys
 
 import gunicorn.workers.base as base
 
-from aiohttp.helpers import ensure_future
+from gunicorn.config import AccessLogFormat as GunicornAccessLogFormat
+from aiohttp.helpers import AccessLogger, ensure_future
 
 __all__ = ('GunicornWebWorker', 'GunicornUVLoopWebWorker')
 
 
 class GunicornWebWorker(base.Worker):
+
+    DEFAULT_AIOHTTP_LOG_FORMAT = AccessLogger.LOG_FORMAT
+    DEFAULT_GUNICORN_LOG_FORMAT = GunicornAccessLogFormat.default
 
     def __init__(self, *args, **kw):  # pragma: no cover
         super().__init__(*args, **kw)
@@ -48,7 +53,8 @@ class GunicornWebWorker(base.Worker):
             timeout=self.cfg.timeout,
             keep_alive=self.cfg.keepalive,
             access_log=self.log.access_log,
-            access_log_format=self.cfg.access_log_format)
+            access_log_format=self._get_valid_log_format(
+                self.cfg.access_log_format))
 
     @asyncio.coroutine
     def close(self):
@@ -157,6 +163,20 @@ class GunicornWebWorker(base.Worker):
         if cfg.ciphers:
             ctx.set_ciphers(cfg.ciphers)
         return ctx
+
+    def _get_valid_log_format(self, source_format):
+        if source_format == self.DEFAULT_GUNICORN_LOG_FORMAT:
+            return self.DEFAULT_AIOHTTP_LOG_FORMAT
+        elif re.search(r'%\([^\)]+\)', source_format):
+            raise ValueError(
+                "Gunicorn's style options in form of `%(name)s` are not "
+                "supported for the log formatting. Please use aiohttp's "
+                "format specification to configure access log formatting: "
+                "http://aiohttp.readthedocs.io/en/stable/logging.html"
+                "#format-specification"
+            )
+        else:
+            return source_format
 
 
 class GunicornUVLoopWebWorker(GunicornWebWorker):

--- a/docs/gunicorn.rst
+++ b/docs/gunicorn.rst
@@ -1,3 +1,5 @@
+.. _deployment-using-gunicorn:
+
 Deployment using Gunicorn
 =========================
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -89,6 +89,16 @@ Default access log format is::
    '%a %l %u %t "%r" %s %b "%{Referrer}i" "%{User-Agent}i"'
 
 
+.. note::
+
+   When `Gunicorn <http://docs.gunicorn.org/en/latest/index.html>`_ is used for
+   :ref:`deployment <deployment-using-gunicorn>` its default access log format
+   will be automatically replaced with the default aiohttp's access log format.
+
+   If Gunicorn's option access_logformat_ is
+   specified explicitly it should use aiohttp's format specification.
+
+
 Error logs
 ----------
 
@@ -100,3 +110,7 @@ The log is enabled by default.
 To use different logger name please specify *logger* parameter
 (:class:`logging.Logger` instance) on performing
 :meth:`aiohttp.web.Application.make_handler` call.
+
+
+.. _access_logformat:
+    http://docs.gunicorn.org/en/stable/settings.html#access-log-format


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- This is a workaround for a problem described in #705.
It's intended to check `GunicornWebWorker.cfg.access_log_format`.
If its value is default Gunicorn's format string, it will be replaced with default aiohttp's log format string to create request handler with.
If it doesn't use default Gunicorn's format string but still sticks to Gunicorn's specification with format options in form of `%(name)s`, the `ValueError` will be thrown with an appropriate message.

- Additionally a note about this added to `Logging` section of the documentation.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

Should fix #705 and show correct output in the access log.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#705
## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes

