### PR TITLE
Changed close method to delete the instance itself.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ CHANGES
 
 -
 
+- close() now deletes the instance for those who forget to delete it in their code. #1505
+
 1.2.0 (2016-12-17)
 ------------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -118,6 +118,7 @@ Raúl Cumplido
 "Required Field" <requiredfield256@gmail.com>
 Robert Lu
 Samuel Colvin
+Sean Hunt
 Sebastian Hanula
 Sebastian Hüther
 SeongSoo Cho

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -438,6 +438,7 @@ class ClientSession:
             self._connector = None
         ret = helpers.create_future(self._loop)
         ret.set_result(None)
+        del self
         return ret
 
     @property


### PR DESCRIPTION
This is to help those who forget to delete the instance of ClientSession
after closing it.

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
delete the instance in close() so that way people do not forget to delete it after closing their Client Session

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No user code should get broken with this. This should help the end user so they don't have to worry about instances not getting deleted on their end.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
