### PR TITLE
Do not pause transport during set_parser stage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,11 +10,14 @@ CHANGES
 
 - Fix sub-Multipart messages missing their headers on serialization #1525
 
-- remove `web.Application` dependency from `web.UrlDispatcher` #1510
+- Remove `web.Application` dependency from `web.UrlDispatcher` #1510
+
+- Do not pause transport during set_parser stage #1211
 
 - Fix typo in FAQ section "How to programmatically close websocket server-side?"
 
 - Allow users to specify what should happen to decoding errors when calling a responses `text()` method #1542
+
 
 1.2.0 (2016-12-17)
 ------------------

--- a/aiohttp/parsers.py
+++ b/aiohttp/parsers.py
@@ -194,6 +194,7 @@ class StreamParser:
             # parser still require more data
             self._parser = p
             self._output = output
+            self._output.allow_pause = True
 
             if self._eof:
                 self.unset_parser()

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -534,6 +534,7 @@ class FlowControlStreamReader(StreamReader):
 
         self._stream = stream
         self._b_limit = limit * 2
+        self.allow_pause = False
 
         # resume transport reading
         if stream.paused:
@@ -543,6 +544,7 @@ class FlowControlStreamReader(StreamReader):
                 pass
             else:
                 self._stream.paused = False
+                self.allow_pause = True
 
     def _check_buffer_size(self):
         if self._stream.paused:
@@ -567,7 +569,7 @@ class FlowControlStreamReader(StreamReader):
 
         super().feed_data(data)
 
-        if (not self._stream.paused and
+        if (self.allow_pause and not self._stream.paused and
                 not has_waiter and self._buffer_size > self._b_limit):
             try:
                 self._stream.transport.pause_reading()
@@ -611,6 +613,7 @@ class FlowControlDataQueue(DataQueue):
 
         self._stream = stream
         self._limit = limit * 2
+        self.allow_pause = False
 
         # resume transport reading
         if stream.paused:
@@ -620,13 +623,14 @@ class FlowControlDataQueue(DataQueue):
                 pass
             else:
                 self._stream.paused = False
+                self.allow_pause = True
 
     def feed_data(self, data, size):
         has_waiter = self._waiter is not None and not self._waiter.cancelled()
 
         super().feed_data(data, size)
 
-        if (not self._stream.paused and
+        if (self.allow_pause and not self._stream.paused and
                 not has_waiter and self._size > self._limit):
             try:
                 self._stream.transport.pause_reading()

--- a/tests/test_stream_parser.py
+++ b/tests/test_stream_parser.py
@@ -213,6 +213,7 @@ def test_set_parser_feed_existing_stop(loop):
 def test_feed_parser(loop, lines_parser):
     stream = parsers.StreamParser(loop=loop)
     s = stream.set_parser(lines_parser)
+    assert s.allow_pause
 
     stream.feed_data(b'line1')
     stream.feed_data(b'\r\nline2\r\ndata')


### PR DESCRIPTION
Added `allow_pause` to flow control related streams, so we can prevent transport pausing during `set_parser` stage. this should solve #1211 

@asvetlov @kxepal i need your review and thoughts

