### PR TITLE
Remove inaccurate reference to HTTP pipelining.

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -342,7 +342,7 @@ calculate the file SHA1 hash::
 
 Because the response content attribute is a
 :class:`~aiohttp.streams.StreamReader`, you can chain get and post
-requests together (aka HTTP pipelining)::
+requests together::
 
    r = await session.get('http://python.org')
    await session.post('http://httpbin.org/post',

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -130,7 +130,6 @@ params
 parsers
 pathlib
 ping
-pipelining
 pluggable
 plugin
 poller


### PR DESCRIPTION
## What do these changes do?
Removes references to HTTP pipelining. While the example shows some kind of pipelining, it is not "HTTP pipelining". 

## Are there changes in behavior for the user?
Nope. Hopefully it will make them less confused if they are looking to do HTTP pipelining.

As far as I know, aiohttp does not support HTTP pipelining. aiohttp requests must be released/exhausted before s connection can be reused (even for the same session).