### PR TITLE
Make prettier urls if query is empty dict

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -59,7 +59,7 @@ class AbstractResource(Sized, Iterable):
 
     @staticmethod
     def _append_query(url, query):
-        if query is not None:
+        if query:
             return url + "?" + urlencode(query)
         else:
             return url

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -405,6 +405,15 @@ def test_params_update_path_and_url(make_request):
     assert req.url == 'http://python.org/?test=foo&test=baz'
 
 
+def test_params_empty_path_and_url(make_request):
+    req_empty = make_request('get', 'http://python.org', params={})
+    assert req_empty.path == '/'
+    assert req_empty.url == 'http://python.org/'
+    req_none = make_request('get', 'http://python.org')
+    assert req_none.path == '/'
+    assert req_none.url == 'http://python.org/'
+
+
 def test_gen_netloc_all(make_request):
     req = make_request('get',
                        'https://aiohttp:pwpwpw@' +


### PR DESCRIPTION
## What do these changes do?

Make better urls for named routes when query is empty dict. 

## Are there changes in behavior for the user?

Should not require to update or change existed code.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
