### PR TITLE
File upload fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,7 +38,8 @@ CHANGES
 
 - Raise ValueError if BasicAuth login has a ":" character #1307
 
--
+- Fix bug when ClientRequest send payload file with opened as
+  open('filename', 'r+b') #1306
 
 -
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -139,3 +139,4 @@ Yusuke Tsutsumi
 Pau Freixes
 Alexey Firsov
 Vikas Kawadia
+Dmitry Shamov

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -257,7 +257,9 @@ class ClientRequest:
                 size = len(data.getbuffer())
                 self.headers[hdrs.CONTENT_LENGTH] = str(size)
                 self.chunked = False
-            elif not self.chunked and isinstance(data, io.BufferedReader):
+            elif not self.chunked and \
+                (isinstance(data, io.BufferedReader) or
+                 isinstance(data, io.BufferedRandom)):
                 # Not chunking if content-length can be determined
                 try:
                     size = os.fstat(data.fileno()).st_size - data.tell()

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -406,7 +406,7 @@ class ClientRequest:
             elif isinstance(self.body, io.IOBase):
                 chunk = self.body.read(self.chunked)
                 while chunk:
-                    request.write(chunk)
+                    yield from request.write(chunk, drain=True)
                     chunk = self.body.read(self.chunked)
                 request.transport.set_tcp_nodelay(True)
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -8,13 +8,14 @@ import urllib.parse
 import zlib
 from http.cookies import SimpleCookie
 from unittest import mock
+import tempfile
 
 import pytest
 from multidict import CIMultiDict, CIMultiDictProxy, upstr
 from yarl import URL
 
 import aiohttp
-from aiohttp import BaseConnector, helpers
+from aiohttp import BaseConnector, helpers, hdrs
 from aiohttp.client_reqrep import ClientRequest, ClientResponse
 
 
@@ -519,6 +520,21 @@ def test_pass_falsy_data(loop):
             'post', URL('http://python.org/'),
             data={}, loop=loop)
         req.update_body_from_data.assert_called_once_with({}, frozenset())
+    yield from req.close()
+
+
+@asyncio.coroutine
+def test_pass_falsy_data_file(loop):
+    with tempfile.TemporaryFile() as testfile:
+        testfile.write(b'data')
+        testfile.seek(0)
+        skip = frozenset([hdrs.CONTENT_TYPE])
+        req = ClientRequest(
+            'post', URL('http://python.org/'),
+            data=testfile,
+            skip_auto_headers=skip,
+            loop=loop)
+        assert req.headers.get('CONTENT-LENGTH', None) is not None
     yield from req.close()
 
 


### PR DESCRIPTION
Add missed yield from. As result got MemoryError in big files.
And maybe nessesary specify chunk size. I think in this case we read all data from file.
