### PR TITLE
Ensure same connection is reused during client keep-alive tests

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -83,6 +83,7 @@ Joongi Kim
 Julien Duponchelle
 Junjie Tao
 Justas Trimailovas
+Justin Turner Arthur
 Kay Zheng
 Kimmo Parviainen-Jalanko
 Kirill Klenov

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -47,7 +47,10 @@ def test_keepalive_two_requests_success(loop, test_client):
 
     app = web.Application(loop=loop)
     app.router.add_route('GET', '/', handler)
-    client = yield from test_client(app)
+
+    connector = aiohttp.TCPConnector(loop=loop, limit=1)
+    client = yield from test_client(app, connector=connector)
+
     resp1 = yield from client.get('/')
     yield from resp1.read()
     resp2 = yield from client.get('/')
@@ -66,7 +69,9 @@ def test_keepalive_response_released(loop, test_client):
 
     app = web.Application(loop=loop)
     app.router.add_route('GET', '/', handler)
-    client = yield from test_client(app)
+
+    connector = aiohttp.TCPConnector(loop=loop, limit=1)
+    client = yield from test_client(app, connector=connector)
 
     resp1 = yield from client.get('/')
     yield from resp1.release()
@@ -88,7 +93,9 @@ def test_keepalive_server_force_close_connection(loop, test_client):
 
     app = web.Application(loop=loop)
     app.router.add_route('GET', '/', handler)
-    client = yield from test_client(app)
+
+    connector = aiohttp.TCPConnector(loop=loop, limit=1)
+    client = yield from test_client(app, connector=connector)
 
     resp1 = yield from client.get('/')
     resp1.close()
@@ -440,7 +447,9 @@ def test_keepalive_closed_by_server(loop, test_client):
 
     app = web.Application(loop=loop)
     app.router.add_route('GET', '/', handler)
-    client = yield from test_client(app)
+
+    connector = aiohttp.TCPConnector(loop=loop, limit=1)
+    client = yield from test_client(app, connector=connector)
 
     resp1 = yield from client.get('/')
     val1 = yield from resp1.read()

--- a/tests/test_client_functional_oldstyle.py
+++ b/tests/test_client_functional_oldstyle.py
@@ -646,7 +646,7 @@ class TestHttpClientFunctional(unittest.TestCase):
 
             addr = server.sockets[0].getsockname()
 
-            connector = aiohttp.TCPConnector(loop=self.loop)
+            connector = aiohttp.TCPConnector(loop=self.loop, limit=1)
 
             url = 'http://{}:{}/'.format(*addr)
             for i in range(2):
@@ -689,7 +689,7 @@ class TestHttpClientFunctional(unittest.TestCase):
 
             addr = server.sockets[0].getsockname()
 
-            connector = aiohttp.TCPConnector(loop=self.loop)
+            connector = aiohttp.TCPConnector(loop=self.loop, limit=1)
 
             url = 'http://{}:{}/'.format(*addr)
 


### PR DESCRIPTION
Forces reuse of the same connection in client keep-alive tests by setting pool limit to 1.

I'm working on pipelining options for connectors and this helps provide a clean baseline. Added myself to contributors.