### PR TITLE
Early check multipart body part data sanity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ CHANGES
 1.3.0 (XXXX-XX-XX)
 ------------------
 
+- Multipart writer validates the data on append instead of on a request send #920
+
 - Multipart reader accepts multipart messages with or without their epilogue
   to consistently handle valid and legacy behaviors #1526 #1581
 

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -698,6 +698,19 @@ class BodyPartWriter(object):
             ('application', 'json'): self._serialize_json,
             ('application', 'x-www-form-urlencoded'): self._serialize_form
         }
+        self._validate_obj(obj, headers)
+
+    def _validate_obj(self, obj, headers):
+        mtype, stype, *_ = parse_mimetype(headers.get(CONTENT_TYPE))
+        if (mtype, stype) in self._serialize_map:
+            return
+        for key in self._serialize_map:
+            if isinstance(key, tuple):
+                continue
+            if isinstance(obj, key):
+                return
+        else:
+            raise TypeError('unexpected body part value type %r' % type(obj))
 
     def _fill_headers_with_defaults(self):
         if CONTENT_TYPE not in self.headers:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1115,6 +1115,21 @@ class MultipartWriterTestCase(unittest.TestCase):
             writer.append_json({'baz': True})
         self.assertEqual(3, len(writer))
 
+    def test_append_int_not_allowed(self):
+        with self.assertRaises(TypeError):
+            with aiohttp.multipart.MultipartWriter(boundary=':') as writer:
+                writer.append(1)
+
+    def test_append_float_not_allowed(self):
+        with self.assertRaises(TypeError):
+            with aiohttp.multipart.MultipartWriter(boundary=':') as writer:
+                writer.append(1.1)
+
+    def test_append_none_not_allowed(self):
+        with self.assertRaises(TypeError):
+            with aiohttp.multipart.MultipartWriter(boundary=':') as writer:
+                writer.append(None)
+
 
 class ParseContentDispositionTestCase(unittest.TestCase):
     # http://greenbytes.de/tech/tc2231/


### PR DESCRIPTION
Raising exception on append stage simplifies a lot searches of the issue origin.

This closes #920