### PR TITLE
well quote Location on redirect

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -55,6 +55,7 @@ Enrique Saez
 Erich Healy
 Eugene Chernyshov
 Eugene Naydenov
+Eugene Tatarkin
 Frederik Gladhorn
 Frederik Peter Aalund
 Gabriel Tremblay

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -19,7 +19,7 @@ from .client_reqrep import ClientRequest, ClientResponse
 from .client_ws import ClientWebSocketResponse
 from .cookiejar import CookieJar
 from .errors import WSServerHandshakeError
-from .helpers import Timeout
+from .helpers import Timeout, requote_uri
 
 __all__ = ('ClientSession', 'request', 'get', 'options', 'head',
            'delete', 'post', 'put', 'patch', 'ws_connect')
@@ -212,7 +212,9 @@ class ClientSession:
                                        "a redirect [{0.status}] status "
                                        "but response lacks a Location "
                                        "or URI HTTP header".format(resp))
-                r_url = URL(r_url)
+
+                # Ensure Location is fully and consistently quoted
+                r_url = URL(requote_uri(r_url), encoded=True)
 
                 scheme = r_url.scheme
                 if scheme not in ('http', 'https', ''):

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -18,6 +18,7 @@ from urllib.parse import urlencode
 
 from async_timeout import timeout
 from multidict import MultiDict, MultiDictProxy
+from yarl.quoting import UNRESERVED, quote
 
 from . import hdrs
 
@@ -675,3 +676,61 @@ class HeadersMixin:
 def check_loop(loop):
     if loop is None:
         loop = asyncio.get_event_loop()
+
+
+def unquote_unreserved(uri):
+    """Un-escape any percent-escape sequences in a URI that are unreserved
+    characters. This leaves all reserved, illegal and non-ASCII bytes encoded.
+
+    Stolen from `requests`.
+
+    :rtype: str
+    """
+    parts = uri.split('%')
+    for i in range(1, len(parts)):
+        h = parts[i][0:2]
+        if len(h) == 2 and h.isalnum():
+            try:
+                c = chr(int(h, 16))
+            except ValueError:
+                raise ValueError("Invalid percent-escape sequence: '%s'" % h)
+
+            if c in UNRESERVED:
+                parts[i] = c + parts[i][2:]
+            else:
+                parts[i] = '%' + parts[i]
+        else:
+            parts[i] = '%' + parts[i]
+    return ''.join(parts)
+
+
+def requote_uri(uri):
+    """Re-quote the given URI.
+    This function passes the given URI through an unquote/quote cycle to
+    ensure that it is fully and consistently quoted.
+
+    Stolen from `requests`.
+
+    :rtype: str
+    """
+    safe_with_percent = "!#$%&'()*+,/:;=?@[]~"
+    safe_without_percent = "!#$&'()*+,/:;=?@[]~"
+    try:
+        # Unquote only the unreserved characters
+        # Then quote only illegal characters (do not quote reserved,
+        # unreserved, or '%')
+        return quote(unquote_unreserved(uri), safe=safe_with_percent)
+    except Exception:
+        # We couldn't unquote the given URI, so let's try quoting it, but
+        # there may be unquoted '%'s in the URI. We need to make sure they're
+        # properly quoted so they do not cause issues elsewhere.
+        try:
+            return quote(uri, safe=safe_without_percent)
+        except ValueError:  # pragma: no cover
+            # TODO: make changes in yarl.quote to quote percent
+            # Fallback to standart urllib.parse.quote
+            # yarl.quote must quote percent
+            # >>> yarl.quote('%25') == '%25'
+            # >>> urllib.parse.quote('%25') == '%2525'
+            import urllib
+            return urllib.parse.quote(uri, safe=safe_without_percent)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -432,3 +432,38 @@ class TestFrozenList:
     def test_le(self):
         l = helpers.FrozenList([1])
         assert l < [2]
+
+
+@pytest.mark.parametrize(
+    'uri, expected', (
+        (
+            # Illegal bytes
+            'http://example.com/?a=%--',
+            'http://example.com/?a=%--',
+        ),
+        (
+            # Reserved characters
+            'http://example.com/?a=%300',
+            'http://example.com/?a=00',
+        )
+    ))
+def test_unquote_unreserved(uri, expected):
+    assert helpers.unquote_unreserved(uri) == expected
+
+
+@pytest.mark.parametrize(
+    'uri, expected', (
+        (
+            # Ensure requoting doesn't break expectations
+            'http://example.com/fiz?buz=%25ppicture',
+            'http://example.com/fiz?buz=%25ppicture',
+        ),
+        (
+            # Ensure we handle unquoted percent signs in redirects
+            'http://example.com/fiz?buz=%ppicture',
+            'http://example.com/fiz?buz=%25ppicture',
+        ),
+    ))
+def test_requote_uri(uri, expected):
+    """See: https://github.com/kennethreitz/requests/issues/2356"""
+    assert helpers.requote_uri(uri) == expected


### PR DESCRIPTION
## What do these changes do?

When I upgrade from `aiohttp==0.22.5` to `aiohttp==1.1.5` found that redirects follow to wrong `Location`.
In master `Location` quoting by `yarl.URL` like that

```
import yarl
>>> Location = 'http://127.0.0.1/?next=http%3A//example.com/'
>>> str(yarl.URL(Location))
'http://127.0.0.1/?next=http%3A%2F%2Fexample.com%2F'
```

And when client follow to `http://127.0.0.1/?next=http%3A%2F%2Fexample.com%2F` server respond 404 in my case. Redirect must follow to `http://127.0.0.1/?next=http%3A//example.com/`

Also this PR related to https://github.com/kennethreitz/requests/issues/2356

Changes:
 - Fix invalid double quoting `Location` on redirect. By stolen idea from `request` for quoting `Location` on redirect.
 - `def unquote_unreserved` from `requests`
 - `def requote_uri` from `requests` with small changes

Also I found that `yarl.parse.quote('%25') != urllib.parse.quote('%25')` where
```
import yarl
import urllib
>>> yarl.quote('%25') == '%25'
>>> urllib.parse.quote('%25') == '%2525' 
```

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`

P.S. sorry for my poor English.