### PR TITLE
Fix bug with https proxy acquired cleanup #1340

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,13 +42,13 @@ CHANGES
 
 -
 
+-
+
+-
+
+-
+
 - Fix bug with https proxy acquired cleanup #1340
-
--
-
--
-
--
 
 -
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,15 +34,15 @@ CHANGES
 
 - Fix bugs related to the use of unicode hostnames #1444
 
+-
+
+-
+
+-
+
+-
+
 - Fix bug with https proxy acquired cleanup #1340
-
--
-
--
-
--
-
--
 
 -
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,7 @@ CHANGES
 
 - Fix bugs related to the use of unicode hostnames #1444
 
--
+- Fix bug with https proxy acquired cleanup #1340
 
 -
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -364,17 +364,20 @@ class BaseConnector(object):
         except KeyError:  # pragma: no cover
             # this may be result of undetermenistic order of objects
             # finalization due garbage collection.
-            pass
-        else:
-            if self._limit is not None and len(acquired) < self._limit:
-                self._release_waiter(key)
+            return None
+
+        return acquired
 
     def _release(self, key, req, transport, protocol, *, should_close=False):
         if self._closed:
             # acquired connection is already released on connector closing
             return
 
-        self._release_acquired(key, transport)
+        acquired = self._release_acquired(key, transport)
+
+        if self._limit is not None and acquired is not None:
+            if len(acquired) < self._limit:
+                self._release_waiter(key)
 
         resp = req.response
 

--- a/tests/test_client_connection.py
+++ b/tests/test_client_connection.py
@@ -95,5 +95,6 @@ def test_detach(connector, key, request, transport, protocol, loop):
     assert not conn.closed
     conn.detach()
     assert conn._transport is None
+    assert connector._release_acquired.called
     assert not connector._release.called
     assert conn.closed

--- a/tests/test_client_connection.py
+++ b/tests/test_client_connection.py
@@ -98,3 +98,13 @@ def test_detach(connector, key, request, transport, protocol, loop):
     assert connector._release_acquired.called
     assert not connector._release.called
     assert conn.closed
+
+
+def test_detach_closed(connector, key, request, transport, protocol, loop):
+    conn = Connection(connector, key, request,
+                      transport, protocol, loop)
+    conn.release()
+    conn.detach()
+
+    assert not connector._release_acquired.called
+    assert conn._transport is None

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -367,10 +367,11 @@ def test_request_ctx_manager_props(loop):
     with aiohttp.ClientSession(loop=loop) as client:
         ctx_mgr = client.get('http://example.com')
 
-        yield from next(ctx_mgr)
+        next(ctx_mgr)
         assert isinstance(ctx_mgr.gi_frame, types.FrameType)
         assert not ctx_mgr.gi_running
         assert isinstance(ctx_mgr.gi_code, types.CodeType)
+        yield from asyncio.sleep(0.1, loop=loop)
 
 
 @asyncio.coroutine

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -367,7 +367,7 @@ def test_request_ctx_manager_props(loop):
     with aiohttp.ClientSession(loop=loop) as client:
         ctx_mgr = client.get('http://example.com')
 
-        next(ctx_mgr)
+        yield from next(ctx_mgr)
         assert isinstance(ctx_mgr.gi_frame, types.FrameType)
         assert not ctx_mgr.gi_running
         assert isinstance(ctx_mgr.gi_code, types.CodeType)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -161,6 +161,19 @@ def test_release_acquired(loop):
     conn.close()
 
 
+def test_release_acquired_closed(loop):
+    conn = aiohttp.BaseConnector(loop=loop, limit=5)
+    conn._release_waiter = unittest.mock.Mock()
+
+    key, tr = 1, unittest.mock.Mock()
+    conn._acquired[key].add(tr)
+    conn._closed = True
+    conn._release_acquired(key, tr)
+    assert 1 == len(conn._acquired[key])
+    assert not conn._release_waiter.called
+    conn.close()
+
+
 def test_release(loop):
     loop.time = mock.Mock(return_value=10)
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -149,6 +149,18 @@ def test_get_expired(loop):
     conn.close()
 
 
