### PR TITLE
Change can_start to can_prepare in ws example

### DIFF
--- a/examples/web_ws.py
+++ b/examples/web_ws.py
@@ -13,7 +13,7 @@ WS_FILE = os.path.join(os.path.dirname(__file__), 'websocket.html')
 
 async def wshandler(request):
     resp = WebSocketResponse()
-    ok, protocol = resp.can_start(request)
+    ok, protocol = resp.can_prepare(request)
     if not ok:
         with open(WS_FILE, 'rb') as fp:
             return Response(body=fp.read(), content_type='text/html')


### PR DESCRIPTION
WebSocketResponse.can_start is deprecated and should be replaced by
can_prepare. Lets make our example reflect this.