### PR TITLE
Make CookieJar.filter_cookies() accept plain string parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,3 +32,5 @@ CHANGES
   attributes and `resolve` constructor  parameter #1607
 
 - Dropped `ProxyConnector` #1609
+
+- Allow string parameter for `aiohttp.CookieJar.filter_cookies()` #1636

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -97,6 +97,7 @@ Lukasz Marcin Dobrzanski
 Manuel Miranda
 Marco Paolini
 Mariano Anaya
+Martin Melka
 Martin Richard
 Mathias Fröjdman
 Matthieu Hauglustaine

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -166,6 +166,7 @@ class CookieJar(AbstractCookieJar):
     def filter_cookies(self, request_url=URL()):
         """Returns this jar's cookies filtered by their attributes."""
         self._do_expiration()
+        request_url = URL(request_url)
         filtered = SimpleCookie()
         hostname = request_url.raw_host or ""
         is_not_secure = request_url.scheme not in ("https", "wss")


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

If parameter passed to `CookieJar.filter_cookies()` is a string, the method fails.
Convert the `request_url` to expected `URL` object. If `URL` object is
passed as a parameter, everything still works as expected.

[Documentation](http://aiohttp.readthedocs.io/en/1.3.1/client.html#keep-alive-connection-pooling-and-cookie-sharing) suggests that passing a raw string to `filter_cookies` should work, but as of 1.3.0 it does not. 

## Are there changes in behavior for the user?

It is now possible to pass a string as a parameter to `filter_cookies()` method. Passing a `URL` object still works.

## Related issue number

#1636 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
