### PR TITLE
Add recreate method to aiohttp.ClientSession().

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,10 @@ CHANGES
 
 - Fix polls demo run application #1487
 
--
+- Add recreate method to aiohttp.ClientSession(). #1501
+  This addresses an Issue I spotted with ClientSession in a comment to #1468 found here https://github.com/KeepSafe/aiohttp/pull/1468#issuecomment-269052523.
+
+- 
 
 1.2.0 (2016-12-17)
 ------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,4 +1,4 @@
-Contributors
+﻿Contributors
 ------------
 
 A. Jesse Jiryu Davis
@@ -118,6 +118,7 @@ Raúl Cumplido
 "Required Field" <requiredfield256@gmail.com>
 Robert Lu
 Samuel Colvin
+Sean Hunt
 Sebastian Hanula
 Sebastian Hüther
 SeongSoo Cho

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -91,6 +91,13 @@ class ClientSession:
         self._response_class = response_class
         self._ws_response_class = ws_response_class
 
+    @asyncio.coroutine
+    def recreate(self, *args, **kwargs):
+
+        if not self.closed:
+            raise RuntimeError('Session is not closed')
+        self.__init__(*args, **kwargs)
+
     def __del__(self, _warnings=warnings):
         if not self.closed:
             self.close()

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -261,6 +261,34 @@ def test_closed(session):
     assert session.closed
 
 
+def test_recreate(create_session, connector, loop):
+    session = create_session(connector=connector)
+
+    @asyncio.coroutine
+    def _test_recreate_helper(session, connector):
+        ret = yield from session.recreate(connector=connector)
+        return ret
+    session.close()
+    session = loop.run_until_complete(_test_recreate_helper(session,
+                                                            connector))
+
+
+def test_recreate_2(create_session, connector, loop):
+    session = create_session(connector=connector)
+
+    @asyncio.coroutine
+    def _test_recreate_helper(session, connector):
+        ret = yield from session.recreate(connector=connector)
+        return ret
+    try:
+        session = loop.run_until_complete(_test_recreate_helper(session,
+                                                                connector))
+    except RuntimeError:
+        session.close()
+        session = loop.run_until_complete(_test_recreate_helper(session,
+                                                                connector))
+
+
 def test_connector(create_session, loop):
     connector = TCPConnector(loop=loop)
     session = create_session(connector=connector)


### PR DESCRIPTION
This allows a person to create a ``ClientSession`` that was closed without having to reinitialize a class.

There is a problem this fixes. Classes are not destructed after initialized even after the variable that the initialization goes it is overridden by another instance causing a Resource Leak until the Python interpreter is closed. This fixes that issue by explicitly adding an recreate method to eliminate the need to reinitialize the class.

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Adds a way to create a ClientSession without having to reinitialize the class causign a Resource and a Memory leak if not careful.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Yes, instead of overwriting a closed Client Session Instance with a new instance they should use the new ``recreate`` method I made in this PR instead to reduce Memory and Resource leaks.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#1503 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.