### PR TITLE
Add a function to notify StreamReader when connection from ClientSession is closed.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,7 +45,8 @@ CHANGES
 
 - Ensure TestClient HTTP methods return a context manager #1318
 
--
+- Add a function to notify StreamReader when connection from
+  ClientSession is closed. #1323
 
 -
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,8 +45,8 @@ CHANGES
 
 - Ensure TestClient HTTP methods return a context manager #1318
 
-- Raise aiohttp.ClientDisconnectedError to StreamReader if ClientSession
-  object is closed by client when reading data. #1323
+- Raise `ClientDisconnectedError` to `StreamReader` read function if
+  `ClientSession` object is closed by client when reading data. #1323
 
 -
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,8 +45,8 @@ CHANGES
 
 - Ensure TestClient HTTP methods return a context manager #1318
 
-- Add a function to notify StreamReader when connection from
-  ClientSession is closed. #1323
+- Raise aiohttp.ClientDisconnectedError to StreamReader if ClientSession
+  object is closed by client when reading data. #1323
 
 -
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,8 +45,8 @@ CHANGES
 
 - Ensure TestClient HTTP methods return a context manager #1318
 
-- Raise `ClientDisconnectedError` to `StreamReader` read function if
-  `ClientSession` object is closed by client when reading data. #1323
+- Raise `ClientDisconnectedError` to `FlowControlStreamReader` read function
+  if `ClientSession` object is closed by client when reading data. #1323
 
 -
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -134,6 +134,7 @@ Vladimir Rutsky
 Vladimir Shulyak
 Vladimir Zakharov
 Willem de Groot
+Wilson Ong
 W. Trevor King
 Yannick Koechlin
 Young-Ho Cha

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -697,8 +697,9 @@ class ClientResponse:
         self._writer = None
 
     def _notify_content(self):
