### PR TITLE
Update the docs for web_reqrep.Request.post

### DIFF
--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -291,7 +291,7 @@ like one using :meth:`Request.copy`.
       Returns :class:`~multidict.MultiDictProxy` instance filled
       with parsed data.
 
-      If :attr:`method` is not *POST*, *PUT* or *PATCH* or
+      If :attr:`method` is not *POST*, *PUT*, *PATCH*, *TRACE* or *DELETE* or
       :attr:`content_type` is not empty or
       *application/x-www-form-urlencoded* or *multipart/form-data*
       returns empty multidict.


### PR DESCRIPTION
## What do these changes do?

Fix the documentation for `web_reqrep.Request.post`: the supported HTTP methods list was missing TRACE and DELETE, which are supported by the code.
