### PR TITLE
Fixing issue #1188 (mktime call replaced by constant)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -54,6 +54,7 @@ Gennady Andreyev
 Georges Dubus
 Greg Holt
 Gregory Haynes
+Günther Jena
 Hugo Herter
 Igor Pavlov
 Ingmar Steen

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -1,6 +1,5 @@
 import datetime
 import re
-import time
 from collections import defaultdict
 from collections.abc import Mapping
 from http.cookies import Morsel, SimpleCookie
@@ -27,7 +26,7 @@ class CookieJar(AbstractCookieJar):
 
     DATE_YEAR_RE = re.compile("(\d{2,4})")
 
-    MAX_TIME = time.mktime((2100, 1, 1, 1, 1, 1, 1, 1, 1,))  # so far in future
+    MAX_TIME = 2208985261.0  # so far in future (1/1/2100)
 
     def __init__(self, *, unsafe=False, loop=None):
         super().__init__(loop=loop)


### PR DESCRIPTION
## What do these changes do?

Change the call for mktime to calculate a time stamp in the far future (1/1/2100) and replace it by the resulting constant of 2208985261.0 .

## Are there changes in behavior for the user?

No changes, as mktime is resulting this exact value

## Related issue number

#1188 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#isuue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.

Fixing issue https://github.com/KeepSafe/aiohttp/issues/1188 . mktime depends on the underlying mktime from libc and on some embedded systems it uses only a 32bit time stamp which is reaching only to year 2038.