### PR TITLE
Fixed StreamReader._read_nowait

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ CHANGES
 1.0.5 (XXXX-XX-XX)
 ------------------
 
--
+- Fix StreamReader._read_nowait to return all available 
+  data up to the requested amount
 
 -
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -124,6 +124,28 @@ class TestStreamReader(unittest.TestCase):
         data = self.loop.run_until_complete(stream.read(5))
         self.assertEqual(b'line2', data)
 
+    def test_read_all(self):
+        # Read all avaliable buffered bytes
+        stream = self._make_one()
+        stream.feed_data(b'line1')
+        stream.feed_data(b'line2')
+        stream.feed_eof()
+
+        data = self.loop.run_until_complete(stream.read())
+        self.assertEqual(b'line1line2', data)
+
+    def test_read_up_to(self):
+        # Read available buffered bytes up to requested amount
+        stream = self._make_one()
+        stream.feed_data(b'line1')
+        stream.feed_data(b'line2')
+
+        data = self.loop.run_until_complete(stream.read(8))
+        self.assertEqual(b'line1lin', data)
+
+        data = self.loop.run_until_complete(stream.read(8))
+        self.assertEqual(b'e2', data)
+
     def test_read_eof(self):
         # Read bytes, stop at eof.
         stream = self._make_one()


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

`StreamReader._read_nowait` was returning a single chunk from `self._buffer` even if a much larger chunk was requested and available. This behavior caused performance regressions.

Simple test:
```
import asyncio
import time

import aiohttp


async def measure(chunk_size, timeout):
    start_time = time.time()

    file_size = 0
    chunks_num = 0

    async with aiohttp.ClientSession() as session:
        async with session.get('http://localhost:8000/garbage') as response:
            response.content._b_limit = 20 * 1024 * 1024
            while True:
                chunk = await response.content.read(chunk_size)
                if not chunk:
                    break
                file_size += len(chunk)
                chunks_num += 1
                await asyncio.sleep(timeout)

    avg_chunk_size = file_size // chunks_num
    total_time = time.time() - start_time
    print(
        'req chunk size:', chunk_size,
        'avg chunk size:', avg_chunk_size,
        'timeout:', timeout,
        'total time:', total_time)


asyncio.get_event_loop().run_until_complete(measure(10 * 1024 * 1024, 0.1))
asyncio.get_event_loop().run_until_complete(measure(10 * 1024 * 1024, 0.5))
```  

Before:

```
req chunk size: 10485760 avg chunk size: 202427 timeout: 0.1 total time: 53.54 s
req chunk size: 10485760 avg chunk size: 171335 timeout: 0.5 total time: 308.13 s
```

After:
```
req chunk size: 10485760 avg chunk size: 9532509 timeout: 0.1 total time: 1.18 s
req chunk size: 10485760 avg chunk size: 9532509 timeout: 0.5 total time: 5.58 s
```

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#isuue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.

