### PR TITLE
Show more verbose message on import errors

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -366,8 +366,8 @@ def main(argv):
         arg_parser.error("relative module names not supported")
     try:
         module = import_module(mod_str)
-    except ImportError:
-        arg_parser.error("module %r not found" % mod_str)
+    except ImportError as ex:
+        arg_parser.error("unable to import %s: %s" % (mod_str, ex))
     try:
         func = getattr(module, func_str)
     except AttributeError:

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -69,14 +69,15 @@ def test_entry_func_relative_module(mocker):
 def test_entry_func_non_existent_module(mocker):
     argv = ["alpha.beta:func"]
 
-    mocker.patch("aiohttp.web.import_module", side_effect=ImportError)
+    mocker.patch("aiohttp.web.import_module",
+                 side_effect=ImportError("Test Error"))
     error = mocker.patch("aiohttp.web.ArgumentParser.error",
                          side_effect=SystemExit)
 
     with pytest.raises(SystemExit):
         web.main(argv)
 
-    error.assert_called_with("module %r not found" % "alpha.beta")
+    error.assert_called_with('unable to import alpha.beta: Test Error')
 
 
 def test_entry_func_non_existent_attribute(mocker):


### PR DESCRIPTION
Show more verbose message on import errors when using `python -m aiohttp.web`

User will see more details in case of problems with their code.

For example message:

    aiohttp.web: error: unable to import defiler.server: No module named 'aiomysql'

is more useful then:

    aiohttp.web: error: module 'defiler.server' not found

such messages can be even misleading