### PR TITLE
fix "''resp' referenced before assignment"

### DIFF
--- a/aiohttp/web_server.py
+++ b/aiohttp/web_server.py
@@ -61,7 +61,7 @@ class RequestHandler(ServerHttpProtocol):
                 resp = yield from self._handler(request)
             except HTTPException as exc:
                 resp = exc
-            except Exception as exc:
+            except BaseException as exc:
                 msg = "<h1>500 Internal Server Error</h1>"
                 if self.debug:
                     try:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -62,6 +62,26 @@ def test_raw_server_not_http_exception_debug(raw_test_server, test_client):
         exc_info=exc)
 
 
+@asyncio.coroutine
+def test_raw_server_base_exception(raw_test_server, test_client):
+    class TestBaseException(BaseException):
+        pass
+
+    @asyncio.coroutine
+    def handler(request):
+        raise TestBaseException()
+
+    logger = mock.Mock()
+    server = yield from raw_test_server(handler, logger=logger, debug=True)
+    client = yield from test_client(server)
+    resp = yield from client.get('/path/to')
+    assert resp.status == 500
+
+    txt = yield from resp.text()
+    assert 'During handling of the above exception' not in txt
+    assert 'TestBaseException' in txt
+
+
 def test_create_web_server_with_implicit_loop(loop):
     asyncio.set_event_loop(loop)
 


### PR DESCRIPTION
(this occurs on both 1.20 and master, I presuming fixing in master is best)

## What do these changes do?

I'm getting an error

```
Traceback (most recent call last):
  File "/home/samuel/code/purge_cloudflare/env/lib/python3.5/site-packages/aiohttp/web_server.py", line 61, in handle_request
    resp = yield from self._handler(request)
  File "/home/samuel/code/purge_cloudflare/env/lib/python3.5/site-packages/aiohttp/web.py", line 249, in _handle
    resp = yield from handler(request)
  File "/home/samuel/code/purge_cloudflare/env/lib/python3.5/site-packages/aiohttp_debugtoolbar/middlewares.py", line 59, in toolbar_middleware
    toolbar = DebugToolbar(request, panel_classes, global_panel_classes)
  File "/home/samuel/code/purge_cloudflare/env/lib/python3.5/site-packages/aiohttp_debugtoolbar/toolbar.py", line 30, in __init__
    panel_inst = panel_class(request)
  File "/home/samuel/code/purge_cloudflare/env/lib/python3.5/site-packages/aiohttp_debugtoolbar/panels/routes.py", line 21, in __init__
    self.populate(request)
  File "/home/samuel/code/purge_cloudflare/env/lib/python3.5/site-packages/aiohttp_debugtoolbar/panels/routes.py", line 33, in populate
    "source": inspect.getsource(route.handler)
  File "/usr/lib/python3.5/inspect.py", line 944, in getsource
    lines, lnum = getsourcelines(object)
  File "/usr/lib/python3.5/inspect.py", line 936, in getsourcelines
    return getblock(lines[lnum:]), lnum + 1
  File "/usr/lib/python3.5/inspect.py", line 916, in getblock
    for _token in tokens:
  File "/home/samuel/code/purge_cloudflare/env/lib/python3.5/tokenize.py", line 550, in _tokenize
    elif line[pos] == '\t':
KeyboardInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/samuel/code/purge_cloudflare/env/lib/python3.5/site-packages/aiohttp/server.py", line 261, in start
    yield from self.handle_request(message, payload)
  File "/home/samuel/code/purge_cloudflare/env/lib/python3.5/site-packages/aiohttp/web_server.py", line 88, in handle_request
    resp._task = None
UnboundLocalError: local variable 'resp' referenced before assignment
```

I think the `KeyboardInterrupt` is caused by aiohttp-devtools trying to restart the app in the middle of a request.

## Are there changes in behavior for the user?

Only if they were getting an error similar to above.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
