### PR TITLE
Use 1001 Going-Away code in websocket shutdown example

### DIFF
--- a/docs/web.rst
+++ b/docs/web.rst
@@ -978,7 +978,7 @@ Signal handler may look like::
 
     async def on_shutdown(app):
         for ws in app['websockets']:
-            await ws.close(code=999, message='Server shutdown')
+            await ws.close(code=WSCloseCode.GOING_AWAY, message='Server shutdown')
 
     app.on_shutdown.append(on_shutdown)
 


### PR DESCRIPTION
The current example (with 999 code) will result in exception: `WebSocketError: Invalid close code: 999`