### PR TITLE
gunicorn worker should use `create_unix_server` for AF_UNIX sockets.

### DIFF
--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import re
 import signal
+import socket
 import ssl
 import sys
 
@@ -88,8 +89,13 @@ class GunicornWebWorker(base.Worker):
 
         for sock in self.sockets:
             handler = self.make_handler(self.wsgi)
-            srv = yield from self.loop.create_server(handler, sock=sock.sock,
-                                                     ssl=ctx)
+
+            if hasattr(socket, 'AF_UNIX') and sock.family == socket.AF_UNIX:
+                srv = yield from self.loop.create_unix_server(
+                    handler, sock=sock.sock, ssl=ctx)
+            else:
+                srv = yield from self.loop.create_server(
+                    handler, sock=sock.sock, ssl=ctx)
             self.servers[srv] = handler
 
         # If our parent changed then we shut down.


### PR DESCRIPTION
## What do these changes do?

Use `loop.create_unix_server` for `AF_UNIX` sockets. Right now it works only accidentally. Unix sockets are sufficiently different from TCP sockets, and we should use the correct APIs for them.

## Are there changes in behavior for the user?

No.

## Related issue number

uvloop raises an exception when gunicorn is configured to use a UNIX socket: https://github.com/MagicStack/uvloop/issues/59