### PR TITLE
Fixed JSON response character set detection.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -76,6 +76,7 @@ Julien Duponchelle
 Junjie Tao
 Justas Trimailovas
 Kay Zheng
+Kimmo Parviainen-Jalanko
 Kirill Klenov
 Kirill Malovitsa
 Kyrylo Perevozchikov

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -728,7 +728,11 @@ class ClientResponse:
 
         encoding = params.get('charset')
         if not encoding:
-            encoding = chardet.detect(self._content)['encoding']
+            if mtype == 'application' and stype == 'json':
+                # RFC 7159 states that the default encoding is UTF-8.
+                encoding = 'utf-8'
+            else:
+                encoding = chardet.detect(self._content)['encoding']
         if not encoding:
             encoding = 'utf-8'
 

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -171,7 +171,7 @@ def test_text_detect_encoding(loop):
         fut.set_result('{"тест": "пройден"}'.encode('cp1251'))
         return fut
 
-    response.headers = {'Content-Type': 'application/json'}
+    response.headers = {'Content-Type': 'text/plain'}
     content = response.content = mock.Mock()
     content.read.side_effect = side_effect
 
@@ -273,25 +273,6 @@ def test_json_override_encoding(loop):
     assert res == {'тест': 'пройден'}
     assert response._connection is None
     assert not response._get_encoding.called
-
-
-@asyncio.coroutine
-def test_json_detect_encoding(loop):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop)
-
-    def side_effect(*args, **kwargs):
-        fut = helpers.create_future(loop)
-        fut.set_result('{"тест": "пройден"}'.encode('cp1251'))
-        return fut
-
-    response.headers = {'Content-Type': 'application/json'}
-    content = response.content = mock.Mock()
-    content.read.side_effect = side_effect
-
-    res = yield from response.json()
-    assert res == {'тест': 'пройден'}
-    assert response._connection is None
 
 
 def test_override_flow_control(loop):


### PR DESCRIPTION
## What do these changes do?

This disables running chardet on responses with `CONTENT_TYPE: application/json` as this is a HUGE performance hit.

RFC 7519 states that JSON *MUST* be encoded in UTF and that
the default encoding, in absence of charset in CONTENT_TYPE header is UTF-8.

This vastly improves performance when doing many small requests in environments
where the server does not specify the character by omitting chardet.

## Are there changes in behavior for the user?

This does not change the behaviour unless a non-conforming server sends a HTTP response using an invalid encoding without specifying the encoding correctly in the header.
## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
