### PR TITLE
Document streams

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,7 +107,7 @@ CHANGES
 
 -
 
--
+- Default value for StreamReader.read_nowait is -1 from now
 
 -
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -284,7 +284,8 @@ class ClientRequest:
             if hdrs.CONTENT_LENGTH not in self.headers and not self.chunked:
                 self.headers[hdrs.CONTENT_LENGTH] = str(len(self.body))
 
-        elif isinstance(data, (asyncio.StreamReader, streams.DataQueue)):
+        elif isinstance(data, (asyncio.StreamReader, streams.StreamReader,
+                               streams.DataQueue)):
             self.body = data
 
         elif asyncio.iscoroutine(data):

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -428,7 +428,8 @@ class ClientRequest:
                             'Bytes object is expected, got: %s.' %
                             type(result))
 
-            elif isinstance(self.body, asyncio.StreamReader):
+            elif isinstance(self.body, (asyncio.StreamReader,
+                                        streams.StreamReader)):
                 request.transport.set_tcp_nodelay(True)
                 chunk = yield from self.body.read(streams.DEFAULT_LIMIT)
                 while chunk:

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -65,7 +65,7 @@ class AsyncStreamReaderMixin:
             return AsyncStreamIterator(self.readany)
 
 
-class StreamReader(asyncio.StreamReader, AsyncStreamReaderMixin):
+class StreamReader(AsyncStreamReaderMixin):
     """An enhancement of asyncio.StreamReader.
 
     Supports asynchronous iteration by line, chunk or as available::

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -66,7 +66,7 @@ class AsyncStreamReaderMixin:
 
 
 class StreamReader(asyncio.StreamReader, AsyncStreamReaderMixin):
-    """An enhancement of :class:`asyncio.StreamReader`.
+    """An enhancement of asyncio.StreamReader.
 
     Supports asynchronous iteration by line, chunk or as available::
 
@@ -77,8 +77,6 @@ class StreamReader(asyncio.StreamReader, AsyncStreamReaderMixin):
         async for slice in reader.iter_any():
             ...
 
-    .. automethod:: AsyncStreamReaderMixin.iter_chunked
-    .. automethod:: AsyncStreamReaderMixin.iter_any
     """
 
     total_bytes = 0

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -215,15 +215,6 @@ aiohttp.signals module
     :undoc-members:
     :show-inheritance:
 
-aiohttp.streams module
-----------------------
-
-.. automodule:: aiohttp.streams
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
 aiohttp.wsgi module
 -------------------
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -4,7 +4,6 @@ HTTP Client Reference
 =====================
 
 .. module:: aiohttp
-
 .. currentmodule:: aiohttp
 
 
@@ -1121,9 +1120,7 @@ Response object
 
    .. attribute:: content
 
-      Payload stream, contains response's BODY (:class:`StreamReader`
-      compatible instance, most likely
-      :class:`FlowControlStreamReader` one).
+      Payload stream, contains response's BODY (:class:`StreamReader`).
 
    .. attribute:: cookies
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -160,6 +160,7 @@ Contents
    abc
    server
    multipart
+   streams
    api
    logging
    testing

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -5,29 +5,130 @@
 Streaming API
 =============
 
+.. module:: aiohttp
+.. currentmodule:: aiohttp
+
 
 ``aiohttp`` uses streams for retrieving *BODIES*:
 :attr:`aiohttp.web.Request.content` and
-:attr:`aiohttp.ClientResponse.content` are streams.
+:attr:`aiohttp.ClientResponse.content` are properties with stream API.
 
-
-StreamReader
-------------
 
 .. class:: StreamReader
 
-   .. comethod:: read(n=-1)
+   The reader from incoming stream.
 
-   .. comethod:: readany()
+   User should never instantiate streams manually but use existing
+   :attr:`aiohttp.web.Request.content` and
+   :attr:`aiohttp.ClientResponse.content` properties for accessing raw
+   BODY data.
 
-   .. comethod:: readexactly(n)
+Reading Methods
+---------------
 
-   .. comethod:: readline()
+.. comethod:: StreamReader.read(n=-1)
 
-   .. method:: read_nowait(n=None)
+   Read up to *n* bytes. If *n* is not provided, or set to ``-1``, read until
+   EOF and return all read bytes.
 
