### PR TITLE
Maybe resume read nowait

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ CHANGES
 
 - Make CookieJar compatible with 32-bit systems #1188
 
--
+- Fix FlowControlStreamReader.read_nowait so that it checks
+  whether the transport is paused
 
 -
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,6 +3,7 @@ Contributors
 
 A. Jesse Jiryu Davis
 Alejandro Gómez
+Aleksandr Danshyn
 Aleksey Kutepov
 Alex Khomchenko
 Alex Lisovoy

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -532,6 +532,8 @@ class FlowControlStreamReader(StreamReader):
                 self._stream.transport.resume_reading()
             except (AttributeError, NotImplementedError):
                 pass
+            else:
+                self._stream.paused = False
 
     def _check_buffer_size(self):
         if self._stream.paused:

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -501,29 +501,19 @@ class ChunksQueue(DataQueue):
 
 def maybe_resume(func):
 
-    @asyncio.coroutine
-    @functools.wraps(func)
-    def wrapper(self, *args, **kw):
-        result = yield from func(self, *args, **kw)
-
-        if self._stream.paused:
-            if self._buffer_size < self._b_limit:
-                try:
-                    self._stream.transport.resume_reading()
-                except (AttributeError, NotImplementedError):
-                    pass
-                else:
-                    self._stream.paused = False
-        else:
-            if self._buffer_size > self._b_limit:
-                try:
-                    self._stream.transport.pause_reading()
-                except (AttributeError, NotImplementedError):
-                    pass
-                else:
-                    self._stream.paused = True
-
-        return result
+    if asyncio.iscoroutinefunction(func):
+        @asyncio.coroutine
+        @functools.wraps(func)
+        def wrapper(self, *args, **kw):
+            result = yield from func(self, *args, **kw)
+            self._check_buffer_size()
+            return result
+    else:
+        @functools.wraps(func)
+        def wrapper(self, *args, **kw):
+            result = func(self, *args, **kw)
+            self._check_buffer_size()
+            return result
 
     return wrapper
 
@@ -543,6 +533,24 @@ class FlowControlStreamReader(StreamReader):
             except (AttributeError, NotImplementedError):
                 pass
 
+    def _check_buffer_size(self):
+        if self._stream.paused:
+            if self._buffer_size < self._b_limit:
+                try:
+                    self._stream.transport.resume_reading()
+                except (AttributeError, NotImplementedError):
+                    pass
+                else:
+                    self._stream.paused = False
+        else:
+            if self._buffer_size > self._b_limit:
+                try:
+                    self._stream.transport.pause_reading()
+                except (AttributeError, NotImplementedError):
+                    pass
+                else:
+                    self._stream.paused = True
+
     def feed_data(self, data, size=0):
         has_waiter = self._waiter is not None and not self._waiter.cancelled()
 
@@ -558,20 +566,28 @@ class FlowControlStreamReader(StreamReader):
                 self._stream.paused = True
 
     @maybe_resume
+    @asyncio.coroutine
     def read(self, n=-1):
         return (yield from super().read(n))
 
     @maybe_resume
+    @asyncio.coroutine
     def readline(self):
         return (yield from super().readline())
 
     @maybe_resume
+    @asyncio.coroutine
     def readany(self):
         return (yield from super().readany())
 
     @maybe_resume
+    @asyncio.coroutine
     def readexactly(self, n):
         return (yield from super().readexactly(n))
+
+    @maybe_resume
+    def read_nowait(self, n=-1):
+        return super().read_nowait(n)
 
 
 class FlowControlDataQueue(DataQueue):

--- a/tests/test_flowcontrol_streams.py
+++ b/tests/test_flowcontrol_streams.py
@@ -8,7 +8,7 @@ from aiohttp import streams
 class TestFlowControlStreamReader(unittest.TestCase):
 
     def setUp(self):
-        self.stream = mock.Mock()
+        self.stream = mock.Mock(paused=False)
         self.transp = self.stream.transport
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(None)
@@ -22,7 +22,7 @@ class TestFlowControlStreamReader(unittest.TestCase):
 
     def test_read(self):
         r = self._make_one()
-        r.paused = True
+        r._stream.paused = True
         r.feed_data(b'da', 2)
         res = self.loop.run_until_complete(r.read(1))
         self.assertEqual(res, b'd')
@@ -30,7 +30,7 @@ class TestFlowControlStreamReader(unittest.TestCase):
 
     def test_readline(self):
         r = self._make_one()
-        r.paused = True
+        r._stream.paused = True
         r.feed_data(b'data\n', 5)
         res = self.loop.run_until_complete(r.readline())
         self.assertEqual(res, b'data\n')
@@ -38,7 +38,7 @@ class TestFlowControlStreamReader(unittest.TestCase):
 
     def test_readany(self):
         r = self._make_one()
-        r.paused = True
+        r._stream.paused = True
         r.feed_data(b'data', 4)
         res = self.loop.run_until_complete(r.readany())
         self.assertEqual(res, b'data')
@@ -46,10 +46,10 @@ class TestFlowControlStreamReader(unittest.TestCase):
 
     def test_readexactly(self):
         r = self._make_one()
