### PR TITLE
fix #1525: add missing sub MultipartWriter headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ CHANGES
 
 - Fix polls demo run application #1487
 
--
+- Fix sub-Multipart messages missing their headers on serialization #1525
 
 1.2.0 (2016-12-17)
 ------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -133,6 +133,7 @@ Steven Seguin
 Sviatoslav Bulbakha
 Taha Jahangir
 Taras Voinarovskyi
+Terence Honles
 Thomas Grainger
 Tolga Tezel
 Vaibhav Sagar

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -670,7 +670,11 @@ class BodyPartWriter(object):
     """Multipart writer for single body part."""
 
     def __init__(self, obj, headers=None, *, chunk_size=8192):
-        if headers is None:
+        if isinstance(obj, MultipartWriter):
+            if headers is not None:
+                obj.headers.update(headers)
+            headers = obj.headers
+        elif headers is None:
             headers = CIMultiDict()
         elif not isinstance(headers, CIMultiDict):
             headers = CIMultiDict(headers)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -838,6 +838,12 @@ class BodyPartWriterTestCase(unittest.TestCase):
         multipart = aiohttp.multipart.MultipartWriter(boundary=':')
         multipart.append('foo-bar-baz')
         multipart.append_json({'test': 'passed'})
+        multipart.append_form({'test': 'passed'})
+        multipart.append_form([('one', 1), ('two', 2)])
+        sub_multipart = aiohttp.multipart.MultipartWriter(boundary='::')
+        sub_multipart.append('nested content')
+        sub_multipart.headers['X-CUSTOM'] = 'test'
+        multipart.append(sub_multipart)
         self.assertEqual(
             [b'--:\r\n',
              b'Content-Type: text/plain; charset=utf-8\r\n'
@@ -845,10 +851,36 @@ class BodyPartWriterTestCase(unittest.TestCase):
              b'\r\n\r\n',
              b'foo-bar-baz',
              b'\r\n',
+
              b'--:\r\n',
              b'Content-Type: application/json',
              b'\r\n\r\n',
              b'{"test": "passed"}',
+             b'\r\n',
+
+             b'--:\r\n',
+             b'Content-Type: application/x-www-form-urlencoded',
+             b'\r\n\r\n',
+             b'test=passed',
+             b'\r\n',
+
+             b'--:\r\n',
+             b'Content-Type: application/x-www-form-urlencoded',
+             b'\r\n\r\n',
+             b'one=1&two=2',
+             b'\r\n',
+
+             b'--:\r\n',
+             b'Content-Type: multipart/mixed; boundary="::"\r\nX-Custom: test',
+             b'\r\n\r\n',
+             b'--::\r\n',
+             b'Content-Type: text/plain; charset=utf-8\r\n'
+             b'Content-Length: 14',
+             b'\r\n\r\n',
+             b'nested content',
+             b'\r\n',
+             b'--::--\r\n',
+             b'',
              b'\r\n',
              b'--:--\r\n',
              b''],

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1014,6 +1014,13 @@ class BodyPartWriterTestCase(unittest.TestCase):
         self.part.set_content_disposition('related', filename='foo.html')
         self.assertEqual('foo.html', self.part.filename)
 
+    def test_wrap_multipart(self):
+        writer = aiohttp.multipart.MultipartWriter(boundary=':')
+        part = aiohttp.multipart.BodyPartWriter(writer)
+        self.assertEqual(part.headers, writer.headers)
+        part.headers['X-Custom'] = 'test'
+        self.assertEqual(part.headers, writer.headers)
+
 
 class MultipartWriterTestCase(unittest.TestCase):
 
@@ -1079,6 +1086,14 @@ class MultipartWriterTestCase(unittest.TestCase):
         part = self.writer.parts[0]
         self.assertEqual(part.headers[CONTENT_TYPE],
                          'application/x-www-form-urlencoded')
+
+    def test_append_multipart(self):
+        subwriter = aiohttp.multipart.MultipartWriter(boundary=':')
+        subwriter.append_json({'foo': 'bar'})
+        self.writer.append(subwriter, {CONTENT_TYPE: 'test/passed'})
+        self.assertEqual(1, len(self.writer))
+        part = self.writer.parts[0]
+        self.assertEqual(part.headers[CONTENT_TYPE], 'test/passed')
 
     def test_serialize(self):
         self.assertEqual([b''], list(self.writer.serialize()))


### PR DESCRIPTION
When appending MultipartWriter objects to another MultipartWriter use
the subwriter's headers in the constructed BodyPartWriter

fixes issue #1525 

## What do these changes do?

Fixes issue #1525 by allowing the wrapping BodyPartWriter to use the containing MultipartWriter's headers. This fixes the issue with the missing headers and also allows additional header changes until `.serialize()` is called.

## Are there changes in behavior for the user?

Documentation is now correct, and if the user previously explicitly passed the subwriter's headers when appending the object the headers will already be in the subwriter's headers object so it is effectively a no-op replacing existing values with their same values.

## Related issue number

#1525 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
