### PR TITLE
Add docstrings for pytest plugin fixtures

### DIFF
--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -48,17 +48,23 @@ def pytest_pyfunc_call(pyfuncitem):
 
 @pytest.yield_fixture
 def loop():
+    """Return an instance of the event loop."""
     with loop_context() as _loop:
         yield _loop
 
 
 @pytest.fixture
 def unused_port():
+    """Return a port that is unused on the current host."""
     return _unused_port
 
 
 @pytest.yield_fixture
 def test_server(loop):
+    """Factory to create a TestServer instance, given an app.
+
+    test_server(app, **kwargs)
+    """
     servers = []
 
     @asyncio.coroutine
@@ -83,6 +89,10 @@ def test_server(loop):
 
 @pytest.yield_fixture
 def raw_test_server(loop):
+    """Factory to create a RawTestServer instance, given a web handler.
+
+    raw_test_server(handler, **kwargs)
+    """
     servers = []
 
     @asyncio.coroutine
@@ -104,6 +114,12 @@ def raw_test_server(loop):
 
 @pytest.yield_fixture
 def test_client(loop):
+    """Factory to create a TestClient instance.
+
+    test_client(app, **kwargs)
+    test_client(server, **kwargs)
+    test_client(raw_server, **kwargs)
+    """
     clients = []
 
     @asyncio.coroutine


### PR DESCRIPTION
## What do these changes do?

The aiohttp pytest plugin fixtures don't have docstrings, so when someone runs the following, they don't get much help:

```
$ pytest --fixtures
...
--------------------- fixtures defined from aiohttp.pytest_plugin ---------------------
test_client
    aiohttp/pytest_plugin.py:106: no docstring available
loop
    aiohttp/pytest_plugin.py:50: no docstring available
unused_port
    aiohttp/pytest_plugin.py:56: no docstring available
test_server
    aiohttp/pytest_plugin.py:61: no docstring available
raw_test_server
    aiohttp/pytest_plugin.py:85: no docstring available
```

This PR adds docstrings to the above fixtures.

## Are there changes in behavior for the user?

Users will now see:

```
--------------------- fixtures defined from aiohttp.pytest_plugin ---------------------
test_client
    Factory to create a TestClient instance.

    test_client(app, **kwargs)
    test_client(server, **kwargs)
    test_client(raw_server, **kwargs)
loop
    Return an instance of the event loop.
unused_port
    Return a port that is unused on the current host.
test_server
    Factory to create a TestServer instance, given an app.

    test_server(app, **kwargs)
raw_test_server
    Factory to create a RawTestServer instance, given a web handler.

    raw_test_server(handler, **kwargs)

```

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