+def test_release_acquired(loop):
+    conn = aiohttp.BaseConnector(loop=loop, limit=5)
+    conn._release_waiter = unittest.mock.Mock()
+
+    key, tr = 1, unittest.mock.Mock()
+    conn._acquired[key].add(tr)
+    conn._release_acquired(key, tr)
+    assert 0 == len(conn._acquired[key])
+    assert conn._release_waiter.called
+    conn.close()
+
+
 def test_release(loop):
     loop.time = mock.Mock(return_value=10)
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -155,9 +155,15 @@ def test_release_acquired(loop):
 
     key, tr = 1, unittest.mock.Mock()
     conn._acquired[key].add(tr)
-    conn._release_acquired(key, tr)
+    acquired = conn._release_acquired(key, tr)
     assert 0 == len(conn._acquired[key])
-    assert conn._release_waiter.called
+    assert acquired == conn._acquired[key]
+    assert not conn._release_waiter.called
+
+    acquired = conn._release_acquired(key, tr)
+    assert 0 == len(conn._acquired[key])
+    assert acquired is None
+
     conn.close()
 
 
@@ -179,6 +185,7 @@ def test_release(loop):
 
     conn = aiohttp.BaseConnector(loop=loop)
     conn._start_cleanup_task = unittest.mock.Mock()
+    conn._release_waiter = unittest.mock.Mock()
     req = unittest.mock.Mock()
     resp = req.response = unittest.mock.Mock()
     resp._should_close = False
@@ -187,8 +194,60 @@ def test_release(loop):
     key = 1
     conn._acquired[key].add(tr)
     conn._release(key, req, tr, proto)
+    assert conn._release_waiter.called
     assert conn._conns[1][0] == (tr, proto, 10)
     assert conn._start_cleanup_task.called
+    conn.close()
+
+
+def test_release_already_closed(loop):
+    conn = aiohttp.BaseConnector(loop=loop)
+
+    tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
+    key = 1
+    conn._acquired[key].add(tr)
+    conn.close()
+
+    conn._start_cleanup_task = unittest.mock.Mock()
+    conn._release_waiter = unittest.mock.Mock()
+    conn._release_acquired = unittest.mock.Mock()
+    req = unittest.mock.Mock()
+
+    conn._release(key, req, tr, proto)
+    assert not conn._release_waiter.called
+    assert not conn._start_cleanup_task.called
+    assert not conn._release_acquired.called
+
+
+def test_release_do_not_call_release_waiter(loop):
+    req = unittest.mock.Mock()
+    resp = req.response = unittest.mock.Mock()
+    resp._should_close = False
+    tr, proto = unittest.mock.Mock(), unittest.mock.Mock()
+    key = 1
+
+    # limit is None
+    conn = aiohttp.BaseConnector(limit=None, loop=loop)
+    conn._release_waiter = unittest.mock.Mock()
+    conn._acquired[key].add(tr)
+    conn._release(key, req, tr, proto)
+    assert not conn._release_waiter.called
+    conn.close()
+
+    # acquired key error
+    conn = aiohttp.BaseConnector(loop=loop)
+    conn._release_waiter = unittest.mock.Mock()
+    conn._release(key, req, tr, proto)
+    assert not conn._release_waiter.called
+    conn.close()
+
+    # acquired len >= limit
+    conn = aiohttp.BaseConnector(limit=1, loop=loop)
+    conn._release_waiter = unittest.mock.Mock()
+    conn._acquired[key].add(unittest.mock.Mock())
+    conn._acquired[key].add(tr)
+    conn._release(key, req, tr, proto)
+    assert not conn._release_waiter.called
     conn.close()
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -228,7 +228,7 @@ class TestProxy(unittest.TestCase):
         self.assertEqual(req.url.path, '/')
         self.assertEqual(proxy_req.method, 'CONNECT')
         self.assertEqual(proxy_req.url, URL('https://www.python.org'))