-        r.paused = True
-        r.feed_data(b'datadata', 8)
-        res = self.loop.run_until_complete(r.readexactly(2))
-        self.assertEqual(res, b'da')
+        r._stream.paused = True
+        r.feed_data(b'data', 4)
+        res = self.loop.run_until_complete(r.readexactly(3))
+        self.assertEqual(res, b'dat')
         self.assertTrue(self.transp.resume_reading.called)
 
     def test_feed_data(self):
@@ -57,6 +57,30 @@ class TestFlowControlStreamReader(unittest.TestCase):
         r._stream.paused = False
         r.feed_data(b'datadata', 8)
         self.assertTrue(self.transp.pause_reading.called)
+
+    def test_read_nowait(self):
+        r = self._make_one()
+        r._stream.paused = False
+        r.feed_data(b'data1', 5)
+        r.feed_data(b'data2', 5)
+
+        res = self.loop.run_until_complete(r.read(5))
+        self.assertTrue(res == b'data1')
+        # _buffer_size > _buffer_limit
+        self.assertTrue(self.transp.pause_reading.call_count == 1)
+        self.assertTrue(not self.transp.resume_reading.call_count)
+
+        res = r.read_nowait(5)
+        self.assertTrue(res == b'data2')
+        # _buffer_size < _buffer_limit
+        self.assertTrue(self.transp.pause_reading.call_count == 1)
+        self.assertTrue(self.transp.resume_reading.call_count == 1)
+
+        res = r.read_nowait(5)
+        self.assertTrue(res == b'')
+        # _buffer_size < _buffer_limit
+        self.assertTrue(self.transp.pause_reading.call_count == 1)
+        self.assertTrue(self.transp.resume_reading.call_count == 1)
 
 
 class FlowControlMixin:

--- a/tests/test_flowcontrol_streams.py
+++ b/tests/test_flowcontrol_streams.py
@@ -63,18 +63,26 @@ class TestFlowControlStreamReader(unittest.TestCase):
         r._stream.paused = False
         r.feed_data(b'data1', 5)
         r.feed_data(b'data2', 5)
+        r.feed_data(b'data3', 5)
+        self.assertTrue(self.stream.paused)
+
+        res = self.loop.run_until_complete(r.read(5))
+        self.assertTrue(res == b'data1')
+        # _buffer_size > _buffer_limit
+        self.assertTrue(self.transp.pause_reading.call_count == 1)
+        self.assertTrue(self.transp.resume_reading.call_count == 0)
         self.assertTrue(self.stream.paused)
 
         r._stream.paused = False
-        res = self.loop.run_until_complete(r.read(5))
-        self.assertTrue(res == b'data1')
+        res = r.read_nowait(5)
+        self.assertTrue(res == b'data2')
         # _buffer_size > _buffer_limit
         self.assertTrue(self.transp.pause_reading.call_count == 2)
         self.assertTrue(self.transp.resume_reading.call_count == 0)
         self.assertTrue(self.stream.paused)
 
         res = r.read_nowait(5)
-        self.assertTrue(res == b'data2')
+        self.assertTrue(res == b'data3')
         # _buffer_size < _buffer_limit
         self.assertTrue(self.transp.pause_reading.call_count == 2)
         self.assertTrue(self.transp.resume_reading.call_count == 1)

--- a/tests/test_flowcontrol_streams.py
+++ b/tests/test_flowcontrol_streams.py
@@ -63,24 +63,29 @@ class TestFlowControlStreamReader(unittest.TestCase):
         r._stream.paused = False
         r.feed_data(b'data1', 5)
         r.feed_data(b'data2', 5)
+        self.assertTrue(self.stream.paused)
 
+        r._stream.paused = False
         res = self.loop.run_until_complete(r.read(5))
         self.assertTrue(res == b'data1')
         # _buffer_size > _buffer_limit
-        self.assertTrue(self.transp.pause_reading.call_count == 1)
-        self.assertTrue(not self.transp.resume_reading.call_count)
+        self.assertTrue(self.transp.pause_reading.call_count == 2)
+        self.assertTrue(self.transp.resume_reading.call_count == 0)
+        self.assertTrue(self.stream.paused)
 
         res = r.read_nowait(5)
         self.assertTrue(res == b'data2')
         # _buffer_size < _buffer_limit
-        self.assertTrue(self.transp.pause_reading.call_count == 1)
+        self.assertTrue(self.transp.pause_reading.call_count == 2)
         self.assertTrue(self.transp.resume_reading.call_count == 1)
+        self.assertTrue(not self.stream.paused)
 
         res = r.read_nowait(5)
         self.assertTrue(res == b'')
         # _buffer_size < _buffer_limit
-        self.assertTrue(self.transp.pause_reading.call_count == 1)
+        self.assertTrue(self.transp.pause_reading.call_count == 2)
         self.assertTrue(self.transp.resume_reading.call_count == 1)
+        self.assertTrue(not self.stream.paused)
 
     def test_rudimentary_transport(self):
         self.transp.resume_reading.side_effect = NotImplementedError()


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

`FlowControlStreamReader.read_nowait` was not resuming the underlaying transport in case the buffers are drained, so that the subsequent `FlowControlStreamReader.read` call would hang until it timed out.

`read`, `readany` and others had `@maybe_resume` decorator but `read_nowait` did not. Since `read_nowait` changes `_buffer` and `_buffer_size`, we need to check the new size against `_buffer_limit` and perform the pause/resume action accordingly.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#isuue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
