### PR TITLE
helpers.TimeService.stop() safe multiple calls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ CHANGES
 
 - Fix bugs with client proxy target path and proxy host with port #1413
 
-- Fix raise error in case of multiple calls of `TimeServive.stop()`
+-
 
 -
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,8 @@ CHANGES
 
 - Introduce `router.post_init()` for solving #1373
 
+- Fix raise error in case of multiple calls of `TimeServive.stop()`
+
 - Allow to raise web exceptions on router resolving stage #1460
 
 - Add a warning for session creation outside of coroutine #1468

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ CHANGES
 
 - Fix bugs with client proxy target path and proxy host with port #1413
 
--
+- Fix raise error in case of multiple calls of `TimeServive.stop()`
 
 -
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -105,6 +105,7 @@ Mun Gwan-gyeong
 Nicolas Braem
 Nikolay Novik
 Olaf Conradi
+Pahaz Blinov <pahaz.blinov@gmail.com>
 Pankaj Pandey
 Pau Freixes
 Paul Colomiets

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -592,7 +592,8 @@ class TimeService:
         self._cb = loop.call_later(1, self._on_cb)
 
     def stop(self):
-        self._cb.cancel()
+        if self._cb:
+            self._cb.cancel()
         self._cb = None
         self._loop = None
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -404,6 +404,12 @@ class TestTimeService:
         assert time_service._cb is None
         assert time_service._loop is None
 
+    def test_stop_call_again(self, time_service):
+        time_service.stop()
+        time_service.stop()
+        assert time_service._cb is None
+        assert time_service._loop is None
+
     def test_time(self, time_service):
         t = time_service._time
         assert t == time_service.time()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -404,7 +404,7 @@ class TestTimeService:
         assert time_service._cb is None
         assert time_service._loop is None
 
-    def test_stop_call_again(self, time_service):
+    def test_double_stopping(self, time_service):
         time_service.stop()
         time_service.stop()
         assert time_service._cb is None


### PR DESCRIPTION
## What do these changes do?

I have updated aiohttp version in my project. And now I have some problem with `TimeServive`:
```
Error
Traceback (most recent call last):
  File ".../rXrealtime/tests/test_base.py", line 64, in tearDown
    self.loop.run_until_complete(self.handler.finish_connections())
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/base_events.py", line 337, in run_until_complete
    return future.result()
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File ".../lib/python3.5/site-packages/aiohttp/web.py", line 165, in finish_connections
    self._time_service.stop()
  File ".../lib/python3.5/site-packages/aiohttp/helpers.py", line 595, in stop
    self._cb.cancel()
AttributeError: 'NoneType' object has no attribute 'cancel'
```

## Are there changes in behavior for the user?

We just don't raise error in case of multiple calls of `stop()` method.
It's safe cleaning of resources.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.

