### PR TITLE
ClientSession.request() shouldn't duplicate the param defaults from _request()

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -92,45 +92,9 @@ class ClientSession:
                 context['source_traceback'] = self._source_traceback
             self._loop.call_exception_handler(context)
 
-    def request(self, method, url, *,
-                params=None,
-                data=None,
-                headers=None,
-                skip_auto_headers=None,
-                auth=None,
-                allow_redirects=True,
-                max_redirects=10,
-                encoding='utf-8',
-                version=None,
-                compress=None,
-                chunked=None,
-                expect100=False,
-                read_until_eof=True,
-                proxy=None,
-                proxy_auth=None,
-                timeout=5*60):
+    def request(self, method, url, **kwargs):
         """Perform HTTP request."""
-
-        return _RequestContextManager(
-            self._request(
-                method,
-                url,
-                params=params,
-                data=data,
-                headers=headers,
-                skip_auto_headers=skip_auto_headers,
-                auth=auth,
-                allow_redirects=allow_redirects,
-                max_redirects=max_redirects,
-                encoding=encoding,
-                version=version,
-                compress=compress,
-                chunked=chunked,
-                expect100=expect100,
-                read_until_eof=read_until_eof,
-                proxy=proxy,
-                proxy_auth=proxy_auth,
-                timeout=timeout))
+        return _RequestContextManager(self._request(method, url, **kwargs))
 
     @asyncio.coroutine
     def _request(self, method, url, *,


### PR DESCRIPTION
Most of the request methods on `ClientSession` (`get()`, `post()`, etc), have pretty generic "**kwargs" signatures and wrap `self._request()`. `_request()` itself contains sensible defaults, and provides one convenient method to override in a subclass if one would like to change those defaults.

`ClientSession.request()` (no underscore), is an exception, though, and duplicates all of those defaults. As a result, if one wants to make their requests via `request()` (I have my reasons) overriding `_request()` alone is no longer sufficient - `request()` must itself be overridden, as well.

While this is only a minor inconvenience, `request()` should, in my opinion, behave consistently with the other `_request()` wrappers, and have a generic "**kwargs" signature.