### PR TITLE
Ensure TestClient HTTP methods return a context manager

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,10 @@ CHANGES
 
 - Enhancement to AccessLogger (pass *extra* dict) #1303
 
+- Ensure TestClient HTTP methods return a context manager #1318
+
+-
+
 -
 
 -

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -5,6 +5,7 @@ A. Jesse Jiryu Davis
 Alejandro Gómez
 Aleksandr Danshyn
 Aleksey Kutepov
+Alex Hayes
 Alexander Bayandin
 Alexander Karpinsky
 Alexander Koshevoy

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -13,6 +13,7 @@ from multidict import CIMultiDict
 from yarl import URL
 
 import aiohttp
+from aiohttp.client import _RequestContextManager
 
 from . import ClientSession, hdrs
 from .helpers import sentinel
@@ -214,31 +215,45 @@ class TestClient:
 
     def get(self, path, *args, **kwargs):
         """Perform an HTTP GET request."""
-        return self.request(hdrs.METH_GET, path, *args, **kwargs)
+        return _RequestContextManager(
+            self.request(hdrs.METH_GET, path, *args, **kwargs)
+        )
 
     def post(self, path, *args, **kwargs):
         """Perform an HTTP POST request."""
-        return self.request(hdrs.METH_POST, path, *args, **kwargs)
+        return _RequestContextManager(
+            self.request(hdrs.METH_POST, path, *args, **kwargs)
+        )
 
     def options(self, path, *args, **kwargs):
         """Perform an HTTP OPTIONS request."""
-        return self.request(hdrs.METH_OPTIONS, path, *args, **kwargs)
+        return _RequestContextManager(
+            self.request(hdrs.METH_OPTIONS, path, *args, **kwargs)
+        )
 
     def head(self, path, *args, **kwargs):
         """Perform an HTTP HEAD request."""
-        return self.request(hdrs.METH_HEAD, path, *args, **kwargs)
+        return _RequestContextManager(
+            self.request(hdrs.METH_HEAD, path, *args, **kwargs)
+        )
 
     def put(self, path, *args, **kwargs):
         """Perform an HTTP PUT request."""
-        return self.request(hdrs.METH_PUT, path, *args, **kwargs)
+        return _RequestContextManager(
+            self.request(hdrs.METH_PUT, path, *args, **kwargs)
+        )
 
     def patch(self, path, *args, **kwargs):
         """Perform an HTTP PATCH request."""
-        return self.request(hdrs.METH_PATCH, path, *args, **kwargs)
+        return _RequestContextManager(
+            self.request(hdrs.METH_PATCH, path, *args, **kwargs)
+        )
 
     def delete(self, path, *args, **kwargs):
         """Perform an HTTP PATCH request."""
-        return self.request(hdrs.METH_DELETE, path, *args, **kwargs)
+        return _RequestContextManager(
+            self.request(hdrs.METH_DELETE, path, *args, **kwargs)
+        )
 
     @asyncio.coroutine
     def ws_connect(self, path, *args, **kwargs):

--- a/tests/test_py35/test_test_utils_35.py
+++ b/tests/test_py35/test_test_utils_35.py
@@ -23,7 +23,13 @@ async def test_server_context_manager(app, loop):
                 assert resp.status == 200
 
 
-async def test_client_context_manager(app, loop):
+@pytest.mark.parametrize("method", [
+    "head", "get", "post", "options", "post", "put", "patch", "delete"
+])
+async def test_client_context_manager_response(method, app, loop):
     async with _TestClient(app) as client:
-        resp = await client.head('/')
-        assert resp.status == 200
+        async with getattr(client, method)('/') as resp:
+            assert resp.status == 200
+            if method != 'head':
+                text = await resp.text()
+                assert "OK" in text


### PR DESCRIPTION
## What do these changes do?

A user should be able to run a test as per the [client documentation](http://aiohttp.readthedocs.io/en/stable/client.html);

```python
async with aiohttp.ClientSession() as session:
    async with session.get('https://api.github.com/events') as resp:
        print(resp.status)
        print(await resp.text())
```

However, because the test client doesn't return a context manager the above does not work (unless of course I'm doing something wrong).

This PR ensures the HTTP methods on TestClient return a context manager so that it mimics the same interface as a non-test client

## Are there changes in behaviour for the user?

Yes, the TestClient will behave the same as the non-test client that their code will be using :)

Let's say or instance your code looked as follows;

```python
# client request code
async request_hello(session):
    async with session.get('...') as resp:
        ...
```

Note the use of the context manager: `async with session.get('...') as resp:`

And your test was;

```python
# pytest
from aiohttp import web

async def hello(request):
    return web.Response(text='Hello, world')

async def test_hello(test_client, loop):
    app = web.Application(loop=loop)
    app.router.add_get('/', hello)
    client = await test_client(app)
    resp = await request_hello(client)
    assert resp.status == 200
    ...
```

On master, this would fail, because TestClient does not return a context manager.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
- [x] Add a new entry to `CHANGES.rst` 