### PR TITLE
multiple fixes in examples 

### DIFF
--- a/examples/client_auth.py
+++ b/examples/client_auth.py
@@ -7,7 +7,7 @@ async def fetch(session):
     async with session.get(
             'http://httpbin.org/basic-auth/andrew/password') as resp:
         print(resp.status)
-        body = yield from resp.text()
+        body = await resp.text()
         print(body)
 
 
@@ -15,8 +15,8 @@ async def go(loop):
     async with aiohttp.ClientSession(
             auth=aiohttp.BasicAuth('andrew', 'password'),
             loop=loop) as session:
-        await go(session)
+        await fetch(session)
 
 
 loop = asyncio.get_event_loop()
-loop.run_until_complete(go())
+loop.run_until_complete(go(loop))

--- a/examples/curl.py
+++ b/examples/curl.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
+import argparse
 import asyncio
-import sys
 
 import aiohttp
 
@@ -19,11 +19,17 @@ def curl(url):
 
 
 if __name__ == '__main__':
-    if '--iocp' in sys.argv:
+    ARGS = argparse.ArgumentParser(description="GET url example")
+    ARGS.add_argument('url', nargs=1, metavar='URL',
+                      help="URL to download")
+    ARGS.add_argument('--iocp', default=False, action="store_true",
+                      help="Use ProactorEventLoop on Windows")
+    options = ARGS.parse_args()
+
+    if options.iocp:
         from asyncio import events, windows_events
-        sys.argv.remove('--iocp')
         el = windows_events.ProactorEventLoop()
         events.set_event_loop(el)
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(curl(sys.argv[1]))
+    loop.run_until_complete(curl(options.url[0]))

--- a/examples/static_files.py
+++ b/examples/static_files.py
@@ -1,4 +1,5 @@
 import pathlib
+
 from aiohttp import web
 
 app = web.Application()

--- a/examples/web_classview1.py
+++ b/examples/web_classview1.py
@@ -58,4 +58,4 @@ async def init(loop):
 
 loop = asyncio.get_event_loop()
 app = loop.run_until_complete(init(loop))
-run_app(app, loop=loop)
+run_app(app)

--- a/examples/web_cookies.py
+++ b/examples/web_cookies.py
@@ -3,6 +3,7 @@
 """
 
 import asyncio
+from pprint import pformat
 
 from aiohttp import web
 
@@ -12,7 +13,7 @@ tmpl = '''\
     <body>
         <a href="/login">Login</a><br/>
         <a href="/logout">Logout</a><br/>
-        {}
+        <pre>{}</pre>
     </body>
 </html>'''
 
@@ -20,7 +21,7 @@ tmpl = '''\
 @asyncio.coroutine
 def root(request):
     resp = web.Response(content_type='text/html')
-    resp.text = tmpl.format(request.cookies)
+    resp.text = tmpl.format(pformat(request.cookies))
     return resp
 
 
@@ -48,4 +49,4 @@ def init(loop):
 
 loop = asyncio.get_event_loop()
 app = loop.run_until_complete(init(loop))
-web.run_app(app, loop=loop)
+web.run_app(app)

--- a/examples/web_srv.py
+++ b/examples/web_srv.py
@@ -15,7 +15,8 @@ async def intro(request):
     binary = txt.encode('utf8')
     resp = StreamResponse()
     resp.content_length = len(binary)
-    yield from resp.prepare(request)
+    resp.content_type = 'text/plain'
+    await resp.prepare(request)
     resp.write(binary)
     return resp
 
@@ -27,6 +28,7 @@ async def simple(request):
 async def change_body(request):
     resp = Response()
     resp.body = b"Body changed"
+    resp.content_type = 'text/plain'
     return resp
 
 
@@ -35,6 +37,7 @@ async def hello(request):
     name = request.match_info.get('name', 'Anonymous')
     answer = ('Hello, ' + name).encode('utf8')
     resp.content_length = len(answer)
+    resp.content_type = 'text/plain'
     await resp.prepare(request)
     resp.write(answer)
     await resp.write_eof()
@@ -52,4 +55,4 @@ async def init(loop):
 
 loop = asyncio.get_event_loop()
 app = loop.run_until_complete(init(loop))
-run_app(app, loop=loop)
+run_app(app)

--- a/examples/web_ws.py
+++ b/examples/web_ws.py
@@ -57,4 +57,4 @@ async def init(loop):
 
 loop = asyncio.get_event_loop()
 app = loop.run_until_complete(init(loop))
-run_app(app, loop=loop)
+run_app(app)


### PR DESCRIPTION
## What do these changes do?

Examples fixes:
* `content_type` where `Response(body=...)` is used
* `Response(text=...)` where it's more obvoius
* `loop` argument in `run_app`
* few `yield from`s in native coroutines

## Are there changes in behavior for the user?

examples just work

## Related issue number

#1194 #1195
