### PR TITLE
Make TestServer.make_url compatible with yarl.URL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ CHANGES
   (former `RequestHandlerFactory`), introduce new low-level web server
   which is not coupled with `web.Application` and routing #1362
 
--
+- Make `TestServer.make_url` compatible with yarl.URL #1389
 
 -
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ CHANGES
   (former `RequestHandlerFactory`), introduce new low-level web server
   which is not coupled with `web.Application` and routing #1362
 
-- Make `TestServer.make_url` compatible with yarl.URL #1389
+- Make `TestServer.make_url` compatible with `yarl.URL` #1389
 
 -
 

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -74,6 +74,8 @@ class TestServer:
                                                           ssl=self._ssl)
 
     def make_url(self, path):
+        if isinstance(path, URL):
+            path = str(path)
         assert path.startswith('/')
         return URL(str(self._root) + path)
 

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -78,10 +78,9 @@ class BaseTestServer(ABC):
         pass
 
     def make_url(self, path):
-        if isinstance(path, URL):
-            path = str(path)
-        assert path.startswith('/')
-        return URL(str(self._root) + path)
+        url = URL(path)
+        assert not url.is_absolute()
+        return self._root.join(url)
 
     @property
     def started(self):

--- a/demos/polls/aiohttpdemo_polls/main.py
+++ b/demos/polls/aiohttpdemo_polls/main.py
@@ -6,7 +6,7 @@ import jinja2
 
 import aiohttp_jinja2
 from aiohttp import web
-from aiohttpdemo_polls.db import init_pg, close_pg
+from aiohttpdemo_polls.db import close_pg, init_pg
 from aiohttpdemo_polls.middlewares import setup_middlewares
 from aiohttpdemo_polls.routes import setup_routes
 from aiohttpdemo_polls.utils import load_config

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -271,8 +271,13 @@ def test_client_unsupported_arg():
 
 def test_server_make_url_yarl_compatibility(loop):
     app = _create_example_app(loop)
-    make_url = _TestServer(app).make_url
-    assert make_url(URL('/')) == make_url('/')
+    with _TestServer(app) as server:
+        make_url = server.make_url
+        assert make_url(URL('/foo')) == make_url('/foo')
+        with pytest.raises(AssertionError):
+            make_url('http://foo.com')
+        with pytest.raises(AssertionError):
+            make_url(URL('http://foo.com'))
 
 
 def test_raw_server_implicit_loop(loop):

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
 
 import aiohttp
 from aiohttp import web, web_reqrep
@@ -266,3 +267,9 @@ def test_client_host_mutually_exclusive_with_server(loop):
 def test_client_unsupported_arg():
     with pytest.raises(TypeError):
         _TestClient('string')
+
+
+def test_server_make_url_yarl_compatibility(loop):
+    app = _create_example_app(loop)
+    make_url = _TestServer(app).make_url
+    assert make_url(URL('/')) == make_url('/')


### PR DESCRIPTION
## Are there changes in behavior for the user?

Nope

## Related issue number

https://github.com/KeepSafe/aiohttp/issues/1389
