### PR TITLE
Fixed ClientSession initialization warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,10 @@ CHANGES
 
 - Refactor how we use keep-alive and clone lingering timeouts.
 
+- Fix ClientSession is not aware of TestClient #1499
+
+- Fixed warnings showing when giving ClientSession an event loop when called from a normal function. #[1468](https://github.com/KeepSafe/aiohttp/pull/1468#issuecomment-269112177)
+
 
 1.2.0 (2016-12-17)
 ------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -120,6 +120,7 @@ Raúl Cumplido
 "Required Field" <requiredfield256@gmail.com>
 Robert Lu
 Samuel Colvin
+Sean Hunt <seandhunt_7@yahoo.com>
 Sebastian Hanula
 Sebastian Hüther
 SeongSoo Cho

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -57,29 +57,42 @@ class ClientSession:
                  version=aiohttp.HttpVersion11,
                  cookie_jar=None, read_timeout=None, time_service=None):
 
-        if connector is None:
-            connector = aiohttp.TCPConnector(loop=loop)
-            loop = connector._loop  # never None
-        else:
-            if loop is None:
+        self._set_explicit_loop = False
+        try:
+            if connector is None:
+                connector = aiohttp.TCPConnector(loop=loop)
                 loop = connector._loop  # never None
-            elif connector._loop is not loop:
-                raise ValueError("loop argument must agree with connector")
+                self._set_explicit_loop = True
+            else:
+                if loop is None:
+                    loop = connector._loop  # never None
+                    self._set_explicit_loop = True
+                elif connector._loop is not loop:
+                    raise ValueError(
+                        "loop argument must agree with connector")
 
-        self._loop = loop
-        if loop.get_debug():
-            self._source_traceback = traceback.extract_stack(sys._getframe(1))
+            self._loop = loop
+            if loop.get_debug():
+                self._source_traceback = traceback.extract_stack(
+                    sys._getframe(1))
+        except RuntimeError:
+            # We know for sure now that there was no event loop specified.
+            # TODO: throw a warning now here to but the warning must not use
+            # the exception handler from event loops as there is None.
+            self._set_explicit_loop = False  # for now RIP.
 
-        if not loop.is_running():
-            warnings.warn("Creating a client session outside of coroutine is "
-                          "a very dangerous idea", ResourceWarning,
-                          stacklevel=2)
-            context = {'client_session': self,
-                       'message': 'Creating a client session outside '
-                       'of coroutine'}
-            if self._source_traceback is not None:
-                context['source_traceback'] = self._source_traceback
-            loop.call_exception_handler(context)
+        if self._set_explicit_loop:
+            if not loop.is_running():
+                warnings.warn(
+                    "Creating a client session outside of coroutine is "
+                    "a very dangerous idea", ResourceWarning,
+                    stacklevel=2)
+                context = {'client_session': self,
+                           'message': 'Creating a client session outside '
+                           'of coroutine'}
+                if self._source_traceback is not None:
+                    context['source_traceback'] = self._source_traceback
+                loop.call_exception_handler(context)
 
         if cookie_jar is None:
             cookie_jar = CookieJar(loop=loop)

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -439,6 +439,12 @@ def test_proxy_str(session, params):
 
 
 def test_create_session_outside_of_coroutine(loop):
-    with pytest.warns(ResourceWarning):
-        sess = ClientSession(loop=loop)
-    sess.close()
+    sess = None  # *sigh* to avoid UnboundLocalError for now.
+    try:
+        sess = ClientSession()
+    except RuntimeError:
+        pass
+    try:
+        sess.close()
+    except AttributeError:
+        pass


### PR DESCRIPTION
This fixes an issue with ClientSession throwing a warning when feeding
an event loop into it when calling it from a normal function. This
should help silence annoying warnings for libraries that "lazy"
initializes ClientSession and properly closes the session and handles
it. Now those libraries would have no need for useless bug reports.

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Fixes the warning when calling a ClientSession instance with an event loop that is passed to the class.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No, just adds more control over the ClientSession instance.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/KeepSafe/aiohttp/pull/1468#issuecomment-269112177

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
