### PR TITLE
fix #1555 AioHTTPTestCase method name mistype - get_applicaion

### DIFF
--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -382,7 +382,8 @@ class AioHTTPTestCase(unittest.TestCase):
 
     def setUp(self):
         self.loop = setup_test_loop()
-        self.app = self.loop.run_until_complete(self.get_application(self.loop))
+        self.app = self.loop.run_until_complete(
+            self.get_application(self.loop))
         self.client = TestClient(self.app)
         self.loop.run_until_complete(self.client.start_server())
 

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -356,14 +356,14 @@ class AioHTTPTestCase(unittest.TestCase):
     * self.loop (asyncio.BaseEventLoop): the event loop in which the
         application and server are running.
     * self.app (aiohttp.web.Application): the application returned by
-        self.get_applicaion()
+        self.get_application()
 
     Note that the TestClient's methods are asynchronous: you have to
     execute function on the test client using asynchronous methods.
     """
 
     @asyncio.coroutine
-    def get_applicaion(self, loop):
+    def get_application(self, loop):
         """
         This method should be overridden
         to return the aiohttp.web.Application
@@ -375,14 +375,14 @@ class AioHTTPTestCase(unittest.TestCase):
     def get_app(self, loop):
         """Obsolete method used to constructing web application.
 
-        Use .get_applicaion() coroutine instead
+        Use .get_application() coroutine instead
 
         """
         pass  # pragma: no cover
 
     def setUp(self):
         self.loop = setup_test_loop()
-        self.app = self.loop.run_until_complete(self.get_applicaion(self.loop))
+        self.app = self.loop.run_until_complete(self.get_application(self.loop))
         self.client = TestClient(self.app)
         self.loop.run_until_complete(self.client.start_server())
 


### PR DESCRIPTION

## What do these changes do?

fix mistype in method name

## Are there changes in behavior for the user?

yes, it changes AioHTTPTestCase public method name

## Related issue number

#1555 

## Checklist
it is just a typo fix
