### PR TITLE
Fix URL instance comparsion

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -9,7 +9,7 @@ import warnings
 from http.cookies import CookieError, Morsel
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
-from yarl import URL
+from yarl import BaseURL, URL
 
 import aiohttp
 
@@ -70,8 +70,8 @@ class ClientRequest:
         if loop is None:
             loop = asyncio.get_event_loop()
 
-        assert isinstance(url, URL), url
-        assert isinstance(proxy, (URL, type(None))), proxy
+        assert isinstance(url, BaseURL), url
+        assert isinstance(proxy, (BaseURL, type(None))), proxy
 
         if params:
             q = MultiDict(url.query)

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -9,7 +9,7 @@ import warnings
 from http.cookies import CookieError, Morsel
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
-from yarl import BaseURL, URL
+from yarl import BaseURL
 
 import aiohttp
 
@@ -516,7 +516,7 @@ class ClientResponse(HeadersMixin):
 
     def __init__(self, method, url, *,
                  writer=None, continue100=None, timer=None):
-        assert isinstance(url, URL)
+        assert isinstance(url, BaseURL)
 
         self.method = method
         self._url_obj = url

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -4,8 +4,8 @@ import asyncio
 import json
 import sys
 
-from ._ws_impl import (CLOSED_MESSAGE, CLOSING_MESSAGE,
-                       WebSocketError, WSMessage, WSMsgType)
+from ._ws_impl import (CLOSED_MESSAGE, CLOSING_MESSAGE, WebSocketError,
+                       WSMessage, WSMsgType)
 from .errors import ServerDisconnectedError
 from .helpers import create_future
 

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from http.cookies import Morsel
 from math import ceil
+
 from yarl import URL
 
 from .abc import AbstractCookieJar

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -4,9 +4,8 @@ import sys
 from collections import namedtuple
 
 from . import hdrs
-from ._ws_impl import (CLOSED_MESSAGE, CLOSING_MESSAGE,
-                       WebSocketError, WebSocketReader,
-                       WSMessage, WSMsgType, do_handshake)
+from ._ws_impl import (CLOSED_MESSAGE, CLOSING_MESSAGE, WebSocketError,
+                       WebSocketReader, WSMessage, WSMsgType, do_handshake)
 from .errors import ClientDisconnectedError, HttpProcessingError
 from .helpers import create_future
 from .streams import FlowControlDataQueue

--- a/demos/polls/aiohttpdemo_polls/__main__.py
+++ b/demos/polls/aiohttpdemo_polls/__main__.py
@@ -1,4 +1,5 @@
 import sys
+
 from aiohttpdemo_polls.main import main
 
 main(sys.argv[1:])

--- a/demos/polls/aiohttpdemo_polls/db.py
+++ b/demos/polls/aiohttpdemo_polls/db.py
@@ -1,6 +1,5 @@
-import sqlalchemy as sa
-
 import aiopg.sa
+import sqlalchemy as sa
 
 __all__ = ['question', 'choice']
 

--- a/demos/polls/aiohttpdemo_polls/main.py
+++ b/demos/polls/aiohttpdemo_polls/main.py
@@ -5,15 +5,13 @@ import sys
 
 import jinja2
 
-from trafaret_config import commandline
-
-
 import aiohttp_jinja2
 from aiohttp import web
 from aiohttpdemo_polls.db import close_pg, init_pg
 from aiohttpdemo_polls.middlewares import setup_middlewares
 from aiohttpdemo_polls.routes import setup_routes
 from aiohttpdemo_polls.utils import TRAFARET
+from trafaret_config import commandline
 
 
 def init(loop, argv):

--- a/examples/lowlevel_srv.py
+++ b/examples/lowlevel_srv.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from aiohttp import web
 
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -20,5 +20,5 @@ gunicorn==19.6.0
 pygments>=2.1
 #aiodns  # Enable from .travis.yml as required c-ares will not build on windows
 twine==1.8.1
-yarl==0.9.2
+yarl==0.9.5
 -e .

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1,7 +1,6 @@
 import os
 import socket
 import ssl
-
 from io import StringIO
 from unittest import mock
 from uuid import uuid4
@@ -10,7 +9,6 @@ import pytest
 
 from aiohttp import web
 from aiohttp.test_utils import loop_context
-
 
 # Test for features of OS' socket support
 _has_unix_domain_socks = hasattr(socket, 'AF_UNIX')


### PR DESCRIPTION
## What do these changes do?

yarl 0.9.5 introduces BaseURL class, so isinstance(foo, URL) doesn't work anymore.

## Are there changes in behavior for the user?

No

## Related issue number

#1632 #1631 #1635 