### PR TITLE
Set documentation page title

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-aiohttp
-=======
+aiohttp: Asynchronous HTTP Client/Server
+========================================
 
 HTTP client/server for :term:`asyncio` (:pep:`3156`).
 


### PR DESCRIPTION
The documentation page title was not configured in `conf.py`, so it was the default, "aiohttp - aiohttp 1.0.1- documentation". Applying the change it becomes "aiohttp - HTTP client/server for asyncio v1.0.1"