### PR TITLE
Add 'content_type' & 'charset' properties to aiohttp.ClientResponse

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,7 +90,8 @@ CHANGES
 
 - Boost performance by adding a custom time service #1350
 
--
+- Extend `ClientResponse` with `content_type` and `charset`
+  properties like in `web.Request`. #1349
 
 -
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -41,6 +41,7 @@ Daniel García
 Daniel Nelson
 Danny Song
 David Michael Brown
+Denis Matiychuk
 Dima Veselov
 Dimitar Dimitrov
 Dmitry Shamov

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -14,7 +14,7 @@ from yarl import URL
 import aiohttp
 
 from . import hdrs, helpers, streams
-from .helpers import Timeout
+from .helpers import HeadersMixin, Timeout
 from .log import client_logger
 from .multipart import MultipartWriter
 from .protocol import HttpMessage
@@ -488,7 +488,7 @@ class ClientRequest:
             self._writer = None
 
 
-class ClientResponse:
+class ClientResponse(HeadersMixin):
 
     # from the Status-Line of the response
     version = None  # HTTP-Version
@@ -582,28 +582,6 @@ class ClientResponse:
     def history(self):
         """A sequence of of responses, if redirects occurred."""
         return self._history
-
-    @property
-    def content_type(self):
-        """The value of content part for Content-Type HTTP header."""
-        ctype = self.headers.get(hdrs.CONTENT_TYPE, None)
-        if ctype is None:
-            # no Content-Type header
-            return None
-        mtype, stype, _, _ = helpers.parse_mimetype(ctype.lower())
-        _content_type = '{mtype}/{stype}'.format(mtype=mtype, stype=stype)
-        return _content_type
-
-    @property
-    def charset(self):
-        """The value of charset part for Content-Type HTTP header."""
-        ctype = self.headers.get(hdrs.CONTENT_TYPE, None)
-        if ctype is None:
-            # no Content-Type header
-            return None
-        _, _, _, params = helpers.parse_mimetype(ctype.lower())
-        _charset = params.get('charset')
-        return _charset
 
     def waiting_for_continue(self):
         return self._continue is not None

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -580,8 +580,30 @@ class ClientResponse:
 
     @property
     def history(self):
-        """A sequence of of responses, if redirects occured."""
+        """A sequence of of responses, if redirects occurred."""
         return self._history
+
+    @property
+    def content_type(self):
+        """The value of content part for Content-Type HTTP header."""
+        ctype = self.headers.get(hdrs.CONTENT_TYPE, None)
+        if ctype is None:
+            # no Content-Type header
+            return None
+        mtype, stype, _, _ = helpers.parse_mimetype(ctype.lower())
+        _content_type = '{mtype}/{stype}'.format(mtype=mtype, stype=stype)
+        return _content_type
+
+    @property
+    def charset(self):
+        """The value of charset part for Content-Type HTTP header."""
+        ctype = self.headers.get(hdrs.CONTENT_TYPE, None)
+        if ctype is None:
+            # no Content-Type header
+            return None
+        _, _, _, params = helpers.parse_mimetype(ctype.lower())
+        _charset = params.get('charset')
+        return _charset
 
     def waiting_for_continue(self):
         return self._continue is not None

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import binascii
+import cgi
 import datetime
 import functools
 import io
@@ -620,3 +621,44 @@ class TimeService:
         if s is None:
             self._strtime = s = self._format_date_time()
         return self._strtime
+
+
+class HeadersMixin:
+
+    _content_type = None
+    _content_dict = None
+    _stored_content_type = sentinel
+
+    def _parse_content_type(self, raw):
+        self._stored_content_type = raw
+        if raw is None:
+            # default value according to RFC 2616
+            self._content_type = 'application/octet-stream'
+            self._content_dict = {}
+        else:
+            self._content_type, self._content_dict = cgi.parse_header(raw)
+
+    @property
+    def content_type(self, _CONTENT_TYPE=hdrs.CONTENT_TYPE):
+        """The value of content part for Content-Type HTTP header."""
+        raw = self.headers.get(_CONTENT_TYPE)
+        if self._stored_content_type != raw:
+            self._parse_content_type(raw)
+        return self._content_type
+
+    @property
+    def charset(self, _CONTENT_TYPE=hdrs.CONTENT_TYPE):
+        """The value of charset part for Content-Type HTTP header."""
+        raw = self.headers.get(_CONTENT_TYPE)
+        if self._stored_content_type != raw:
+            self._parse_content_type(raw)
+        return self._content_dict.get('charset')
+
+    @property
+    def content_length(self, _CONTENT_LENGTH=hdrs.CONTENT_LENGTH):
+        """The value of Content-Length HTTP header."""
+        l = self.headers.get(_CONTENT_LENGTH)
+        if l is None:
+            return None
+        else:
+            return int(l)

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -17,9 +17,9 @@ from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
 
 from . import hdrs, multipart
-from .helpers import reify, sentinel, HeadersMixin
-from .protocol import HttpVersion10, HttpVersion11
+from .helpers import HeadersMixin, reify, sentinel
 from .protocol import WebResponse as ResponseImpl
