### PR TITLE
keep consistent doc links to suggested libraries, fix some typos

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -111,7 +111,7 @@ Thus we **suggest** to use the following approach:
       parameter, e.g. ``./run_app --config=/opt/config/app_cfg.yaml``.
 
    4. Applying strict validation checks to loaded dict. `trafaret
-      <https://github.com/Deepwalker/trafaret>`_, `collander
+      <http://trafaret.readthedocs.io/en/latest/>`_, `colander
       <http://docs.pylonsproject.org/projects/colander/en/latest/>`_
       or `JSON schema
       <http://python-jsonschema.readthedocs.io/en/latest/>`_ are good


### PR DESCRIPTION
Updates the link for Trafaret in the HTTP Server tutorial to its official document pages, to keep it consistent with the other suggested libraries.

Also fixed a mini typo on the name of Colander library.