### PR TITLE
Improve speed of native WebSocket frame parsing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -253,3 +253,5 @@ CHANGES
 - Add manylinux wheel builds
 
 - Dup a socket for sendfile usage #964
+
+- Improve speed of WebSocket frame parsing

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -105,6 +105,7 @@ Sebastian Hüther
 SeongSoo Cho
 Sergey Ninua
 Sergey Skripnick
+Seth Larson
 Simon Kennedy
 Sin-Woo Bang
 Stanislas Plum

--- a/aiohttp/_ws_impl.py
+++ b/aiohttp/_ws_impl.py
@@ -218,7 +218,7 @@ def _websocket_mask_python(mask, data):
         # everything work without this, but may be changed later in Python.
         return bytearray()
     data = int.from_bytes(data, native_byteorder)
-    mask = int.from_bytes(mask * (datalen // 4) + mask[: datalen % 4],
+    mask = int.from_bytes(mask * (datalen >> 2) + mask[: datalen & 3],
                           native_byteorder)
     return (data ^ mask).to_bytes(datalen, native_byteorder)
 
@@ -236,26 +236,24 @@ else:
 def parse_frame(buf, continuation=False):
     """Return the next frame from the socket."""
     # read header
-    data = yield from buf.read(2)
-    first_byte, second_byte = data
+    first_byte, second_byte = yield from buf.read(2)
 
-    fin = (first_byte >> 7) & 1
-    rsv1 = (first_byte >> 6) & 1
-    rsv2 = (first_byte >> 5) & 1
-    rsv3 = (first_byte >> 4) & 1
-    opcode = first_byte & 0xf
+    reserved = first_byte & 112
 
     # frame-fin = %x0 ; more frames of this message follow
     #           / %x1 ; final frame of this message
     # frame-rsv1 = %x0 ; 1 bit, MUST be 0 unless negotiated otherwise
     # frame-rsv2 = %x0 ; 1 bit, MUST be 0 unless negotiated otherwise
     # frame-rsv3 = %x0 ; 1 bit, MUST be 0 unless negotiated otherwise
-    if rsv1 or rsv2 or rsv3:
+    if reserved:
         raise WebSocketError(
             WSCloseCode.PROTOCOL_ERROR,
             'Received frame with non-zero reserved bits')
+            
+    fin = first_byte & 128
+    opcode = first_byte & 15
 
-    if opcode > 0x7 and fin == 0:
+    if opcode > 7 and fin == 0:
         raise WebSocketError(
             WSCloseCode.PROTOCOL_ERROR,
             'Received fragmented control frame')
@@ -266,11 +264,11 @@ def parse_frame(buf, continuation=False):
             'Received new fragment frame with non-zero '
             'opcode {!r}'.format(opcode))
 
-    has_mask = (second_byte >> 7) & 1
-    length = (second_byte) & 0x7f
+    has_mask = second_byte & 128
+    length = second_byte & 127
 
     # Control frames MUST have a payload length of 125 bytes or less
-    if opcode > 0x7 and length > 125:
+    if opcode > 7 and length > 125:
         raise WebSocketError(
             WSCloseCode.PROTOCOL_ERROR,
             "Control frame payload cannot be larger than 125 bytes")
@@ -310,18 +308,18 @@ class WebSocketWriter:
 
         use_mask = self.use_mask
         if use_mask:
-            mask_bit = 0x80
+            mask_bit = 128
         else:
             mask_bit = 0
 
         if msg_length < 126:
-            header = PACK_LEN1(0x80 | opcode, msg_length | mask_bit)
-        elif msg_length < (1 << 16):
-            header = PACK_LEN2(0x80 | opcode, 126 | mask_bit, msg_length)
+            header = PACK_LEN1(128 | opcode, msg_length | mask_bit)
+        elif msg_length < 65536:
+            header = PACK_LEN2(128 | opcode, 126 | mask_bit, msg_length)
         else:
-            header = PACK_LEN3(0x80 | opcode, 127 | mask_bit, msg_length)
+            header = PACK_LEN3(128 | opcode, 127 | mask_bit, msg_length)
         if use_mask:
-            mask = self.randrange(0, 0xffffffff)
+            mask = self.randrange(0, 4294967295)
             mask = mask.to_bytes(4, 'big')
             message = _websocket_mask(mask, bytearray(message))
             self.writer.write(header + mask + message)

--- a/aiohttp/_ws_impl.py
+++ b/aiohttp/_ws_impl.py
@@ -249,7 +249,7 @@ def parse_frame(buf, continuation=False):
         raise WebSocketError(
             WSCloseCode.PROTOCOL_ERROR,
             'Received frame with non-zero reserved bits')
-            
+
     fin = first_byte & 128
     opcode = first_byte & 15
 

--- a/aiohttp/_ws_impl.py
+++ b/aiohttp/_ws_impl.py
@@ -319,7 +319,7 @@ class WebSocketWriter:
         else:
             header = PACK_LEN3(0x80 | opcode, 127 | mask_bit, msg_length)
         if use_mask:
-            mask = self.randrange(0, 0xFFFFFFFF)
+            mask = self.randrange(0, 0xffffffff)
             mask = mask.to_bytes(4, 'big')
             message = _websocket_mask(mask, bytearray(message))
             self.writer.write(header + mask + message)


### PR DESCRIPTION
## What do these changes do?

Improve speed for native parsing WebSocket frames using faster bit-manipulation and constants. Doesn't require any new documentation/unit-tests.

## Are there changes in behavior for the user?

No changes in behavior.

## Related issue number

No issues are closed with this PR.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (Not needed?)
- [ ] Documentation reflects the changes (Not needed?)
- [x] Add yourself to `CONTRIBUTORS.txt`
- [x] Add a new entry to `CHANGES.rst`
