### PR TITLE
fixes #1194

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ This is simple usage example:
     async def handle(request):
         name = request.match_info.get('name', "Anonymous")
         text = "Hello, " + name
-        return web.Response(body=text.encode('utf-8'))
+        return web.Response(text=text)
 
     async def wshandler(request):
         ws = web.WebSocketResponse()
@@ -83,6 +83,7 @@ This is simple usage example:
 
     app = web.Application()
     app.router.add_get('/echo', wshandler)
+    app.router.add_get('/', handle)
     app.router.add_get('/{name}', handle)
 
     web.run_app(app)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ replacement for :term:`chardet`:
 
 For speeding up DNS resolving by client API you may install
 :term:`aiodns` as well.
-This options is highly recommended:
+This option is highly recommended:
 
 .. code-block:: bash
 
@@ -72,9 +72,10 @@ Server example::
     async def handle(request):
         name = request.match_info.get('name', "Anonymous")
         text = "Hello, " + name
-        return web.Response(body=text.encode('utf-8'))
+        return web.Response(text=text)
 
     app = web.Application()
+    app.router.add_get('/', handle)
     app.router.add_get('/{name}', handle)
 
     web.run_app(app)

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -57,7 +57,7 @@ A simple would be::
     from aiohttp import web
 
     async def hello(request):
-        return web.Response(body=b'Hello, world')
+        return web.Response(text='Hello, world')
 
     async def test_hello(test_client, loop):
         app = web.Application(loop=loop)
@@ -82,7 +82,7 @@ app test client::
             request.app['value'] = (await request.post())['value']
             return web.Response(body=b'thanks for the data')
         return web.Response(
-            body='value: {}'.format(request.app['value']).encode())
+            body='value: {}'.format(request.app['value']).encode('utf-8'))
 
     @pytest.fixture
     def cli(loop, test_client):

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -196,7 +196,7 @@ As discussed above, :ref:`handlers <aiohttp-web-handler>` can be first-class
 functions or coroutines::
 
    async def hello(request):
-       return web.Response(body=b"Hello, world")
+       return web.Response(text="Hello, world")
 
    app.router.add_get('/', hello)
 
@@ -212,7 +212,7 @@ application developers can organize handlers in classes if they so wish::
            pass
 
        def handle_intro(self, request):
-           return web.Response(body=b"Hello, world")
+           return web.Response(text="Hello, world")
 
        async def handle_greeting(self, request):
            name = request.match_info.get('name', "Anonymous")
@@ -414,7 +414,7 @@ third-party library, :mod:`aiohttp_session`, that adds *session* support::
         session = await get_session(request)
         last_visit = session['last_visit'] if 'last_visit' in session else None
         text = 'Last visited: {}'.format(last_visit)
-        return web.Response(body=text.encode('utf-8'))
+        return web.Response(text=text)
 
     def make_app():
         app = web.Application()
@@ -554,7 +554,7 @@ should use :meth:`Request.multipart` which returns :ref:`multipart reader
                 size += len(chunk)
                 f.write(chunk)
 
-        return web.Response(body='{} sized of {} successfully stored'
+        return web.Response(text='{} sized of {} successfully stored'
                                  ''.format(filename, size))
 
 .. _aiohttp-web-websockets:

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -19,7 +19,7 @@ accepts a :class:`Request` instance as its only parameter and returns a
    from aiohttp import web
 
    async def hello(request):
-       return web.Response(body=b"Hello, world")
+       return web.Response(text="Hello, world")
 
 Next, create an :class:`Application` instance and register the
 request handler with the application's :class:`router <UrlDispatcher>` on a


### PR DESCRIPTION
Fixes for examples README and docs index page (#1194).

Also there are many examples using `web.Response(body=text.encode('utf-8'))`
and so making content_type fallback to `application/octet-stream`.
I guess all those examples should be fixed aswell. Any thoughts?