### PR TITLE
remove gc.collect() from teardown_test_loop

### DIFF
--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -3,7 +3,6 @@
 import asyncio
 import contextlib
 import functools
-import gc
 import socket
 import sys
 import unittest
@@ -457,7 +456,6 @@ def teardown_test_loop(loop):
         loop.call_soon(loop.stop)
         loop.run_forever()
         loop.close()
-    gc.collect()
     asyncio.set_event_loop(None)
 
 


### PR DESCRIPTION
Was there a good reason to call `gc.collect()` while tearing down a loop in tests?

In the particular code I'm working on atm. removing that line roughly halves the time taken to run tests.

If you really think it's necessary perhaps use `gc.collect(1)` which is less aggressive and seems to still yield the 2x speed increase.