### PR TITLE
Update Connection header to match RFC 6455 case

### DIFF
--- a/aiohttp/protocol.py
+++ b/aiohttp/protocol.py
@@ -684,7 +684,7 @@ class HttpMessage(ABC):
         # set the connection header
         connection = None
         if self.upgrade:
-            connection = 'upgrade'
+            connection = 'Upgrade'
         elif not self.closing if self.keepalive is None else self.keepalive:
             if self.version == HttpVersion10:
                 connection = 'keep-alive'

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -216,7 +216,7 @@ def test_default_headers_connection_upgrade(transport):
     msg.upgrade = True
     msg._add_default_headers()
 
-    assert msg.headers['Connection'] == 'upgrade'
+    assert msg.headers['Connection'] == 'Upgrade'
 
 
 def test_default_headers_connection_close(transport):


### PR DESCRIPTION
## What do these changes do?

This change modifies the case of the 'Connection' header value to match the case used in [RFC 6455](https://tools.ietf.org/html/rfc6455#section-4.2.1). Although section 4.2.1 paragraph 4 instructs the server to treat the value as case-insensitive, if aiohttp needs to pick a case, we should use the one defined in the spec.

## Are there changes in behavior for the user?

No

## Related issue number

Fixes #1495 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
