### PR TITLE
Accept an errors parameter for text decoding ClientResponses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,7 @@ CHANGES
 
 - Fix typo in FAQ section "How to programmatically close websocket server-side?".
 
-- Allow users to specify what should happen to decoding errors when calling a responses `text()` method
-
+- Allow users to specify what should happen to decoding errors when calling a responses `text()` method #1542
  
 1.2.0 (2016-12-17)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ CHANGES
 
 - Fix typo in FAQ section "How to programmatically close websocket server-side?".
 
+- Allow users to specify what should happen to decoding errors when calling a responses `text()` method
+
  
 1.2.0 (2016-12-17)
 ------------------

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -749,7 +749,7 @@ class ClientResponse(HeadersMixin):
         if encoding is None:
             encoding = self._get_encoding()
 
-        return self._content.decode(encoding, errors)
+        return self._content.decode(encoding, errors=errors)
 
     @asyncio.coroutine
     def json(self, *, encoding=None, loads=json.loads):

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -741,7 +741,7 @@ class ClientResponse(HeadersMixin):
         return encoding
 
     @asyncio.coroutine
-    def text(self, encoding=None):
+    def text(self, encoding=None, errors='strict'):
         """Read response payload and decode."""
         if self._content is None:
             yield from self.read()
@@ -749,7 +749,7 @@ class ClientResponse(HeadersMixin):
         if encoding is None:
             encoding = self._get_encoding()
 
-        return self._content.decode(encoding)
+        return self._content.decode(encoding, errors)
 
     @asyncio.coroutine
     def json(self, *, encoding=None, loads=json.loads):


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Users can now give a parameter specifying what should happen to decoding errors when asking for the `text()` from a `ClientResponse`.  This is passed directly into the [bytes() decode method](https://docs.python.org/3/library/stdtypes.html#bytearray.decode).

The internet is full of websites that have incorrectly specified their character encoding or that have one or two characters on a page that are not encoded correctly.  Right now, the `aiohttp` library just throws an exception when this happens - for a more resilient solution, users should be able to optionally provide an alternative error handling strategy for incorrectly encoded characters.

## Are there changes in behavior for the user?

Nope - just a new optional parameter.

## Related issue number

Nope.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
