### PR TITLE
Indicate in the docs that response history contains the earliest request first, rather than the most recent

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1271,8 +1271,8 @@ Response object
    .. attribute:: history
 
       A :class:`~collections.abc.Sequence` of :class:`ClientResponse`
-      objects of preceding requests if there were redirects, an empty
-      sequence otherwise.
+      objects of preceding requests (earliest request first) if there were
+      redirects, an empty sequence otherwise.
 
    .. method:: close()
 


### PR DESCRIPTION
Either was plausible, and I'd wrongly assumed the latter. Seems worth noting this explicitly in the docs.