### PR TITLE
fix polls demo run application

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,3 +58,5 @@ CHANGES
 - Fix bug with https proxy acquired cleanup #1340
 
 - Use UTF-8 as the default encoding for multipart text parts #1484
+
+- Fix polls demo run application

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -51,6 +51,7 @@ Dmitry Shamov
 Dmitry Trofimov
 Dmytro Kuznetsov
 Dustin J. Mitchell
+Eduard Iskandarov
 Elizabeth Leddy
 Enrique Saez
 Erich Healy

--- a/demos/polls/aiohttpdemo_polls/__main__.py
+++ b/demos/polls/aiohttpdemo_polls/__main__.py
@@ -1,3 +1,4 @@
+import sys
 from aiohttpdemo_polls.main import main
 
-main()
+main(sys.argv[1:])


### PR DESCRIPTION
I'm adding a bug fix, but there's no branch for current version of `aiohttp` - `1.2`. Set `master` as a target branch.

## What do these changes do?

Fixed run demo polls application:

```
$ python -m aiohttpdemo_polls
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/e.iskandarov/sandbox/aiohttp/demos/polls/aiohttpdemo_polls/__main__.py", line 3, in <module>
    main()
TypeError: main() missing 1 required positional argument: 'argv'
```

## Checklist

- [√] I think the code is well written
- [-] Unit tests for the changes exist
- [-] Documentation reflects the changes
- [√] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [√] Add a new entry to `CHANGES.rst`
