### PR TITLE
Fixed ClientSession initialization warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,12 @@ CHANGES
 
 - remove `web.Application` dependency from `web.UrlDispatcher` #1510
 
- 
+- Fix ClientSession is not aware of TestClient #1499
+
+- Fixed warnings showing when giving ClientSession an event loop when called from a normal function. #[1468](https://github.com/KeepSafe/aiohttp/pull/1468#issuecomment-269112177)
+
+-
+
 1.2.0 (2016-12-17)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,9 @@ CHANGES
 
 - Fix polls demo run application #1487
 
--
+- remove `web.Application` dependency from `web.UrlDispatcher` #1510
 
+ 
 1.2.0 (2016-12-17)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 
 - Fix polls demo run application #1487
 
+- Ignore unknown 1XX status codes in client #1353
+
 - remove `web.Application` dependency from `web.UrlDispatcher` #1510
 
  

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -119,6 +119,7 @@ Raúl Cumplido
 "Required Field" <requiredfield256@gmail.com>
 Robert Lu
 Samuel Colvin
+Sean Hunt <seandhunt_7@yahoo.com>
 Sebastian Hanula
 Sebastian Hüther
 SeongSoo Cho

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.2.0'
+__version__ = '1.2.1a'
 
 # Deprecated, keep it here for a while for backward compatibility.
 import multidict  # noqa

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -54,7 +54,7 @@ class ClientSession:
         if loop.get_debug():
             self._source_traceback = traceback.extract_stack(sys._getframe(1))
 
-        if not loop.is_running():
+        if not loop.is_running() and loop is not None:
             warnings.warn("Creating a client session outside of coroutine is "
                           "a very dangerous idea", ResourceWarning,
                           stacklevel=2)

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -612,7 +612,7 @@ class ClientResponse(HeadersMixin):
             # read response
             with Timeout(self._timeout, loop=self._loop):
                 message = yield from httpstream.read()
-            if message.code != 100:
+            if message.code < 100 or message.code > 199 or message.code == 101:
                 break
 
             if self._continue is not None and not self._continue.done():

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -139,7 +139,7 @@ class Application(MutableMapping):
             raise ValueError("Prefix cannot be empty")
 
         resource = PrefixedSubAppResource(prefix, subapp)
-        self.router.reg_resource(resource)
+        self.router.register_resource(resource)
         self._reg_subapp_signals(subapp)
         subapp.freeze()
         return resource

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -18,7 +18,7 @@ from .web_exceptions import *  # noqa
 from .web_reqrep import *  # noqa
 from .web_server import Server
 from .web_urldispatcher import *  # noqa
