### PR TITLE
Add missing WSMsgType to web_ws.__all__

### DIFF
--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -12,7 +12,7 @@ from .web_exceptions import (HTTPBadRequest, HTTPInternalServerError,
                              HTTPMethodNotAllowed)
 from .web_reqrep import StreamResponse
 
-__all__ = ('WebSocketResponse', 'WebSocketReady', 'MsgType')
+__all__ = ('WebSocketResponse', 'WebSocketReady', 'MsgType', 'WSMsgType',)
 
 PY_35 = sys.version_info >= (3, 5)
 PY_352 = sys.version_info >= (3, 5, 2)


### PR DESCRIPTION
## What do these changes do?

Add `WSMsgType` to `web_ws.__all__` as it was missing there.

## Are there changes in behavior for the user?

`from aiohttp.web import WSMsgType` will work

## Related issue number

#1193
