### PR TITLE
More convenient `make test`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -101,6 +101,20 @@ Please take a look on the produced output.
 
 Any extra texts (print statements and so on) should be removed.
 
+.. tip::
+  You can also run a single test module or a single test case
+  by passing a ``TESTS`` argument as shown below.
+
+  .. code-block:: shell
+
+      $ make test TESTS=test_worker.py
+      $ make test TESTS=test_worker.py::test_run
+
+  .. seealso::
+    `Pytest's reference about Specifying/selecting tests
+    <http://doc.pytest.org/en/latest/usage.html
+    #specifying-tests-selecting-tests>`_
+
 
 Tests coverage
 --------------

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,10 @@ flake: .flake
 	touch .develop
 
 test: .develop
-	py.test -q ./tests
+	py.test -q ./tests/${TESTS}
 
 vtest: .develop
-	py.test -s -v ./tests
+	py.test -s -v ./tests/${TESTS}
 
 cov cover coverage:
 	tox


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- Allow to pass `TESTS` argument to `make test` and `make vtest` targets.
For example:

Following pytest documentation at
http://doc.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests

Run only selected test case: `make test TESTS=test_worker.py::test_run`
Run only selected test module: `make test TESTS=test_worker.py`
Run all tests: `make test`.

- Documented in "Contributing" section.

![image](https://cloud.githubusercontent.com/assets/957767/17989875/43470bc4-6b39-11e6-9ad3-50d82ee3b9b8.png)


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

This makes development faster in some cases.
E.g. when you want to run only one test case or one test module quickly to check your changes in the code or in the test itself and don't want to run all tests after each little change it's more convenient and fast to run only the test case/module you're interested in.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

None

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes

