### PR TITLE
Handle CLOSING in WebSocketResponse.__anext__

### DIFF
--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -245,6 +245,8 @@ class ClientWebSocketResponse:
         @asyncio.coroutine
         def __anext__(self):
             msg = yield from self.receive()
-            if msg.type == WSMsgType.CLOSE or msg.type == WSMsgType.CLOSED:
+            if msg.type in (WSMsgType.CLOSE,
+                            WSMsgType.CLOSING,
+                            WSMsgType.CLOSED):
                 raise StopAsyncIteration  # NOQA
             return msg

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -343,6 +343,8 @@ class WebSocketResponse(StreamResponse):
         @asyncio.coroutine
         def __anext__(self):
             msg = yield from self.receive()
-            if msg.type == WSMsgType.CLOSE or msg.type == WSMsgType.CLOSED:
+            if msg.type in (WSMsgType.CLOSE,
+                            WSMsgType.CLOSING,
+                            WSMsgType.CLOSED):
                 raise StopAsyncIteration  # NOQA
             return msg


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This change allows the `WebSocketResponses` (and `ClientWebSocketResponses`) to automatically handle all messages that signal a websocket closing of some kind -- including the new `WSMsgType.CLOSING` message -- when asynchronously iterated over.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

The user will not get any CLOSING messages when asynchronously iterating over `WebSocketResponses`.  I believe this to be the expected behavior of `__anext__`.

Compared with v1.2, there should be no behavioral changes.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

N/A

## Checklist

I'll get these done soon

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes (No changes needed, `WebSockeResponse.__anext__`  is undocumented)
- [ ] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