-        if self.content and self.content.exception() is None:
-            self.content.set_exception(
+        content = self.content
+        if content and content.exception() is None and not content.is_eof():
+            content.set_exception(
                 aiohttp.ClientDisconnectedError('Connection closed'))
 
     @asyncio.coroutine

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -697,7 +697,7 @@ class ClientResponse:
         self._writer = None
 
     def _notify_content(self):
-        if self.content.exception() is None:
+        if self.content and self.content.exception() is None:
             self.content.set_exception(
                 aiohttp.ClientDisconnectedError('Connection closed'))
 

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -71,6 +71,9 @@ Reading Methods
    If the EOF was received and the internal buffer is empty, return an
    empty bytes object.
 
+   Raise an :exc:`aiohttp.ClientDisconnectedError` if :class:`ClientSession`
+   object is closed when reading data.
+
    :return bytes: the given line
 
 Asynchronous Iteration Support

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -563,14 +563,12 @@ def test_iter_error_on_conn_close(loop, test_client):
         yield from resp_.prepare(request)
 
         # make sure connection is closed by client.
-        try:
+        with pytest.raises(aiohttp.ServerDisconnectedError):
             for _ in range(10):
                 resp_.write(b'data\n')
                 yield from resp_.drain()
                 yield from asyncio.sleep(0.5, loop=loop)
-        except aiohttp.ServerDisconnectedError:
-            yield from asyncio.sleep(2, loop=loop)
-        return resp_
+            return resp_
 
     app = web.Application(loop=loop)
     app.router.add_route('GET', '/', handler)
@@ -588,7 +586,7 @@ def test_iter_error_on_conn_close(loop, test_client):
                     break
                 assert data == b'data'
                 if not timer_started:
-                    loop.call_later(0.5, session.close)
+                    loop.call_later(1.0, resp.close)
                     timer_started = True
 
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -563,12 +563,14 @@ def test_iter_error_on_conn_close(loop, test_client):
         yield from resp_.prepare(request)
 
         # make sure connection is closed by client.
-        with pytest.raises(aiohttp.ServerDisconnectedError):
+        try:
             for _ in range(10):
                 resp_.write(b'data\n')
                 yield from resp_.drain()
                 yield from asyncio.sleep(0.5, loop=loop)
-            return resp_
+        except aiohttp.ServerDisconnectedError:
+            yield from asyncio.sleep(2, loop=loop)
+        return resp_
 
     app = web.Application(loop=loop)
     app.router.add_route('GET', '/', handler)

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -555,7 +555,7 @@ def test_timeout_on_reading_data(loop, test_client):
 
 
 @asyncio.coroutine
-def test_iter_error_on_conn_close(loop, test_client):
+def test_readline_error_on_conn_close(loop, test_client):
 
     @asyncio.coroutine
     def handler(request):
@@ -586,8 +586,61 @@ def test_iter_error_on_conn_close(loop, test_client):
                     break
                 assert data == b'data'
                 if not timer_started:
-                    loop.call_later(1.0, resp.close)
+                    def do_release():
+                        loop.create_task(resp.release())
+                    loop.call_later(1.0, do_release)
                     timer_started = True
+
+
+@asyncio.coroutine
+def test_no_error_on_conn_close_if_eof(loop, test_client):
+
+    @asyncio.coroutine
+    def handler(request):
+        resp_ = web.StreamResponse()
+        yield from resp_.prepare(request)
+        resp_.write(b'data\n')
+        yield from resp_.drain()
+        yield from asyncio.sleep(0.5, loop=loop)
+        return resp_
+
+    app = web.Application(loop=loop)
+    app.router.add_route('GET', '/', handler)
+    server = yield from test_client(app)
+
+    with aiohttp.ClientSession(loop=loop) as session:
+        url, headers = server.make_url('/'), {'Connection': 'Keep-alive'}
+        resp = yield from session.get(url, headers=headers)
+        while True:
+            data = yield from resp.content.readline()
+            data = data.strip()
+            if not data:
+                break
+            assert data == b'data'
+        yield from resp.release()
+        assert resp.content.exception() is None
+
+
+@asyncio.coroutine
+def test_error_not_overwrote_on_conn_close(loop, test_client):
+
+    @asyncio.coroutine
+    def handler(request):
+        resp_ = web.StreamResponse()
+        yield from resp_.prepare(request)
+        return resp_
+
+    app = web.Application(loop=loop)
+    app.router.add_route('GET', '/', handler)
+    server = yield from test_client(app)
+
+    with aiohttp.ClientSession(loop=loop) as session:
+        url, headers = server.make_url('/'), {'Connection': 'Keep-alive'}
+        resp = yield from session.get(url, headers=headers)
+        resp.content.set_exception(aiohttp.ClientRequestError())
+
+    yield from resp.release()
+    assert isinstance(resp.content.exception(), aiohttp.ClientRequestError)
 
 
 @asyncio.coroutine

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -584,7 +584,7 @@ def test_iter_error_on_conn_close(loop, test_client):
                 data = data.strip()
                 if not data:
                     break
-                assert data == 'data'
+                assert data == b'data'
                 if not timer_started:
                     loop.call_later(0.5, session.close)
                     timer_started = True

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -579,8 +579,12 @@ def test_iter_error_on_conn_close(loop, test_client):
         url, headers = server.make_url('/'), {'Connection': 'Keep-alive'}
         resp = yield from session.get(url, headers=headers)
         with pytest.raises(aiohttp.ClientDisconnectedError):
-            for data in resp.content:
-                assert data.strip() == 'data'
+            while True:
+                data = yield from resp.content.readline()
+                data = data.strip()
+                if not data:
+                    break
+                assert data == 'data'
                 if not timer_started:
                     loop.call_later(0.5, session.close)
                     timer_started = True

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -578,13 +578,12 @@ def test_iter_error_on_conn_close(loop, test_client):
         timer_started = False
         url, headers = server.make_url('/'), {'Connection': 'Keep-alive'}
         resp = yield from session.get(url, headers=headers)
-        with resp:
-            with pytest.raises(aiohttp.ClientDisconnectedError):
-                for data in resp.content:
-                    assert data.strip() == 'data'
-                    if not timer_started:
-                        loop.call_later(0.5, session.close)
-                        timer_started = True
+        with pytest.raises(aiohttp.ClientDisconnectedError):
+            for data in resp.content:
+                assert data.strip() == 'data'
+                if not timer_started:
+                    loop.call_later(0.5, session.close)
+                    timer_started = True
 
 
 @asyncio.coroutine

--- a/tests/test_py35/test_resp.py
+++ b/tests/test_py35/test_resp.py
@@ -96,30 +96,3 @@ async def test_iter_any(test_server, loop):
     with aiohttp.ClientSession(loop=loop) as session:
         async with await session.post(server.make_url('/'), data=data) as resp:
             assert resp.status == 200
-
-
-async def test_iter_error_on_conn_close(test_server, loop):
-
-    async def handler(request):
-        resp_ = web.StreamResponse()
-        await resp_.prepare(request)
-        for _ in range(3):
-            resp_.write(b'data\n')
-            await resp_.drain()
-            await asyncio.sleep(0.5, loop=loop)
-        return resp_
-
-    app = web.Application(loop=loop)
-    app.router.add_route('GET', '/', handler)
-    server = await test_server(app)
-
-    with aiohttp.ClientSession(loop=loop) as session:
-            timer_started = False
-            async with await session.get(
-                    server.make_url('/'),
-                    headers={'Connection': 'Keep-alive'}) as resp:
-                with pytest.raises(aiohttp.ClientDisconnectedError):
-                    async for _ in resp.content:
-                        if not timer_started:
-                            loop.call_later(0.5, session.close)
-                            timer_started = True


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Raise `ClientDisconnectedError('Connection closed')` to StreamReader iteration when connection is forced close programmatically.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Currently the iteration will stuck for a long time after connection is forced close. The iteration will raise a `ClientDisconnectedError` immediately after connection is forced close before EOF is read with this change.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#1310

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#isuue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
