### PR TITLE
add pyhton 3.6, 3.7 tests with allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,18 @@ language: python
 python:
   - 3.4
   - 3.5
-#   - 3.6-dev   # for 3.6 beta
-#   - nightly
+  - '3.6-dev'
+  - 'nightly'
 
 os:
   - linux
-#  - osx
+  - osx
+
+matrix:
+  allow_failures:
+    - python: '3.6-dev'
+    - python: 'nightly'
+    - os: osx
 
 cache:
   directories:


### PR DESCRIPTION
(first of all submitting PR to run tests)

## What do these changes do?

add tests (with `allow_failures`) for:
  - '3.6-dev'
  - 'nightly'
  - osx

## Are there changes in behavior for the user?

none

## Related issue number

#1372 (kind of)

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.

