### PR TITLE
Fix invalid invocations of errors.LineTooLong.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,7 @@ CHANGES
 
 - Added option on `StaticRoute` to follow symlinks #1299
 
--
+- Fix invalid invocations of errors.LineTooLong #1335
 
 -
 

--- a/aiohttp/errors.py
+++ b/aiohttp/errors.py
@@ -134,7 +134,7 @@ class LineTooLong(BadHttpMessage):
 
     def __init__(self, line, limit='Unknown'):
         super().__init__(
-            "got more than %s bytes when reading %s" % (limit, line))
+            "Got more than %s bytes when reading %s." % (limit, line))
 
 
 class InvalidHeader(BadHttpMessage):

--- a/aiohttp/protocol.py
+++ b/aiohttp/protocol.py
@@ -102,7 +102,9 @@ class HttpParser:
                     header_length += len(line)
                     if header_length > self.max_field_size:
                         raise errors.LineTooLong(
-                            'limit request headers fields size')
+                            'request header field {}'.format(
+                                bname.decode("utf8", "xmlcharrefreplace")),
+                            self.max_field_size)
                     bvalue.append(line)
 
                     # next line
@@ -113,7 +115,9 @@ class HttpParser:
             else:
                 if header_length > self.max_field_size:
                     raise errors.LineTooLong(
-                        'limit request headers fields size')
+                        'request header field {}'.format(
+                            bname.decode("utf8", "xmlcharrefreplace")),
+                        self.max_field_size)
 
             bvalue = bvalue.strip()
 
@@ -173,7 +177,7 @@ class HttpRequestParser(HttpParser):
             raw_data = yield from buf.readuntil(
                 b'\r\n\r\n', self.max_headers)
         except errors.LineLimitExceededParserError as exc:
-            raise errors.LineTooLong(exc.limit) from None
+            raise errors.LineTooLong('request header', exc.limit) from None
 
         lines = raw_data.split(b'\r\n')
 
@@ -227,7 +231,7 @@ class HttpResponseParser(HttpParser):
             raw_data = yield from buf.readuntil(
                 b'\r\n\r\n', self.max_line_size + self.max_headers)
         except errors.LineLimitExceededParserError as exc:
-            raise errors.LineTooLong(exc.limit) from None
+            raise errors.LineTooLong('response header', exc.limit) from None
 
         lines = raw_data.split(b'\r\n')
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -84,14 +84,21 @@ class TestParseHeaders(unittest.TestCase):
             parser = protocol.HttpParser(8190, 32768, 5)
             parser.parse_headers(
                 [b'', b'test: line data data\r\n', b'data\r\n', b'\r\n'])
-        self.assertIn("limit request headers fields size", str(cm.exception))
+        self.assertIn("request header field TEST", str(cm.exception))
 
     def test_max_continuation_headers_size(self):
         with self.assertRaises(errors.LineTooLong) as cm:
             parser = protocol.HttpParser(8190, 32768, 5)
             parser.parse_headers([b'', b'test: line\r\n',
                                   b' test\r\n', b'\r\n'])
-        self.assertIn("limit request headers fields size", str(cm.exception))
+        self.assertIn("request header field TEST", str(cm.exception))
+
+    def test_max_header_size(self):
+        with self.assertRaises(errors.LineTooLong) as cm:
+            parser = protocol.HttpParser(5, 5, 5)
+            parser.parse_headers(
+                [b'', b'test: line data data\r\n', b'data\r\n', b'\r\n'])
+        self.assertIn("request header", str(cm.exception))
 
     def test_invalid_header(self):
         with self.assertRaisesRegex(


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->
## What do these changes do?

Fix unhelpful messages on `LineTooLong` exceptions due to invalid or incomplete calls to their constructor.

<!-- Please give a short brief about these changes. -->
## Are there changes in behavior for the user?

Only in the message that they see in this case.

<!-- Outline any notable behaviour for the end users. -->
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
## Checklist
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  - The format is &lt;Name&gt; &lt;Surname&gt;.
  - Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  - Choose any open position to avoid merge conflicts with other PRs.
  - Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
