### PR TITLE
Get rid of aiodns gethostbyname()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,7 +90,7 @@ CHANGES
 
 - Boost performance by adding a custom time service #1350
 
--
+- Get rid of usage aiodns gethostbyname() #559
 
 -
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -105,6 +105,7 @@ Olaf Conradi
 Pankaj Pandey
 Pau Freixes
 Paul Colomiets
+Pavel Sapezhko
 Philipp A.
 Raúl Cumplido
 "Required Field" <requiredfield256@gmail.com>

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -56,15 +56,22 @@ class AsyncResolver(AbstractResolver):
 
     @asyncio.coroutine
     def resolve(self, host, port=0, family=socket.AF_INET):
-        hosts_v4 = []
-        hosts_v6 = []
+        hosts_v4 = hosts_v6 = None
         if family in [socket.AF_INET, socket.AF_UNSPEC]:
-            hosts_v4 = yield from \
-                self.resolve_with_query(host, port, socket.AF_INET)
+            try:
+                hosts_v4 = yield from \
+                    self.resolve_with_query(host, port, socket.AF_INET)
+            except aiodns.error.DNSError:
+                if family == socket.AF_INET:
+                    raise
         if family in [socket.AF_INET6, socket.AF_UNSPEC]:
-            hosts_v6 = yield from \
-                self.resolve_with_query(host, port, socket.AF_INET6)
-        return hosts_v4 + hosts_v6
+            try:
+                hosts_v6 = yield from \
+                    self.resolve_with_query(host, port, socket.AF_INET6)
+            except aiodns.error.DNSError:
+                if family == socket.AF_INET6 or not hosts_v4:
+                    raise
+        return (hosts_v4 or []) + (hosts_v6 or [])
 
     @asyncio.coroutine
     def resolve_with_query(self, host, port=0, family=socket.AF_INET):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,7 +1,7 @@
 import asyncio
 import ipaddress
 import socket
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
@@ -9,10 +9,8 @@ from aiohttp.resolver import AsyncResolver, DefaultResolver, ThreadedResolver
 
 try:
     import aiodns
-    gethostbyname = hasattr(aiodns.DNSResolver, 'gethostbyname')
 except ImportError:
     aiodns = None
-    gethostbyname = False
 
 
 class FakeResult:
@@ -48,23 +46,10 @@ def fake_addrinfo(hosts):
     return fake
 
 
-@pytest.mark.skipif(not gethostbyname, reason="aiodns 1.1 required")
 @asyncio.coroutine
+@pytest.mark.skipif(aiodns is None, reason="aiodns required")
 def test_async_resolver_positive_lookup(loop):
     with patch('aiodns.DNSResolver') as mock:
-        mock().gethostbyname.return_value = fake_result(['127.0.0.1'])
-        resolver = AsyncResolver(loop=loop)
-        real = yield from resolver.resolve('www.python.org')
-        ipaddress.ip_address(real[0]['host'])
-        mock().gethostbyname.assert_called_with('www.python.org',
-                                                socket.AF_INET)
-
-
-@pytest.mark.skipif(aiodns is None, reason="aiodns required")
-@asyncio.coroutine
-def test_async_resolver_query_positive_lookup(loop):
-    with patch('aiodns.DNSResolver') as mock:
-        del mock().gethostbyname
         mock().query.return_value = fake_query_result(['127.0.0.1'])
         resolver = AsyncResolver(loop=loop)
         real = yield from resolver.resolve('www.python.org')
@@ -72,12 +57,12 @@ def test_async_resolver_query_positive_lookup(loop):
         mock().query.assert_called_with('www.python.org', 'A')
 
 
-@pytest.mark.skipif(not gethostbyname, reason="aiodns 1.1 required")
+@pytest.mark.skipif(aiodns is None, reason="aiodns required")
 @asyncio.coroutine
 def test_async_resolver_multiple_replies(loop):
     with patch('aiodns.DNSResolver') as mock:
         ips = ['127.0.0.1', '127.0.0.2', '127.0.0.3', '127.0.0.4']
-        mock().gethostbyname.return_value = fake_result(ips)
+        mock().query.return_value = fake_query_result(ips)
         resolver = AsyncResolver(loop=loop)
         real = yield from resolver.resolve('www.google.com')
         ips = [ipaddress.ip_address(x['host']) for x in real]
@@ -86,31 +71,8 @@ def test_async_resolver_multiple_replies(loop):
 
 @pytest.mark.skipif(aiodns is None, reason="aiodns required")
 @asyncio.coroutine
-def test_async_resolver_query_multiple_replies(loop):
-    with patch('aiodns.DNSResolver') as mock:
-        del mock().gethostbyname
-        ips = ['127.0.0.1', '127.0.0.2', '127.0.0.3', '127.0.0.4']
-        mock().query.return_value = fake_query_result(ips)
-        resolver = AsyncResolver(loop=loop)
-        real = yield from resolver.resolve('www.google.com')
-        ips = [ipaddress.ip_address(x['host']) for x in real]
-
-
-@pytest.mark.skipif(not gethostbyname, reason="aiodns 1.1 required")
-@asyncio.coroutine
 def test_async_resolver_negative_lookup(loop):
     with patch('aiodns.DNSResolver') as mock:
