### PR TITLE
do not use readline when reading the content of a part in the multipart reader

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -252,12 +252,8 @@ class BodyPartReader(object):
         if self._at_eof:
             return b''
         data = bytearray()
-        if self._length is None:
-            while not self._at_eof:
-                data.extend((yield from self.readline()))
-        else:
-            while not self._at_eof:
-                data.extend((yield from self.read_chunk(self.chunk_size)))
+        while not self._at_eof:
+            data.extend((yield from self.read_chunk(self.chunk_size)))
         if decode:
             return self.decode(data)
         return data
@@ -377,12 +373,8 @@ class BodyPartReader(object):
         """
         if self._at_eof:
             return
-        if self._length is None:
-            while not self._at_eof:
-                yield from self.readline()
-        else:
-            while not self._at_eof:
-                yield from self.read_chunk(self.chunk_size)
+        while not self._at_eof:
+            yield from self.read_chunk(self.chunk_size)
 
     @asyncio.coroutine
     def text(self, *, encoding=None):

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -255,14 +255,13 @@ class PartReaderTestCase(TestCase):
         self.assertEqual(b'.' * size, result)
         self.assertTrue(obj.at_eof())
 
-    def test_read_does_reads_boundary(self):
+    def test_read_does_not_read_boundary(self):
         stream = Stream(b'Hello, world!\r\n--:')
         obj = aiohttp.multipart.BodyPartReader(
             self.boundary, {}, stream)
         result = yield from obj.read()
         self.assertEqual(b'Hello, world!', result)
-        self.assertEqual(b'', (yield from stream.read()))
-        self.assertEqual([b'--:'], list(obj._unread))
+        self.assertEqual(b'--:', (yield from stream.read()))
 
     def test_multiread(self):
         obj = aiohttp.multipart.BodyPartReader(
@@ -474,8 +473,7 @@ class PartReaderTestCase(TestCase):
             self.boundary, {}, stream)
         yield from obj.release()
         self.assertTrue(obj.at_eof())
-        self.assertEqual(b'\r\nworld!\r\n--:--', stream.content.read())
-        self.assertEqual([b'--:\r\n'], list(obj._unread))
+        self.assertEqual(b'--:\r\n\r\nworld!\r\n--:--', stream.content.read())
 
     def test_release_respects_content_length(self):
         obj = aiohttp.multipart.BodyPartReader(
@@ -491,8 +489,7 @@ class PartReaderTestCase(TestCase):
             self.boundary, {}, stream)
         yield from obj.release()
         yield from obj.release()
-        self.assertEqual(b'\r\nworld!\r\n--:--', stream.content.read())
-        self.assertEqual([b'--:\r\n'], list(obj._unread))
+        self.assertEqual(b'--:\r\n\r\nworld!\r\n--:--', stream.content.read())
 
     def test_filename(self):
         part = aiohttp.multipart.BodyPartReader(

--- a/tests/test_py35/test_multipart_35.py
+++ b/tests/test_py35/test_multipart_35.py
@@ -13,8 +13,14 @@ class Stream(object):
     async def read(self, size=None):
         return self.content.read(size)
 
+    def at_eof(self):
+        return self.content.tell() == len(self.content.getbuffer())
+
     async def readline(self):
         return self.content.readline()
+
+    def unread_data(self, data):
+        self.content = io.BytesIO(data + self.content.read())
 
 
 async def test_async_for_reader(loop):


### PR DESCRIPTION
multipart uploads to an aiohttp server with a "large" file containing no new line fails with a `ValueError('Line is too long')`:

```python
import aiohttp
import aiohttp.web
import asyncio


async def view(request):
	reader = await request.multipart()
	async for part in reader:
		v = await part.read(decode=True)
		print(part, len(v))
	return aiohttp.web.Response(text="OK")

async def server(loop):
	app = aiohttp.web.Application(loop=loop)
	app.router.add_post('/', view)
	handler = app.make_handler()
	await loop.create_server(handler, '0.0.0.0', 1111)

async def main(loop):
	srv = await server(loop)
	async with aiohttp.post('http://0.0.0.0:1111', data={'val':b'0' * (2 ** 16 - 100)}) as resp:
		print('--->', resp.status)
	print('--')
	async with aiohttp.post('http://0.0.0.0:1111', data={'val':b'0' * (2 ** 16 + 1)}) as resp:
		print('--->', resp.status)

loop = asyncio.get_event_loop()
loop.run_until_complete(main(loop))
```
```
<aiohttp.multipart.BodyPartReader object at 0x109c10f28> 65436
---> 200
--
Error handling request
Traceback (most recent call last):
  File "/Users/arthur/Documents/reaaad/lib/aiohttp/aiohttp/web_server.py", line 61, in handle_request
    resp = yield from self._handler(request)
  File "/Users/arthur/Documents/reaaad/lib/aiohttp/aiohttp/web.py", line 268, in _handle
    resp = yield from handler(request)
  File "poc.py", line 9, in view
    v = await part.read(decode=True)
  File "/Users/arthur/Documents/reaaad/lib/aiohttp/aiohttp/multipart.py", line 257, in read
    data.extend((yield from self.readline()))
  File "/Users/arthur/Documents/reaaad/lib/aiohttp/aiohttp/multipart.py", line 351, in readline
    line = yield from self._content.readline()
  File "/Users/arthur/Documents/reaaad/lib/aiohttp/aiohttp/streams.py", line 517, in wrapper
    result = yield from func(self, *args, **kw)
  File "/Users/arthur/Documents/reaaad/lib/aiohttp/aiohttp/streams.py", line 587, in readline
    return (yield from super().readline())
  File "/Users/arthur/Documents/reaaad/lib/aiohttp/aiohttp/streams.py", line 251, in readline
    raise ValueError('Line is too long')
ValueError: Line is too long
---> 500
```


This is because the `StreamReader` class only accepts lines up to 64KB.
I've updated the `MultipartReader` class to avoid `readline` when it doesn't really make sense, and to use `read_chunk` instead.

As far as I can see, it seems to work, but that might not be the right approach to solve this at all…