-from .web_urldispatcher import PrefixedSubAppResource, _wrap_add_subbapp
+from .web_urldispatcher import PrefixedSubAppResource
 from .web_ws import *  # noqa
 
 __all__ = (web_reqrep.__all__ +
@@ -40,6 +40,7 @@ class Application(MutableMapping):
             router = web_urldispatcher.UrlDispatcher()
         assert isinstance(router, AbstractRouter), router
 
+        # backward compatibility until full deprecation
         router.add_subapp = _wrap_add_subbapp(self)
 
         if debug is ...:
@@ -138,8 +139,8 @@ class Application(MutableMapping):
             raise ValueError("Prefix cannot be empty")
 
         resource = PrefixedSubAppResource(prefix, subapp)
-        self.reg_resource(resource)
-        subapp._reg_subapp_signals(subapp)
+        self.router.reg_resource(resource)
+        self._reg_subapp_signals(subapp)
         subapp.freeze()
         return resource
 
@@ -280,6 +281,16 @@ class Application(MutableMapping):
 
     def __repr__(self):
         return "<Application 0x{:x}>".format(id(self))
+
+
+def _wrap_add_subbapp(app):
+    # backward compatibility
+
+    def add_subapp(prefix, subapp):
+        warnings.warn("Use app.add_subapp() instead", DeprecationWarning)
+        return app.add_subapp(prefix, subapp)
+
+    return add_subapp
 
 
 def run_app(app, *, host='0.0.0.0', port=None,

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -887,21 +887,3 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         super().freeze()
         for resource in self._resources:
             resource.freeze()
-
-
-def _wrap_add_subbapp(app):
-
-    def add_subapp(prefix, subapp):
-        if subapp.frozen:
-            raise RuntimeError("Cannot add frozen application")
-        if prefix.endswith('/'):
-            prefix = prefix[:-1]
-        if prefix in ('', '/'):
-            raise ValueError("Prefix cannot be empty")
-        resource = PrefixedSubAppResource(prefix, subapp)
-        app.router.reg_resource(resource)
-        app._reg_subapp_signals(subapp)
-        subapp.freeze()
-        return resource
-
-    return add_subapp

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -714,11 +714,6 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         super().__init__()
         self._resources = []
         self._named_resources = {}
-        self._app = None
-
-    def post_init(self, app):
-        assert app is not None
-        self._app = app
 
     @asyncio.coroutine
     def resolve(self, request):
@@ -759,16 +754,13 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
     def named_resources(self):
         return MappingProxyType(self._named_resources)
 
-    def _reg_resource(self, resource):
+    def reg_resource(self, resource):
         assert isinstance(resource, AbstractResource), \
             'Instance of AbstractResource class is required, got {!r}'.format(
                 resource)
-        if self._app is None:
-            raise RuntimeError(".post_init() should be called before "
-                               "first resource registering")
         if self.frozen:
-            raise RuntimeError("Cannot register a resource into "
-                               "frozen router.")
+            raise RuntimeError(
+                "Cannot register a resource into frozen router.")
 
         name = resource.name
 
@@ -792,7 +784,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
             raise ValueError("path should be started with / or be empty")
         if not ('{' in path or '}' in path or self.ROUTE_RE.search(path)):
             resource = PlainResource(quote(path, safe='/'), name=name)
-            self._reg_resource(resource)
+            self.reg_resource(resource)
             return resource
 
         pattern = ''
@@ -823,7 +815,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
             raise ValueError(
                 "Bad pattern '{}': {}".format(pattern, exc)) from None
         resource = DynamicResource(compiled, formatter, name=name)
-        self._reg_resource(resource)
+        self.reg_resource(resource)
         return resource
 
     def add_route(self, method, path, handler,
@@ -852,7 +844,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
                                   response_factory=response_factory,
                                   show_index=show_index,
                                   follow_symlinks=follow_symlinks)
-        self._reg_resource(resource)
+        self.reg_resource(resource)
         return resource
 
     def add_head(self, *args, **kwargs):
@@ -891,20 +883,25 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         """
         return self.add_route(hdrs.METH_DELETE, *args, **kwargs)
 
-    def add_subapp(self, prefix, subapp):
+    def freeze(self):
+        super().freeze()
+        for resource in self._resources:
+            resource.freeze()
+
+
+def _wrap_add_subbapp(app):
+
+    def add_subapp(prefix, subapp):
         if subapp.frozen:
-            raise RuntimeError("Cannod add frozen application")
+            raise RuntimeError("Cannot add frozen application")
         if prefix.endswith('/'):
             prefix = prefix[:-1]
         if prefix in ('', '/'):
             raise ValueError("Prefix cannot be empty")
         resource = PrefixedSubAppResource(prefix, subapp)
-        self._reg_resource(resource)
-        self._app._reg_subapp_signals(subapp)
+        app.router.reg_resource(resource)
+        app._reg_subapp_signals(subapp)
         subapp.freeze()
         return resource
 
-    def freeze(self):
-        super().freeze()
-        for resource in self._resources:
-            resource.freeze()
+    return add_subapp

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -754,7 +754,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
     def named_resources(self):
         return MappingProxyType(self._named_resources)
 
-    def reg_resource(self, resource):
+    def register_resource(self, resource):
         assert isinstance(resource, AbstractResource), \
             'Instance of AbstractResource class is required, got {!r}'.format(
                 resource)
@@ -784,7 +784,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
             raise ValueError("path should be started with / or be empty")
         if not ('{' in path or '}' in path or self.ROUTE_RE.search(path)):
             resource = PlainResource(quote(path, safe='/'), name=name)
-            self.reg_resource(resource)
+            self.register_resource(resource)
             return resource
 
         pattern = ''
@@ -815,7 +815,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
             raise ValueError(
                 "Bad pattern '{}': {}".format(pattern, exc)) from None
         resource = DynamicResource(compiled, formatter, name=name)
-        self.reg_resource(resource)
+        self.register_resource(resource)
         return resource
 
     def add_route(self, method, path, handler,
@@ -844,7 +844,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
                                   response_factory=response_factory,
                                   show_index=show_index,
                                   follow_symlinks=follow_symlinks)
-        self.reg_resource(resource)
+        self.register_resource(resource)
         return resource
 
     def add_head(self, *args, **kwargs):

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -8,13 +8,13 @@ import signal
 import socket
 import ssl
 import sys
-
-import gunicorn.workers.base as base
-from gunicorn.config import AccessLogFormat as GunicornAccessLogFormat
+import warnings
 
 from aiohttp.helpers import AccessLogger, ensure_future
 from aiohttp.web_server import Server
 from aiohttp.wsgi import WSGIServerHttpProtocol
+from gunicorn.config import AccessLogFormat as GunicornAccessLogFormat
+from gunicorn.workers import base
 
 __all__ = ('GunicornWebWorker', 'GunicornUVLoopWebWorker')
 
@@ -62,6 +62,11 @@ class GunicornWebWorker(base.Worker):
                 access_log_format=self._get_valid_log_format(
                     self.cfg.access_log_format))
         else:
+            warnings.warn(
+                "aiohttp.wsgi is deprecarted, "
+                "consider to switch to aiohttp.web.Application",
+                DeprecationWarning)
+
             return WSGIServer(self.wsgi, self)
 
     @asyncio.coroutine

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -10,11 +10,12 @@ import ssl
 import sys
 import warnings
 
+from gunicorn.config import AccessLogFormat as GunicornAccessLogFormat
+from gunicorn.workers import base
+
 from aiohttp.helpers import AccessLogger, ensure_future
 from aiohttp.web_server import Server
 from aiohttp.wsgi import WSGIServerHttpProtocol
-from gunicorn.config import AccessLogFormat as GunicornAccessLogFormat
-from gunicorn.workers import base
 
 __all__ = ('GunicornWebWorker', 'GunicornUVLoopWebWorker')
 

--- a/demos/polls/requirements.txt
+++ b/demos/polls/requirements.txt
@@ -1,3 +1,3 @@
 -e .
 docker-py==1.10.6
-pytest-aiohttp==0.1.2
+pytest-aiohttp==0.1.3

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -144,7 +144,7 @@ WebSocket utilities
 
       1. :class:`str` for :attr:`WSMsgType.TEXT` messages.
 
-      2. :class:`bytes` for :attr:`WSMsgType.TEXT` messages.
+      2. :class:`bytes` for :attr:`WSMsgType.BINARY` messages.
 
       3. :class:`WSCloseCode` for :attr:`WSMsgType.CLOSE` messages.
 

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -131,6 +131,17 @@ family are plain shortcuts for :meth:`UrlDispatcher.add_route`.
    Introduce resources.
 
 
+.. _aiohttp-web-custom-resource:
+
+Custom resource implementation
+------------------------------
+
+To register custom resource use :meth:`UrlDispatcher.register_resource`.
+Resource instance must implement `AbstractResource` interface.
+
+.. versionadded:: 1.2.1
+
+
 .. _aiohttp-web-variable-handler:
 
 Variable Resources

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -971,12 +971,12 @@ toolbar URLs are served by prefix like ``/admin``.
 
 Thus we'll create a totally separate application named ``admin`` and
 connect it to main app with prefix by
-:meth:`~aiohttp.web.UrlDispatcher.add_subapp`::
+:meth:`~aiohttp.web.Application.add_subapp`::
 
    admin = web.Application()
    # setup admin routes, signals and middlewares
 
-   app.router.add_subapp('/admin/', admin)
+   app.add_subapp('/admin/', admin)
 
 Middlewares and signals from ``app`` and ``admin`` are chained.
 
@@ -1006,7 +1006,7 @@ But for getting URL sub-application's router should be used::
    admin = web.Application()
    admin.router.add_get('/resource', handler, name='name')
 
-   app.router.add_subapp('/admin/', admin)
+   app.add_subapp('/admin/', admin)
 
    url = admin.router['name'].url_for()
 
@@ -1019,7 +1019,7 @@ use the following explicit technique::
    admin = web.Application()
    admin.router.add_get('/resource', handler, name='name')
 
-   app.router.add_subapp('/admin/', admin)
+   app.add_subapp('/admin/', admin)
    app['admin'] = admin
 
    async def handler(request):  # main application's handler

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,7 +1,7 @@
 pip==9.0.1
 flake8==3.2.1
 pyflakes==1.3.0
-coverage==4.2
+coverage==4.3
 cchardet==1.1.1
 sphinx==1.5.1
 cython==0.25.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,7 +1,7 @@
 pip==9.0.1
 flake8==3.2.1
 pyflakes==1.3.0
-coverage==4.3
+coverage==4.3.1
 cchardet==1.1.1
 sphinx==1.5.1
 cython==0.25.2

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -13,7 +13,7 @@ from aiohttp import hdrs, web
 from aiohttp.test_utils import make_mocked_request
 from aiohttp.web import HTTPMethodNotAllowed, HTTPNotFound, Response
 from aiohttp.web_urldispatcher import (AbstractResource, ResourceRoute,
-                                       SystemRoute, UrlDispatcher, View,
+                                       SystemRoute, View,
                                        _defaultExpectHandler)
 
 
@@ -1011,9 +1011,3 @@ def test_convert_empty_path_to_slash_on_freezing(router):
     assert resource.get_info() == {'path': ''}
     router.freeze()
     assert resource.get_info() == {'path': '/'}
-
-
-def test_add_to_non_initialized_router():
-    router = UrlDispatcher()
-    with pytest.raises(RuntimeError):
-        router.add_get('/', make_handler())

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -869,7 +869,7 @@ def test_simple_subapp(loop, test_client):
     app = web.Application(loop=loop)
     subapp = web.Application(loop=loop)
     subapp.router.add_get('/to', handler)
-    app.router.add_subapp('/path', subapp)
+    app.add_subapp('/path', subapp)
 
     client = yield from test_client(app)
     resp = yield from client.get('/path/to')
@@ -893,7 +893,7 @@ def test_subapp_reverse_url(loop, test_client):
     subapp = web.Application(loop=loop)
     subapp.router.add_get('/to', handler)
     subapp.router.add_get('/final', handler2, name='name')
-    app.router.add_subapp('/path', subapp)
+    app.add_subapp('/path', subapp)
 
     client = yield from test_client(app)
     resp = yield from client.get('/path/to')
@@ -918,7 +918,7 @@ def test_subapp_reverse_variable_url(loop, test_client):
     subapp = web.Application(loop=loop)
     subapp.router.add_get('/to', handler)
     subapp.router.add_get('/{part}', handler2, name='name')
-    app.router.add_subapp('/path', subapp)
+    app.add_subapp('/path', subapp)
 
     client = yield from test_client(app)
     resp = yield from client.get('/path/to')
@@ -942,7 +942,7 @@ def test_subapp_reverse_static_url(loop, test_client):
     subapp.router.add_get('/to', handler)
     here = pathlib.Path(__file__).parent
     subapp.router.add_static('/static', here, name='name')
-    app.router.add_subapp('/path', subapp)
+    app.add_subapp('/path', subapp)
 
     client = yield from test_client(app)
     resp = yield from client.get('/path/to')
@@ -963,7 +963,7 @@ def test_subapp_app(loop, test_client):
     app = web.Application(loop=loop)
     subapp = web.Application(loop=loop)
     subapp.router.add_get('/to', handler)
-    app.router.add_subapp('/path/', subapp)
+    app.add_subapp('/path/', subapp)
 
     client = yield from test_client(app)
     resp = yield from client.get('/path/to')
@@ -981,7 +981,7 @@ def test_subapp_not_found(loop, test_client):
     app = web.Application(loop=loop)
     subapp = web.Application(loop=loop)
     subapp.router.add_get('/to', handler)
-    app.router.add_subapp('/path/', subapp)
+    app.add_subapp('/path/', subapp)
 
     client = yield from test_client(app)
     resp = yield from client.get('/path/other')
@@ -997,7 +997,7 @@ def test_subapp_not_found2(loop, test_client):
     app = web.Application(loop=loop)
     subapp = web.Application(loop=loop)
     subapp.router.add_get('/to', handler)
-    app.router.add_subapp('/path/', subapp)
+    app.add_subapp('/path/', subapp)
 
     client = yield from test_client(app)
     resp = yield from client.get('/invalid/other')
@@ -1013,7 +1013,7 @@ def test_subapp_not_allowed(loop, test_client):
     app = web.Application(loop=loop)
     subapp = web.Application(loop=loop)
     subapp.router.add_get('/to', handler)
-    app.router.add_subapp('/path/', subapp)
+    app.add_subapp('/path/', subapp)
 
     client = yield from test_client(app)
     resp = yield from client.post('/path/to')
@@ -1031,7 +1031,7 @@ def test_subapp_cannot_add_app_in_handler(loop, test_client):
     app = web.Application(loop=loop)
     subapp = web.Application(loop=loop)
     subapp.router.add_get('/to', handler)
-    app.router.add_subapp('/path/', subapp)
+    app.add_subapp('/path/', subapp)
 
     client = yield from test_client(app)
     resp = yield from client.get('/path/to')
@@ -1062,8 +1062,8 @@ def test_subapp_middlewares(loop, test_client):
     subapp1 = web.Application(loop=loop, middlewares=[middleware_factory])
     subapp2 = web.Application(loop=loop, middlewares=[middleware_factory])
     subapp2.router.add_get('/to', handler)
-    subapp1.router.add_subapp('/b/', subapp2)
-    app.router.add_subapp('/a/', subapp1)
+    subapp1.add_subapp('/b/', subapp2)
+    app.add_subapp('/a/', subapp1)
 
     client = yield from test_client(app)
     resp = yield from client.get('/a/b/to')
@@ -1095,8 +1095,8 @@ def test_subapp_on_response_prepare(loop, test_client):
     subapp2 = web.Application(loop=loop)
     subapp2.on_response_prepare.append(make_signal(subapp2))
     subapp2.router.add_get('/to', handler)
-    subapp1.router.add_subapp('/b/', subapp2)
-    app.router.add_subapp('/a/', subapp1)
+    subapp1.add_subapp('/b/', subapp2)
+    app.add_subapp('/a/', subapp1)
 
     client = yield from test_client(app)
     resp = yield from client.get('/a/b/to')
@@ -1118,8 +1118,8 @@ def test_subapp_on_startup(loop, test_server):
     subapp1.on_startup.append(on_signal)
     subapp2 = web.Application(loop=loop)
     subapp2.on_startup.append(on_signal)
-    subapp1.router.add_subapp('/b/', subapp2)
-    app.router.add_subapp('/a/', subapp1)
+    subapp1.add_subapp('/b/', subapp2)
+    app.add_subapp('/a/', subapp1)
 
     yield from test_server(app)
 
@@ -1139,8 +1139,8 @@ def test_subapp_on_shutdown(loop, test_server):
     subapp1.on_shutdown.append(on_signal)
     subapp2 = web.Application(loop=loop)
     subapp2.on_shutdown.append(on_signal)
-    subapp1.router.add_subapp('/b/', subapp2)
-    app.router.add_subapp('/a/', subapp1)
+    subapp1.add_subapp('/b/', subapp2)
+    app.add_subapp('/a/', subapp1)
 
     server = yield from test_server(app)
     yield from server.close()
@@ -1162,8 +1162,8 @@ def test_subapp_on_cleanup(loop, test_server):
     subapp1.on_cleanup.append(on_signal)
     subapp2 = web.Application(loop=loop)
     subapp2.on_cleanup.append(on_signal)
-    subapp1.router.add_subapp('/b/', subapp2)
-    app.router.add_subapp('/a/', subapp1)
+    subapp1.add_subapp('/b/', subapp2)
+    app.add_subapp('/a/', subapp1)
 
     server = yield from test_server(app)
     yield from server.close()


### PR DESCRIPTION
This fixes an issue with ClientSession throwing a warnings when feeding
an event loop into it when calling it from a normal function. This
should help silence annoying warnings for libraries that "lazy"
initializes ClientSession and properly closes the session and handles
it. Now those libraries would have no need for a useless bug reports.

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Fixes the warning when calling a ClientSession instance with an event loop that is passed to the class.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No, just adds more control over the ClientSession instance.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/KeepSafe/aiohttp/pull/1468#issuecomment-269112177

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
