### PR TITLE
Raise ValueError if BasicAuth login has a ":"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -231,3 +231,5 @@ CHANGES
   domains (BACKWARD INCOMPATIBLE) #1125
 
 - Support binary Content-Transfer-Encoding #1169
+
+- Raise ValueError if BasicAuth login has a ":"  

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -138,3 +138,4 @@ Yusuke Tsutsumi
 Семён Марьясин
 Pau Freixes
 Alexey Firsov
+Vikas Kawadia

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -47,6 +47,10 @@ class BasicAuth(namedtuple('BasicAuth', ['login', 'password', 'encoding'])):
         if password is None:
             raise ValueError('None is not allowed as password value')
 
+        if ':' in login:
+            raise ValueError(
+                'A ":" is not allowed in login (RFC 1945#section-11.1)')
+
         return super().__new__(cls, login, password, encoding)
 
     @classmethod

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -60,6 +60,11 @@ def test_basic_auth2():
         helpers.BasicAuth('nkim', None)
 
 
+def test_basic_with_auth_colon_in_login():
+    with pytest.raises(ValueError):
+        helpers.BasicAuth('nkim:1', 'pwd')
+
+
 def test_basic_auth3():
     auth = helpers.BasicAuth('nkim')
     assert auth.login == 'nkim'


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Improves BasicAuth by raising ValueError if BasicAuth login has a ":".  A colon is not allowed in login/username per RFC 1945#section-11.1.

## Are there changes in behavior for the user?

Yes. Current BasicAuth would silently fail to authenticate if login has a ":". This change would would instead raise a clear error to the user.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [*] I think the code is well written
- [*] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [*] Add yourself to `CONTRIBUTORS.txt`
- [*] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#isuue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.

