### PR TITLE
Ensure Yarl <0.8 is installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ with codecs.open(os.path.join(os.path.abspath(os.path.dirname(
 
 
 install_requires = ['chardet', 'multidict>=2.0',
-                    'async_timeout>=1.1.0', 'yarl>=0.5.0']
+                    'async_timeout>=1.1.0', 'yarl>=0.5.0,<0.8']
 
 if sys.version_info < (3, 4, 2):
     raise RuntimeError("aiohttp requires Python 3.4.2+")


### PR DESCRIPTION
## What do these changes do?

Prevents Yarl 0.8 from being installed as it breaks aiohttp installs. 

## Related issue number

https://github.com/KeepSafe/aiohttp/issues/1447

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.

