### PR TITLE
update web.run_app to accept a list of host addresses to bind

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -295,7 +295,7 @@ def run_app(app, *, host='0.0.0.0', port=None,
     else:
         urls = [base_url.with_host(h) for h in host]
     print("======== Running on {} ========\n"
-          "(Press CTRL+C to quit)".format(', '.join(str(u) for u in urls))
+          "(Press CTRL+C to quit)".format(', '.join(str(u) for u in urls)))
 
     try:
         loop.run_forever()

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -289,10 +289,13 @@ def run_app(app, *, host='0.0.0.0', port=None,
                                                               loop=loop))
 
     scheme = 'https' if ssl_context else 'http'
-    url = URL('{}://localhost'.format(scheme))
-    url = url.with_host(host).with_port(port)
+    base_url = URL('{}://localhost'.format(scheme)).with_port(port)
+    if isinstance(host, str):
+        urls = [base_url.with_host(host)]
+    else:
+        urls = [base_url.with_host(h) for h in host]
     print("======== Running on {} ========\n"
-          "(Press CTRL+C to quit)".format(url))
+          "(Press CTRL+C to quit)".format(', '.join(str(u) for u in urls))
 
     try:
         loop.run_forever()


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

update web.run_app to accept a list of host addresses to bind

Currently web.run_app does not accept a list of host addresses to bind
on like the underlying AbstractEventLoop.create_server. The only change
needed is to fix the logging line which prints out the address the
server is listening on to support an iterable rather than throwing an
exception.

## Are there changes in behavior for the user?

Completely backwards compatible

## Related issue number

No

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.

Currently web.run_app does not accept a list of host addresses to bind
on like the underlying AbstractEventLoop.create_server. The only change
needed is to fix the logging line which prints out the address the
server is listening on to support an iterable rather than throwing an
exception.