### PR TITLE
allow starting variables with an underscore

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -694,12 +694,12 @@ class RoutesView(Sized, Iterable, Container):
 
 class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
 
-    DYN = re.compile(r'\{(?P<var>[a-zA-Z][_a-zA-Z0-9]*)\}')
+    DYN = re.compile(r'\{(?P<var>[_a-zA-Z][_a-zA-Z0-9]*)\}')
     DYN_WITH_RE = re.compile(
-        r'\{(?P<var>[a-zA-Z][_a-zA-Z0-9]*):(?P<re>.+)\}')
+        r'\{(?P<var>[_a-zA-Z][_a-zA-Z0-9]*):(?P<re>.+)\}')
     GOOD = r'[^{}/]+'
     ROUTE_RE = re.compile(r'(\{[_a-zA-Z][^{}]*(?:\{[^{}]*\}[^{}]*)*\})')
-    NAME_SPLIT_RE = re.compile('[.:-]')
+    NAME_SPLIT_RE = re.compile(r'[.:-]')
 
     def __init__(self, app):
         super().__init__()


### PR DESCRIPTION
This allows the named resources identifiers to start with an underscore

Mongo ids are useful as a named resource in a route, but they are usually named `_id` and are excluded by the current regex


If this isn't an acceptable change, then the documentation should imo be updated to specify what is an acceptable route identifier (`[a-zA-Z][_a-zA-Z0-9]*` currently)