### PR TITLE
Resolved #1299 - Allow StaticRoute to follow symlinks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,7 +47,7 @@ CHANGES
 
 - Added save and load functionality for `CookieJar` #1219
 
--
+- Added option on `StaticRoute` to follow symlinks #1299
 
 -
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -174,6 +174,7 @@ subprotocol
 subprotocols
 subtype
 Svetlov
+symlink
 symlinks
 syscall
 syscalls

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -174,6 +174,7 @@ subprotocol
 subprotocols
 subtype
 Svetlov
+symlinks
 syscall
 syscalls
 TCP

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -348,6 +348,11 @@ instead could be enabled with ``show_index`` parameter set to ``True``::
 
    app.router.add_static('/prefix', path_to_static_folder, show_index=True)
 
+When a symlink from the static directory is accessed, the server respondes to
+client with ``HTTP/404 Not Found`` by default. To allow the server to follow
+symlinks, parameter ``follow_symlinks`` should be set to ``True``::
+
+   app.router.add_static('/prefix', path_to_static_folder, follow_symlinks=True)
 
 Template Rendering
 ------------------

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -348,7 +348,7 @@ instead could be enabled with ``show_index`` parameter set to ``True``::
 
    app.router.add_static('/prefix', path_to_static_folder, show_index=True)
 
-When a symlink from the static directory is accessed, the server respondes to
+When a symlink from the static directory is accessed, the server responses to
 client with ``HTTP/404 Not Found`` by default. To allow the server to follow
 symlinks, parameter ``follow_symlinks`` should be set to ``True``::
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1464,7 +1464,8 @@ Router is any object that implements :class:`AbstractRouter` interface.
    .. method:: add_static(prefix, path, *, name=None, expect_handler=None, \
                           chunk_size=256*1024, \
                           response_factory=StreamResponse, \
-                          show_index=False)
+                          show_index=False, \
+                          follow_symlinks=False)
 
       Adds a router and a handler for returning static files.
 
@@ -1519,6 +1520,10 @@ Router is any object that implements :class:`AbstractRouter` interface.
       :param bool show_index: flag for allowing to show indexes of a directory,
                               by default it's not allowed and HTTP/403 will
                               be returned on directory access.
+
+      :param bool follow_symlinks: flag for allowing to follow symlinks from
+                              a directory, by default it's not allowed and
+                              HTTP/404 will be returned on access.
 
    :returns: new :class:`StaticRoute` instance.
 

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -79,10 +79,8 @@ def test_access_root_of_static_handler(tmp_dir_path, loop, test_client,
 @asyncio.coroutine
 def test_follow_symlink(tmp_dir_path, loop, test_client, data):
     """
-    Tests the access to a looped symlink, which could not be resolved.
+    Tests the access to a symlink, in static folder
     """
-    print('aaaaa', tmp_dir_path)
-
     my_dir_path = os.path.join(tmp_dir_path, 'my_dir')
     os.mkdir(my_dir_path)
 

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -75,6 +75,38 @@ def test_access_root_of_static_handler(tmp_dir_path, loop, test_client,
     yield from r.release()
 
 
+@pytest.mark.parametrize('data', ['hello world'])
+@asyncio.coroutine
+def test_follow_symlink(tmp_dir_path, loop, test_client, data):
+    """
+    Tests the access to a looped symlink, which could not be resolved.
+    """
+    print('aaaaa', tmp_dir_path)
+
+    my_dir_path = os.path.join(tmp_dir_path, 'my_dir')
+    os.mkdir(my_dir_path)
+
+    my_file_path = os.path.join(my_dir_path, 'my_file_in_dir')
+    with open(my_file_path, 'w') as fw:
+        fw.write(data)
+
+    my_symlink_path = os.path.join(tmp_dir_path, 'my_symlink')
+    os.symlink(my_dir_path, my_symlink_path)
+
+    app = web.Application(loop=loop)
+
+    # Register global static route:
+    app.router.add_static('/', tmp_dir_path, follow_symlinks=True)
+    client = yield from test_client(app)
+
+    # Request the root of the static directory.
+    r = yield from client.get('/my_symlink/my_file_in_dir')
+    assert r.status == 200
+    assert (yield from r.text()) == data
+
+    yield from r.release()
+
+
 @pytest.mark.parametrize('dir_name,filename,data', [
     ('', 'test file.txt', 'test text'),
     ('test dir name', 'test dir file .txt', 'test text file folder')


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?
Added option on StaticRoute to follow symlinks. Example:
```
app.router.add_static('/static', path_to_static_dir, follow_symlinks=True)
```

## Are there changes in behavior for the user?
No

## Related issue number
#1299 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
