### PR TITLE
Quote special chars in login, password in BasicAuth

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -138,3 +138,4 @@ Yusuke Tsutsumi
 Семён Марьясин
 Pau Freixes
 Alexey Firsov
+Vikas Kawadia

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -11,7 +11,7 @@ import re
 import warnings
 from collections import namedtuple
 from pathlib import Path
-from urllib.parse import urlencode
+from urllib import parse
 
 from async_timeout import timeout
 from multidict import MultiDict, MultiDictProxy
@@ -65,6 +65,8 @@ class BasicAuth(namedtuple('BasicAuth', ['login', 'password', 'encoding'])):
             username, _, password = base64.b64decode(
                 to_decode.encode('ascii')
             ).decode(encoding).partition(':')
+            username = parse.unquote(username, encoding=encoding)
+            password = parse.unquote(password, encoding=encoding)
         except binascii.Error:
             raise ValueError('Invalid base64 encoding.')
 
@@ -72,7 +74,9 @@ class BasicAuth(namedtuple('BasicAuth', ['login', 'password', 'encoding'])):
 
     def encode(self):
         """Encode credentials."""
-        creds = ('%s:%s' % (self.login, self.password)).encode(self.encoding)
+        quoted_login = parse.quote(self.login, encoding=self.encoding)
+        quoted_password = parse.quote(self.password, encoding=self.encoding)
+        creds = ('%s:%s' % (quoted_login, quoted_password)).encode(self.encoding)
         return 'Basic %s' % base64.b64encode(creds).decode(self.encoding)
 
 
@@ -175,7 +179,7 @@ class FormData:
         for type_options, _, value in self._fields:
             data.append((type_options['name'], value))
 
-        data = urlencode(data, doseq=True)
+        data = parse.urlencode(data, doseq=True)
         return data.encode(encoding)
 
     def _gen_form_data(self, *args, **kwargs):

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -76,7 +76,8 @@ class BasicAuth(namedtuple('BasicAuth', ['login', 'password', 'encoding'])):
         """Encode credentials."""
         quoted_login = parse.quote(self.login, encoding=self.encoding)
         quoted_password = parse.quote(self.password, encoding=self.encoding)
-        creds = ('%s:%s' % (quoted_login, quoted_password)).encode(self.encoding)
+        creds = ('%s:%s' % (quoted_login, quoted_password)).encode(
+            self.encoding)
         return 'Basic %s' % base64.b64encode(creds).decode(self.encoding)
 
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -260,7 +260,8 @@ def test_basic_auth_utf8(make_request):
                        auth=aiohttp.helpers.BasicAuth('nkim', 'секрет',
                                                       'utf-8'))
     assert 'AUTHORIZATION' in req.headers
-    assert 'Basic bmtpbTrRgdC10LrRgNC10YI=' == req.headers['AUTHORIZATION']
+    assert ('Basic bmtpbTolRDElODElRDAlQjUlRDAlQkElRDElODAlRDAlQjUlRDElODI=' ==
+            req.headers['AUTHORIZATION'])
 
 
 def test_basic_auth_tuple_forbidden(make_request):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -79,6 +79,15 @@ def test_basic_auth_decode():
     assert auth.password == 'pwd'
 
 
+def test_basic_auth_with_colons_in_username():
+    auth = helpers.BasicAuth('nkim:1', 'pwd')
+    encoded = auth.encode()
+    auth_decoded = helpers.BasicAuth.decode(encoded)
+
+    assert auth_decoded.login == auth.login
+    assert auth_decoded.password == auth.password
+
+
 def test_basic_auth_invalid():
     with pytest.raises(ValueError):
         helpers.BasicAuth.decode('bmtpbTpwd2Q=')


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Current  implementation of BasicAuth cannot handle a colon in login/username. This change improves it by using urllb.parse.quote/unquote to escape special chars before/after b64 encoding/decoding.

## Are there changes in behavior for the user?

Yes. Eliminates edge case errors when using BasicAuth to encode colon in usernames.

## Related issue number

None.

## Checklist

- [*] I think the code is well written
- [*] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [* ] Add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#isuue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.

