### PR TITLE
fix #1526: multipart messages should consume their epilogue

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -639,6 +639,7 @@ class MultipartReader(object):
             pass
         elif chunk == self._boundary + b'--':
             self._at_eof = True
+            yield from self._readline()
         else:
             raise ValueError('Invalid boundary %r, expected %r'
                              % (chunk, self._boundary))

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -594,6 +594,7 @@ class MultipartReaderTestCase(TestCase):
                    b'\r\n'
                    b'passed\r\n'
                    b'----:----\r\n'
+                   b'\r\n'
                    b'--:--'))
         yield from reader.release()
         self.assertTrue(reader.at_eof())

--- a/tests/test_py35/test_multipart_35.py
+++ b/tests/test_py35/test_multipart_35.py
@@ -46,6 +46,7 @@ async def test_async_for_reader(loop):
             b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03K\xcc\xcc\xcf())'
             b'\xe0\x02\x00\xd6\x90\xe2O\x08\x00\x00\x00',
             b'--::--',
+            b'',
             b'--:--',
             b''])))
     idata = iter(data)


### PR DESCRIPTION
Currently a multipart message epilogue is left unread which when nested
in another multipart message causes a ValueError to be raised because
the parent reader expects to find its multipart boundary not the
sub-message's epilogue.

fixes issue #1526 

## What do these changes do?

Allows reading multipart sub-messages that were created with `aiohttp.multipart.MultipartWriter`

## Are there changes in behavior for the user?

ValueError for an incorrect boundary is not thrown anymore.

## Related issue number

#1526 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
