### PR TITLE
Deprecate changing the status code of a response after it has been prepared

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,9 @@ CHANGES
 - Avoid a race when application might start accepting incoming requests
   but startup signals are not processed yet e98e8c6
 
+- Raise a `RuntimeError` when trying to change the status of the HTTP response
+  after the headers have been sent
+
 -
 
 - Fix bug with https proxy acquired cleanup #1340

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -509,7 +509,6 @@ class StreamResponse(HeadersMixin):
         self._compression_force = False
         self._headers = CIMultiDict()
         self._cookies = SimpleCookie()
-        self.set_status(status, reason)
 
         self._req = None
         self._resp_impl = None
@@ -521,6 +520,8 @@ class StreamResponse(HeadersMixin):
             # TODO: optimize CIMultiDict extending
             self._headers.extend(headers)
         self._headers.setdefault(hdrs.CONTENT_TYPE, 'application/octet-stream')
+
+        self.set_status(status, reason)
 
     @property
     def prepared(self):
@@ -552,6 +553,9 @@ class StreamResponse(HeadersMixin):
         return self._reason
 
     def set_status(self, status, reason=None):
+        if self.prepared:
+            raise RuntimeError("Cannot change the response status code after "
+                               "the headers have been sent")
         self._status = int(status)
         if reason is None:
             reason = ResponseImpl.calc_reason(status)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -905,6 +905,14 @@ def test_drain_before_start():
         yield from resp.drain()
 
 
+@asyncio.coroutine
+def test_changing_status_after_prepare_raises():
+    resp = StreamResponse()
+    yield from resp.prepare(make_request('GET', '/'))
+    with pytest.raises(RuntimeError):
+        resp.set_status(400)
+
+
 def test_nonstr_text_in_ctor():
     with pytest.raises(TypeError):
         Response(text=b'data')


### PR DESCRIPTION
Changing the status of a Response after it has been prepared doesn't do anything and should raise an exception imo.
Since breaking all apps that do this might not be an option, I've added a warning when this happens and I would suggest changing the warning to an exception in the next major release (not sure what the policy on breaking changes is, so up to you!)

(this PR is missing updates in CHANGES/…, I can add those if this looks good to you)