### PR TITLE
Fixed stream reading method of BodyPartReader

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -39,6 +39,7 @@ If you like to use *virtualenv* please run:
 
    $ cd aiohttp
    $ virtualenv --python=`which python3` venv
+   $ . venv/bin/activate
 
 For standard python *venv*:
 
@@ -46,6 +47,7 @@ For standard python *venv*:
 
    $ cd aiohttp
    $ python3 -m venv venv
+   $ . venv/bin/activate
 
 For *virtualenvwrapper* (my choice):
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -108,6 +108,7 @@ Pankaj Pandey
 Pau Freixes
 Paul Colomiets
 Philipp A.
+Rafael Viotti
 Raúl Cumplido
 "Required Field" <requiredfield256@gmail.com>
 Robert Lu

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -332,10 +332,6 @@ class BodyPartReader(object):
             chunk = window[len(self._prev_chunk):idx]
             if not chunk:
                 self._at_eof = True
-        if 0 < len(chunk) < len(sub) and not self._content_eof:
-            self._prev_chunk += chunk
-            self._at_eof = False
-            return b''
         result = self._prev_chunk
         self._prev_chunk = chunk
         return result

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -591,7 +591,7 @@ should use :meth:`Request.multipart` which returns :ref:`multipart reader
 
         filename = mp3.filename
 
-        # You cannot relay on Content-Length if transfer is chunked.
+        # You cannot rely on Content-Length if transfer is chunked.
         size = 0
         with open(os.path.join('/spool/yarrr-media/mp3/', filename), 'wb') as f:
             while True:


### PR DESCRIPTION
The method `BodyPartHeader._read_chunk_from_stream` from `aiohttp.multipart` module was returning an zero length Byte object before reaching EOF while reading a part in a multipart request.

Added missing virtualenv activation instructions in `CONTRIBUTING.rst`.

Fixed a typo in the docs.

Fixes #1428.