### PR TITLE
Remove obsolete remark about `BaseConnector.limit` defaulting to `None`

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -823,7 +823,7 @@ BaseConnector
       Endpoints are the same if they are have equal ``(host, port,
       is_ssl)`` triple.
 
-      If *limit* is ``None`` the connector has no limit (default).
+      If *limit* is ``None`` the connector has no limit.
 
       Read-only property.
 


### PR DESCRIPTION
This hasn't been true since `limit` was given a default of 20 in the `BaseConnector.__init__`.
