### PR TITLE
run_app and CLI can listen on Unix domain sockets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ CHANGES
 
 1.4.0 (XXXX-XX-XX)
 ------------------
+- `run_app` and the Command Line Interface now support serving over Unix domain sockets for
+  faster inter-process communication.
 
 - Dropped: `aiohttp.protocol.HttpPrefixParser`  #1590
 

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -1,7 +1,9 @@
 import asyncio
 import contextlib
+import tempfile
 
 import pytest
+from py import path
 
 from aiohttp.web import Application
 
@@ -155,3 +157,13 @@ def test_client(loop):
             yield from clients.pop().close()
 
     loop.run_until_complete(finalize())
+
+
+@pytest.fixture
+def shorttmpdir():
+    """Provides a temporary directory with a shorter file system path than the
+    tmpdir fixture.
+    """
+    tmpdir = path.local(tempfile.mkdtemp())
+    yield tmpdir
+    tmpdir.remove(rec=1)

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -1,4 +1,5 @@
 import asyncio
+import socket
 import sys
 import warnings
 from argparse import ArgumentParser
@@ -269,12 +270,12 @@ class Application(MutableMapping):
         return "<Application 0x{:x}>".format(id(self))
 
 
-def run_app(app, *, host='0.0.0.0', port=None,
+def run_app(app, *, host='0.0.0.0', port=None, path=None,
             shutdown_timeout=60.0, ssl_context=None,
             print=print, backlog=128, access_log_format=None,
             access_log=access_logger):
     """Run an app locally"""
-    if port is None:
+    if port is None and path is None:
         if not ssl_context:
             port = 8080
         else:
@@ -289,16 +290,30 @@ def run_app(app, *, host='0.0.0.0', port=None,
                                **make_handler_kwargs)
 
     loop.run_until_complete(app.startup())
-    srv = loop.run_until_complete(loop.create_server(handler, host,
-                                                     port, ssl=ssl_context,
-                                                     backlog=backlog))
 
     scheme = 'https' if ssl_context else 'http'
-    base_url = URL('{}://localhost'.format(scheme)).with_port(port)
-    if isinstance(host, str):
-        urls = [base_url.with_host(host)]
+
+    if path is None:
+        # Assume IP networking
+        srv_creation = loop.create_server(
+            handler, host, port, ssl=ssl_context, backlog=backlog
+        )
+        base_url = URL('{}://localhost'.format(scheme)).with_port(port)
+        if isinstance(host, str):
+            urls = (base_url.with_host(host),)
+        else:
+            urls = [base_url.with_host(h) for h in host]
     else:
-        urls = [base_url.with_host(h) for h in host]
+        srv_creation = loop.create_unix_server(
+            handler, path, ssl=ssl_context, backlog=backlog
+        )
+        # nginx-style URLs for Unix socket paths
+        if isinstance(path, str):
+            urls = ('{}://unix:{}:'.format(scheme, path),)
+        else:
+            urls = ['{}://unix:{}:'.format(scheme, p) for p in path]
+
+    srv = loop.run_until_complete(srv_creation)
 
     print("======== Running on {} ========\n"
           "(Press CTRL+C to quit)".format(', '.join(str(u) for u in urls)))
@@ -338,6 +353,11 @@ def main(argv):
         type=int,
         default="8080"
     )
+    arg_parser.add_argument(
+        "-U", "--path",
+        help="Unix file system path to serve on. Specifying a path will cause "
+             "hostname and port arguments to be ignored.",
+    )
     args, extra_argv = arg_parser.parse_known_args(argv)
 
     # Import logic
@@ -357,8 +377,13 @@ def main(argv):
     except AttributeError:
         arg_parser.error("module %r has no attribute %r" % (mod_str, func_str))
 
+    # Compatibility logic
+    if args.path is not None and not hasattr(socket, 'AF_UNIX'):
+        arg_parser.error("file system paths not supported by your operating"
+                         " environment")
+
     app = func(extra_argv)
-    run_app(app, host=args.hostname, port=args.port)
+    run_app(app, host=args.hostname, port=args.port, path=args.path)
     arg_parser.exit(message="Stopped\n")
 
 

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -1,5 +1,7 @@
 import asyncio
+import os
 import socket
+import stat
 import sys
 import warnings
 from argparse import ArgumentParser