-        mock().gethostbyname.side_effect = aiodns.error.DNSError()
-        resolver = AsyncResolver(loop=loop)
-        with pytest.raises(aiodns.error.DNSError):
-            yield from resolver.resolve('doesnotexist.bla')
-
-
-@pytest.mark.skipif(aiodns is None, reason="aiodns required")
-@asyncio.coroutine
-def test_async_resolver_query_negative_lookup(loop):
-    with patch('aiodns.DNSResolver') as mock:
-        del mock().gethostbyname
         mock().query.side_effect = aiodns.error.DNSError()
         resolver = AsyncResolver(loop=loop)
         with pytest.raises(aiodns.error.DNSError):
@@ -170,30 +132,30 @@ def test_default_loop_for_async_resolver(loop):
     assert resolver._loop is loop
 
 
-@pytest.mark.skipif(not gethostbyname, reason="aiodns 1.1 required")
+@pytest.mark.skipif(aiodns is None, reason="aiodns required")
 @asyncio.coroutine
 def test_async_resolver_ipv6_positive_lookup(loop):
     with patch('aiodns.DNSResolver') as mock:
-        mock().gethostbyname.return_value = fake_result(['::1'])
-        resolver = AsyncResolver(loop=loop)
-        real = yield from resolver.resolve('www.python.org',
-                                           family=socket.AF_INET6)
-        ipaddress.ip_address(real[0]['host'])
-        mock().gethostbyname.assert_called_with('www.python.org',
-                                                socket.AF_INET6)
-
-
-@pytest.mark.skipif(aiodns is None, reason="aiodns required")
-@asyncio.coroutine
-def test_async_resolver_query_ipv6_positive_lookup(loop):
-    with patch('aiodns.DNSResolver') as mock:
-        del mock().gethostbyname
         mock().query.return_value = fake_query_result(['::1'])
         resolver = AsyncResolver(loop=loop)
         real = yield from resolver.resolve('www.python.org',
                                            family=socket.AF_INET6)
         ipaddress.ip_address(real[0]['host'])
         mock().query.assert_called_with('www.python.org', 'AAAA')
+
+
+@pytest.mark.skipif(aiodns is None, reason="aiodns required")
+@asyncio.coroutine
+def test_async_resolver_family_unspec_positive_lookup(loop):
+    with patch('aiodns.DNSResolver') as mock:
+        mock().query.return_value = fake_query_result(['127.0.0.1', '::1'])
+        resolver = AsyncResolver(loop=loop)
+        real = yield from resolver.resolve('www.python.org',
+                                           family=socket.AF_UNSPEC)
+        ipaddress.ip_address(real[0]['host'])
+        ipaddress.ip_address(real[1]['host'])
+        calls = [call('www.python.org', 'A'), call('www.python.org', 'AAAA')]
+        mock().query.assert_has_calls(calls, any_order=True)
 
 
 def test_async_resolver_aiodns_not_present(loop, monkeypatch):
@@ -203,7 +165,7 @@ def test_async_resolver_aiodns_not_present(loop, monkeypatch):
 
 
 def test_default_resolver():
-    if gethostbyname:
+    if aiodns:
         assert DefaultResolver is AsyncResolver
     else:
         assert DefaultResolver is ThreadedResolver

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -13,19 +13,9 @@ except ImportError:
     aiodns = None
 
 
-class FakeResult:
-    def __init__(self, addresses):
-        self.addresses = addresses
-
-
 class FakeQueryResult:
     def __init__(self, host):
         self.host = host
-
-
-@asyncio.coroutine
-def fake_result(addresses):
-    return FakeResult(addresses=tuple(addresses))
 
 
 @asyncio.coroutine


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->
## What do these changes do?

By default aiodns function gethostbyname() (which is actually just a wrapper around c-ares function) resolve host as IPv6 address if socket family set to AF_UNSPEC(default value for TCPConnector). On the other hand ThreadedResolver use asyncio loop function getaddrinfo() which, in accordance with POSIX return both(either IPv4 and IPv6) if socket family set to AF_UNSPEC. So we have unconsistent behavior of ThreadedResolver and AsyncResolver. But c-ares lib doesn't have getaddrinfo() function, so we can't use it in aiohttp resolver. So if I use IPv4 the following simple code does not work for me(if aiodns installed of cause):

``` python
 async with aiohttp.ClientSession() as session:
        async with session.get('http://google.com') as resp:
            body = await resp.read()
            print('Done(google.com). status: {}, body len: {}'.format(resp.status, len(body)))
```

To solve this problem in method resolve() of AsyncResolver I query both types if family set to AF_UNSPEC.
## Are there changes in behavior for the user?

No
## Related issue number
# 559
## Checklist
- [ X] I think the code is well written
- [ X] Unit tests for the changes exist
- [ X] Documentation reflects the changes
- [ X] Add yourself to `CONTRIBUTORS.txt`
  - The format is &lt;Name&gt; &lt;Surname&gt;.
  - Please keep alphabetical order, the file is sorted by names. 
- [ X] Add a new entry to `CHANGES.rst`
  - Choose any open position to avoid merge conflicts with other PRs.
  - Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