+from .protocol import HttpVersion10, HttpVersion11
 from .streams import EOF_MARKER
 
 __all__ = (

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -17,56 +17,15 @@ from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
 
 from . import hdrs, multipart
-from .helpers import reify, sentinel
-from .protocol import WebResponse as ResponseImpl
+from .helpers import reify, sentinel, HeadersMixin
 from .protocol import HttpVersion10, HttpVersion11
+from .protocol import WebResponse as ResponseImpl
 from .streams import EOF_MARKER
 
 __all__ = (
     'ContentCoding', 'Request', 'StreamResponse', 'Response',
     'json_response'
 )
-
-
-class HeadersMixin:
-
-    _content_type = None
-    _content_dict = None
-    _stored_content_type = sentinel
-
-    def _parse_content_type(self, raw):
-        self._stored_content_type = raw
-        if raw is None:
-            # default value according to RFC 2616
-            self._content_type = 'application/octet-stream'
-            self._content_dict = {}
-        else:
-            self._content_type, self._content_dict = cgi.parse_header(raw)
-
-    @property
-    def content_type(self, _CONTENT_TYPE=hdrs.CONTENT_TYPE):
-        """The value of content part for Content-Type HTTP header."""
-        raw = self.headers.get(_CONTENT_TYPE)
-        if self._stored_content_type != raw:
-            self._parse_content_type(raw)
-        return self._content_type
-
-    @property
-    def charset(self, _CONTENT_TYPE=hdrs.CONTENT_TYPE):
-        """The value of charset part for Content-Type HTTP header."""
-        raw = self.headers.get(_CONTENT_TYPE)
-        if self._stored_content_type != raw:
-            self._parse_content_type(raw)
-        return self._content_dict.get('charset')
-
-    @property
-    def content_length(self, _CONTENT_LENGTH=hdrs.CONTENT_LENGTH):
-        """The value of Content-Length HTTP header."""
-        l = self.headers.get(_CONTENT_LENGTH)
-        if l is None:
-            return None
-        else:
-            return int(l)
 
 FileField = collections.namedtuple('Field', 'name filename file content_type')
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1237,6 +1237,22 @@ Response object
       HTTP headers of response as unconverted bytes, a sequence of
       ``(key, value)`` pairs.
 
+   .. attribute:: content_type
+
+      Read-only property with *content* part of *Content-Type* header.
+
+      Returns :class:`str` like ``'text/html'`` or ``None`` if no
+      *Content-Type* header present in HTTP headers.
+
+   .. attribute:: charset
+
+      Read-only property that specifies the *encoding* for the request's BODY.
+
+      The value is parsed from the *Content-Type* HTTP header.
+
+      Returns :class:`str` like ``'utf-8'`` or ``None`` if no *Content-Type*
+      header present in HTTP headers or it has no charset information.
+
    .. attribute:: history
 
       A :class:`~collections.abc.Sequence` of :class:`ClientResponse`

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1241,8 +1241,13 @@ Response object
 
       Read-only property with *content* part of *Content-Type* header.
 
-      Returns :class:`str` like ``'text/html'`` or ``None`` if no
-      *Content-Type* header present in HTTP headers.
+      .. note::
+
+         Returns value is ``'application/octet-stream'`` if no
+         Content-Type header present in HTTP headers according to
+         :rfc:`2616`. To make sure Content-Type header is not present in
+         the server reply, use :attr:`headers` or :attr:`raw_headers`, e.g.
+         ``'CONTENT-TYPE' not in resp.headers``.
 
    .. attribute:: charset
 

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -329,7 +329,7 @@ def test_content_type_no_header():
     response = ClientResponse('get', URL('http://def-cl-resp.org'))
     response.headers = {}
 
-    assert response.content_type is None
+    assert 'application/octet-stream' == response.content_type
 
 
 def test_charset():

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -316,3 +316,38 @@ def test_resp_host():
     response = ClientResponse('get', URL('http://del-cl-resp.org'))
     with pytest.warns(DeprecationWarning):
         assert 'del-cl-resp.org' == response.host
+
+
+def test_content_type():
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response.headers = {'Content-Type': 'application/json;charset=cp1251'}
+
+    assert 'application/json' == response.content_type
+
+
+def test_content_type_no_header():
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response.headers = {}
+
+    assert response.content_type is None
+
+
+def test_charset():
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response.headers = {'Content-Type': 'application/json;charset=cp1251'}
+
+    assert 'cp1251' == response.charset
+
+
+def test_charset_no_header():
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response.headers = {}
+
+    assert response.charset is None
+
+
+def test_charset_no_charset():
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response.headers = {'Content-Type': 'application/json'}
+
+    assert response.charset is None


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->
## What do these changes do?

Extends `aiohttp.ClientResponse` with `content_type` and `charset` properties like in `aiohttp.web.Request`.
## Are there changes in behavior for the user?

Backwards compatible, nothing old was changed, added two new properties.
## Related issue number
# 1349
## Checklist
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  - The format is &lt;Name&gt; &lt;Surname&gt;.
  - Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  - Choose any open position to avoid merge conflicts with other PRs.
  - Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
