### PR TITLE
use UTF-8 as the default encoding for multipart text parts

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -394,7 +394,9 @@ class BodyPartReader(object):
         :rtype: str
         """
         data = yield from self.read(decode=True)
-        encoding = encoding or self.get_charset(default='latin1')
+        # see https://www.w3.org/TR/html5/forms.html#multipart/form-data-encoding-algorithm # NOQA
+        # and https://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#dom-xmlhttprequest-send # NOQA
+        encoding = encoding or self.get_charset(default='utf-8')
         return data.decode(encoding)
 
     @asyncio.coroutine

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -361,6 +361,13 @@ class PartReaderTestCase(TestCase):
         result = yield from obj.text()
         self.assertEqual('Hello, world!', result)
 
+    def test_read_text_default_encoding(self):
+        obj = aiohttp.multipart.BodyPartReader(
+            self.boundary, {},
+            Stream('Привет, Мир!\r\n--:--'.encode('utf-8')))
+        result = yield from obj.text()
+        self.assertEqual('Привет, Мир!', result)
+
     def test_read_text_encoding(self):
         obj = aiohttp.multipart.BodyPartReader(
             self.boundary, {},


### PR DESCRIPTION
After some tests on Chrome, it seems in multipart/form-data bodies, regular field=value parts are encoded using utf-8, not latin1

https://www.w3.org/TR/html5/forms.html#multipart/form-data-encoding-algorithm
https://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#dom-xmlhttprequest-send