-        tr.pause_reading.assert_called_once_with()
+        tr.close.assert_called_once_with()
         tr.get_extra_info.assert_called_with('socket', default=None)
 
         self.loop.run_until_complete(proxy_req.close())
@@ -409,7 +409,7 @@ class TestProxy(unittest.TestCase):
         self.assertEqual(req.url.path, '/')
         self.assertEqual(proxy_req.method, 'CONNECT')
         self.assertEqual(proxy_req.url, URL('https://www.python.org'))
-        tr.pause_reading.assert_called_once_with()
+        tr.close.assert_called_once_with()
         tr.get_extra_info.assert_called_with('socket', default=None)
 
         self.loop.run_until_complete(proxy_req.close())

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -204,7 +204,7 @@ def test_proxy_http_acquired_cleanup(proxy_test_server, loop):
 
     assert 0 == len(conn._acquired[key])
 
-    sess.close()
+    yield from sess.close()
 
 
 @asyncio.coroutine
@@ -231,7 +231,7 @@ def test_proxy_http_acquired_cleanup_force(proxy_test_server, loop):
 
     assert 0 == len(conn._acquired[key])
 
-    sess.close()
+    yield from sess.close()
 
 
 @asyncio.coroutine
@@ -255,7 +255,7 @@ def test_proxy_http_multi_conn_limit(proxy_test_server, loop):
     assert len(responses) == multi_conn_num
     assert set(resp.status for resp in responses) == {200}
 
-    sess.close()
+    yield from sess.close()
 
 
 @asyncio.coroutine
@@ -395,7 +395,7 @@ def test_proxy_https_acquired_cleanup(proxy_test_server, loop):
 
     assert 0 == len(conn._acquired[key])
 
-    sess.close()
+    yield from sess.close()
 
 
 @asyncio.coroutine
@@ -422,7 +422,7 @@ def test_proxy_https_aquired_cleanup_force(proxy_test_server, loop):
 
     assert 0 == len(conn._acquired[key])
 
-    sess.close()
+    yield from sess.close()
 
 
 @asyncio.coroutine
@@ -446,7 +446,7 @@ def test_proxy_https_multi_conn_limit(proxy_test_server, loop):
     assert len(responses) == multi_conn_num
     assert set(resp.status for resp in responses) == {200}
 
-    sess.close()
+    yield from sess.close()
 
 
 def _patch_ssl_transport(monkeypatch):

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -88,6 +88,18 @@ def test_proxy_http_raw_path(proxy_test_server, get_request):
 
 
 @asyncio.coroutine
+def test_proxy_http_idna_support(proxy_test_server, get_request):
+    url = 'http://éé.com/'
+    raw_url = 'http://xn--9caa.com/'
+    proxy = yield from proxy_test_server()
+
+    yield from get_request(url=url, proxy=proxy.url)
+
+    assert proxy.request.host == 'xn--9caa.com'
+    assert proxy.request.path_qs == raw_url
+
+
+@asyncio.coroutine
 def test_proxy_http_connection_error(get_request):
     url = 'http://aiohttp.io/path'
     proxy_url = 'http://localhost:2242/'
@@ -198,6 +210,19 @@ def test_proxy_https_connect_with_port(proxy_test_server, get_request):
 
     assert proxy.request.host == 'secure.aiohttp.io:2242'
     assert proxy.request.path_qs == '/path'
+
+
+@asyncio.coroutine
+def test_proxy_https_idna_support(proxy_test_server, get_request):
+    url = 'https://éé.com/'
+    proxy = yield from proxy_test_server()
+
+    yield from get_request(url=url, proxy=proxy.url)
+
+    connect = proxy.requests_list[0]
+    assert connect.method == 'CONNECT'
+    assert connect.path == 'xn--9caa.com:443'
+    assert connect.host == 'xn--9caa.com'
 
 
 @asyncio.coroutine


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?
This pull request fix bug with https proxy acquired cleanup. 
When TCPConnector creates a proxy connection, it adds a transport to the acquired and then sends CONNECT request. But after that TCPConnector detach the transport and does not remove them from the acquired. This caused a memory leak when https proxy connection had used.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#1340
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
