### PR TITLE
fix usage of proxy with https (#845)

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -104,6 +104,8 @@ class ClientRequest:
         self.update_transfer_encoding()
         self.update_expect_continue(expect100)
 
+        self.path = None
+
     @property
     def host(self):
         return self.url.host
@@ -432,7 +434,7 @@ class ClientRequest:
         self._writer = None
 
     def send(self, writer, reader):
-        path = self.url.raw_path
+        path = self.path or self.url.raw_path
         if self.url.raw_query_string:
             path += '?' + self.url.raw_query_string
         request = aiohttp.Request(writer, self.method, path,


### PR DESCRIPTION
Fixes #845, a regression introduced in [e81a47](https://github.com/KeepSafe/aiohttp/commit/e81a4781d80b614da572c2c18635831ad024126b#diff-2fa8ab44317df4fbb7864536a6794d7aL491). I feel this is not the best way to fix this, but it at least points out where the issue is. Perhaps someone more familiar with the code base could rewrite the patch. I'm also not sure how to write a regression test for this, but would be happy to do so if pointed in the right direction.