@@ -312,6 +314,16 @@ def run_app(app, *, host='0.0.0.0', port=None, path=None,
             urls = ('{}://unix:{}:'.format(scheme, path),)
         else:
             urls = ['{}://unix:{}:'.format(scheme, p) for p in path]
+
+        # Clean up prior socket path if stale and not abstract.
+        # CPython 3.5.3+'s event loop already does this. See
+        # https://github.com/python/asyncio/issues/425
+        if path[0] not in (0, '\x00'):
+            try:
+                if stat.S_ISSOCK(os.stat(path).st_mode):
+                    os.remove(path)
+            except FileNotFoundError:
+                pass
 
     srv = loop.run_until_complete(srv_creation)
 

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -5,7 +5,7 @@ import stat
 import sys
 import warnings
 from argparse import ArgumentParser
-from collections import MutableMapping
+from collections import Iterable, MutableMapping
 from importlib import import_module
 
 from yarl import URL
@@ -292,7 +292,8 @@ def run_app(app, *, host=None, port=None, path=None,
 
     if path is None:
         paths = ()
-    elif isinstance(path, str):
+    elif isinstance(path, (str, bytes, bytearray, memoryview))\
+            or not isinstance(path, Iterable):
         paths = (path,)
     else:
         paths = path
@@ -302,7 +303,8 @@ def run_app(app, *, host=None, port=None, path=None,
             hosts = ()
         else:
             hosts = ("0.0.0.0",)
-    elif isinstance(host, str):
+    elif isinstance(host, (str, bytes, bytearray, memoryview))\
+            or not isinstance(host, Iterable):
         hosts = (host,)
     else:
         hosts = host
@@ -334,7 +336,7 @@ def run_app(app, *, host=None, port=None, path=None,
         # Clean up prior socket path if stale and not abstract.
         # CPython 3.5.3+'s event loop already does this. See
         # https://github.com/python/asyncio/issues/425
-        if path[0] not in (0, '\x00'):
+        if path[0] not in (0, '\x00'):  # pragma: no branch
             try:
                 if stat.S_ISSOCK(os.stat(path).st_mode):
                     os.remove(path)

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2092,7 +2092,7 @@ Utilities
    .. seealso:: :ref:`aiohttp-web-file-upload`
 
 
-.. function:: run_app(app, *, host='0.0.0.0', port=None, path=None, \
+.. function:: run_app(app, *, host=None, port=None, path=None, \
                       loop=None, shutdown_timeout=60.0, \
                       ssl_context=None, print=print, backlog=128, \
                       access_log_format=None, \
@@ -2108,17 +2108,29 @@ Utilities
 
    The function uses *app.loop* as event loop to run.
 
+   The server will listen on any host or Unix domain socket path you supply.
+   If no hosts or paths are supplied, or only a port is supplied, a TCP server
+   listening on 0.0.0.0 (all hosts) will be launched.
+
+   Distributing HTTP traffic to multiple hosts or paths on the same
+   application process provides no performance benefit as the requests are
+   handled on the same event loop. See :doc:`deployment` for ways of
+   distributing work for increased performance.
+
    :param app: :class:`Application` instance to run
 
-   :param str host: host for HTTP server, ``'0.0.0.0'`` by default
+   :param str host: TCP/IP host or a sequence of hosts for HTTP server.
+                    Default is ``'0.0.0.0'`` if *port* has been specified
+                    or if *path* is not supplied.
 
-   :param int port: TCP port for HTTP server. By default is ``8080`` for
-                    plain text HTTP and ``8443`` for HTTP via SSL
-                    (when *ssl_context* parameter is specified).
+   :param int port: TCP/IP port for HTTP server. Default is ``8080`` for plain
+                    text HTTP and ``8443`` for HTTP via SSL (when
+                    *ssl_context* parameter is specified).
 
    :param str path: file system path for HTTP server Unix domain socket.
-                    If supplied, TCP/IP parameters `host` and
-                    `port` are ignored.
+                    A sequence of file system paths can be used to bind
+                    multiple domain sockets. Listening on Unix domain
+                    sockets is not supported by all operating systems.
 
    :param int shutdown_timeout: a delay to wait for graceful server
                                 shutdown before disconnecting all

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2092,9 +2092,9 @@ Utilities
    .. seealso:: :ref:`aiohttp-web-file-upload`
 
 
-.. function:: run_app(app, *, host='0.0.0.0', port=None, loop=None, \
-                      shutdown_timeout=60.0, ssl_context=None, \
-                      print=print, backlog=128, \
+.. function:: run_app(app, *, host='0.0.0.0', port=None, path=None, \
+                      loop=None, shutdown_timeout=60.0, \
+                      ssl_context=None, print=print, backlog=128, \
                       access_log_format=None, \
                       access_log=aiohttp.log.access_logger)
 
@@ -2112,9 +2112,13 @@ Utilities
 
    :param str host: host for HTTP server, ``'0.0.0.0'`` by default
 
-   :param int port: port for HTTP server. By default is ``8080`` for
+   :param int port: TCP port for HTTP server. By default is ``8080`` for
                     plain text HTTP and ``8443`` for HTTP via SSL
                     (when *ssl_context* parameter is specified).
+
+   :param str path: file system path for HTTP server Unix domain socket.
+                    If supplied, TCP/IP parameters `host` and
+                    `port` are ignored.
 
    :param int shutdown_timeout: a delay to wait for graceful server
                                 shutdown before disconnecting all

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1,5 +1,10 @@
+import socket
 import ssl
+
+from io import StringIO
 from unittest import mock
+
+import pytest
 
 from aiohttp import web
 
@@ -92,3 +97,40 @@ def test_run_app_custom_backlog(loop, mocker):
     loop.create_server.assert_called_with(mock.ANY, '0.0.0.0', 8080,
                                           ssl=None, backlog=10)
     app.startup.assert_called_once_with()
+
+
+@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'), reason="UNIX sockets are not supported")
+def test_run_app_http_unix_socket(loop, mocker, shorttmpdir):
+    mocker.spy(loop, 'create_unix_server')
+    loop.call_later(0.05, loop.stop)
+
+    app = web.Application(loop=loop)
+    mocker.spy(app, 'startup')
+
+    sock_path = str(shorttmpdir.join('socket.sock'))
+    printed = StringIO()
+    web.run_app(app, path=sock_path, print=printed.write)
+
+    assert loop.is_closed()
+    loop.create_unix_server.assert_called_with(mock.ANY, sock_path, ssl=None, backlog=128)
+    app.startup.assert_called_once_with()
+    assert "http://unix:{}:".format(sock_path) in printed.getvalue()
+
+
+@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'), reason="UNIX sockets are not supported")
+def test_run_app_https_unix_socket(loop, mocker, shorttmpdir):
+    mocker.spy(loop, 'create_unix_server')
+    loop.call_later(0.05, loop.stop)
+
+    app = web.Application(loop=loop)
+    mocker.spy(app, 'startup')
+
+    sock_path = str(shorttmpdir.join('socket.sock'))
+    printed = StringIO()
+    ssl_context = ssl.create_default_context()
+    web.run_app(app, path=sock_path, ssl_context=ssl_context, print=printed.write)
+
+    assert loop.is_closed()
+    loop.create_unix_server.assert_called_with(mock.ANY, sock_path, ssl=ssl_context, backlog=128)
+    app.startup.assert_called_once_with()
+    assert "https://unix:{}:".format(sock_path) in printed.getvalue()

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -99,7 +99,8 @@ def test_run_app_custom_backlog(loop, mocker):
     app.startup.assert_called_once_with()
 
 
-@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'), reason="UNIX sockets are not supported")
+@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'),
+                    reason="UNIX sockets are not supported")
 def test_run_app_http_unix_socket(loop, mocker, shorttmpdir):
     mocker.spy(loop, 'create_unix_server')
     loop.call_later(0.05, loop.stop)
@@ -112,12 +113,14 @@ def test_run_app_http_unix_socket(loop, mocker, shorttmpdir):
     web.run_app(app, path=sock_path, print=printed.write)
 
     assert loop.is_closed()
-    loop.create_unix_server.assert_called_with(mock.ANY, sock_path, ssl=None, backlog=128)
+    loop.create_unix_server.assert_called_with(mock.ANY, sock_path,
+                                               ssl=None, backlog=128)
     app.startup.assert_called_once_with()
     assert "http://unix:{}:".format(sock_path) in printed.getvalue()
 
 
-@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'), reason="UNIX sockets are not supported")
+@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'),
+                    reason="UNIX sockets are not supported")
 def test_run_app_https_unix_socket(loop, mocker, shorttmpdir):
     mocker.spy(loop, 'create_unix_server')
     loop.call_later(0.05, loop.stop)
@@ -128,9 +131,11 @@ def test_run_app_https_unix_socket(loop, mocker, shorttmpdir):
     sock_path = str(shorttmpdir.join('socket.sock'))
     printed = StringIO()
     ssl_context = ssl.create_default_context()
-    web.run_app(app, path=sock_path, ssl_context=ssl_context, print=printed.write)
+    web.run_app(app, path=sock_path, ssl_context=ssl_context,
+                print=printed.write)
 
     assert loop.is_closed()
-    loop.create_unix_server.assert_called_with(mock.ANY, sock_path, ssl=ssl_context, backlog=128)
+    loop.create_unix_server.assert_called_with(mock.ANY, sock_path,
+                                               ssl=ssl_context, backlog=128)
     app.startup.assert_called_once_with()
     assert "https://unix:{}:".format(sock_path) in printed.getvalue()

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -96,6 +96,19 @@ def test_entry_func_non_existent_attribute(mocker):
     )
 
 
+def test_path_when_unsupported(mocker, monkeypatch):
+    argv = "--path=test_path.sock alpha.beta:func".split()
+    mocker.patch("aiohttp.web.import_module")
+    monkeypatch.delattr("socket.AF_UNIX")
+
+    error = mocker.patch("aiohttp.web.ArgumentParser.error",
+                         side_effect=SystemExit)
+    with pytest.raises(SystemExit):
+        web.main(argv)
+
+    error.assert_called_with("file system paths not supported by your operating environment")
+
+
 def test_entry_func_call(mocker):
     mocker.patch("aiohttp.web.run_app")
     import_module = mocker.patch("aiohttp.web.import_module")
@@ -125,5 +138,5 @@ def test_running_application(mocker):
     with pytest.raises(SystemExit):
         web.main(argv)
 
-    run_app.assert_called_with(app, host="testhost", port=6666)
+    run_app.assert_called_with(app, host="testhost", port=6666, path=None)
     exit.assert_called_with(message="Stopped\n")

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -106,7 +106,8 @@ def test_path_when_unsupported(mocker, monkeypatch):
     with pytest.raises(SystemExit):
         web.main(argv)
 
-    error.assert_called_with("file system paths not supported by your operating environment")
+    error.assert_called_with("file system paths not supported by your"
+                             " operating environment")
 
 
 def test_entry_func_call(mocker):

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -99,7 +99,7 @@ def test_entry_func_non_existent_attribute(mocker):
 def test_path_when_unsupported(mocker, monkeypatch):
     argv = "--path=test_path.sock alpha.beta:func".split()
     mocker.patch("aiohttp.web.import_module")
-    monkeypatch.delattr("socket.AF_UNIX")
+    monkeypatch.delattr("socket.AF_UNIX", raising=False)
 
     error = mocker.patch("aiohttp.web.ArgumentParser.error",
                          side_effect=SystemExit)


### PR DESCRIPTION
## What do these changes do?
Makes it easy to serve HTTP or HTTPS requests over Unix domain sockets using pre-existing deployment features. Accomplishes this by:
* Adding a `path=` keyword argument to the `run_app` utility function that can be used to supply a file system path for a Unix domain socket.
* Adding an optional `-U` or `--path` command line argument to the CLI web server that can be used to supply a file system path for a Unix domain socket.

## Are there changes in behavior for the user?
Users serving HTTP or HTTPS over TCP/IP should see no change in behavior.

## Needs Review Before Merge
* Is the term _path_ a good one to use in our APIs? It mimics the `path` parameter passed to asyncio's implementation and is small. Is it intuitive enough?
* CPython <3.6 fails to remove a stale unix socket path from the file system before attempting to bind again, causing an error if a stale path exists (see python/asyncio#425). Do we want to work around this for our 3.4 and 3.5 users and delete the stale path before calling `create_unix_server`?
* I had to choose a URI or URL format to use for portraying the HTTP-over-Unix-domain-socket resource. In this version the text for humans that gets spit out by `run_app` uses [the same format as nginx's proxy_pass directive](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass), e.g. `http://unix:/tmp/backend.sock:`. Some other possible locator or identifier formats we could use:
   * `http+unix://%2Ftmp%2Fbackend.sock` as used by [requests-unix](https://github.com/msabramo/requests-unixsocket).
  * Place a dummy host as used by [curl](https://curl.haxx.se/)'s `curl` tool: `http://localhost/`
    * It does this partly because its Unix domain socket is supplied separately.
  * `unix:/tmp/backend` as used in nginx's `upstream` `server` directive.
    * It won't portray whether the socket is using SSL or not.