-   .. comethod:: iter_chunked(n)
-      :async-for:
+   If the EOF was received and the internal buffer is empty, return an
+   empty bytes object.
 
-   .. comethod:: iter_any(n)
-      :async-for:
+   :param int n: how many bytes to read, ``-1`` for the whole stream.
+
+   :return bytes: the given data
+
+.. comethod:: StreamReader.readany()
+
+   Read next data portion for the stream.
+
+   Returns immediately if internal buffer has a data.
+
+   :return bytes: the given data
+
+.. comethod:: StreamReader.readexactly(n)
+
+   Read exactly *n* bytes.
+
+   Raise an :exc:`asyncio.IncompleteReadError` if the end of the
+   stream is reached before *n* can be read, the
+   :attr:`asyncio.IncompleteReadError.partial` attribute of the
+   exception contains the partial read bytes.
+
+   :param int n: how many bytes to read.
+
+   :return bytes: the given data
+
+
+.. comethod:: StreamReader.readline()
+
+   Read one line, where “line” is a sequence of bytes ending
+   with ``\n``.
+
+   If EOF is received, and ``\n`` was not found, the method will
+   return the partial read bytes.
+
+   If the EOF was received and the internal buffer is empty, return an
+   empty bytes object.
+
+   :return bytes: the given line
+
+Asynchronous Iteration Support
+------------------------------
+
+__aiter__
+
+.. comethod:: StreamReader.iter_chunked(n)
+   :async-for:
+
+.. comethod:: StreamReader.iter_any(n)
+   :async-for:
+
+
+Helpers
+-------
+
+.. method:: StreamReader.exception()
+
+   Get the exception occurred on data reading.
+
+.. method:: is_eof()
+
+   Return ``True`` if EOF was reached.
+
+   Internal buffer may be not empty at the moment.
+
+   .. seealso::
+
+      :meth:`StreamReader.at_eof()`
+
+.. method:: StreamReader.at_eof()
+
+   Return ``True`` if the buffer is empty and EOF was reached.
+
+.. method:: StreamReader.read_nowait(n=None)
+
+   Returns data from internal buffer if any, empty bytes object otherwise.
+
+   Raises :exc:`RuntimeError` if other coroutine is waiting for stream.
+
+
+   :param int n: how many bytes to read, ``-1`` for the whole internal
+                 buffer.
+
+   :return bytes: the given data
+
+.. method:: StreamReader.unread_data(data)
+
+   Rollback reading some data from stream, inserting it to buffer head.
+
+   :param bytes data: data to push back into the stream.
+
+   .. warning:: The method doesn't wake up waiters.
+
+      E.g. :meth:`~StreamReader.read()` will not be resumed.
+
+
+.. comethod:: wait_eof()
+
+   Wait for EOF. The given data may be accessible by upcoming read calls.

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -76,13 +76,32 @@ Reading Methods
 Asynchronous Iteration Support
 ------------------------------
 
-__aiter__
+
+Stream reader supports asynchronous iteration over BODY.
+
+By default it iterates over lines::
+
+   async for line in response.content:
+       print(line)
+
+Also there are methods for iterating over data chunks with maximum
+size limit and over any available data.
 
 .. comethod:: StreamReader.iter_chunked(n)
    :async-for:
 
+   Iterates over data chunks with maximum size limit::
+
+      async for data in response.content.iter_chunked(1024):
+          print(data)
+
 .. comethod:: StreamReader.iter_any(n)
    :async-for:
+
+   Iterates over data chunks in order of intaking them into the stream::
+
+      async for data in response.content.iter_any():
+          print(data)
 
 
 Helpers

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -168,7 +168,7 @@ like one using :meth:`Request.copy`.
 
    .. attribute:: content
 
-      A :class:`~aiohttp.streams.FlowControlStreamReader` instance,
+      A :class:`~aiohttp.StreamReader` instance,
       input stream for reading request's *BODY*.
 
       Read-only property.


### PR DESCRIPTION
Explicitly document streaming API.

Fixes #1106

Also don't inherit `aiohttp.StreamReader` from `asyncio.StreamReader`.

The inheritance makes a mess.

For example `asyncio.StreamReader` has `readuntil()` method but calling it from `aiohttp.StreamReader` leads to crash because internal implementation differs.