### PR TITLE
[Fix] #1651 - request.files in addition to request.data

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -134,6 +134,9 @@ class ClientSession:
     def _request(self, method, url, *,
                  params=None,
                  data=None,
+                 # TODO: make this actually work for files.
+                 # see issue  for more info. #1651
+                 files=None,
                  headers=None,
                  skip_auto_headers=None,
                  auth=None,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -135,7 +135,7 @@ class ClientSession:
                  params=None,
                  data=None,
                  # TODO: make this actually work for files.
-                 # see issue  for more info. #1651
+                 # see issue #1651 for more info.
                  files=None,
                  headers=None,
                  skip_auto_headers=None,
@@ -213,7 +213,7 @@ class ClientSession:
                 req = self._request_class(
                     method, url, params=params, headers=headers,
                     skip_auto_headers=skip_headers, data=data,
-                    cookies=cookies, encoding=encoding,
+                    files=files, cookies=cookies, encoding=encoding,
                     auth=auth, version=version, compress=compress,
                     chunked=chunked, expect100=expect100,
                     loop=self._loop, response_class=self._response_class,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -134,8 +134,6 @@ class ClientSession:
     def _request(self, method, url, *,
                  params=None,
                  data=None,
-                 # TODO: make this actually work for files.
-                 # see issue #1651 for more info.
                  files=None,
                  headers=None,
                  skip_auto_headers=None,

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -60,7 +60,8 @@ class ClientRequest:
 
     def __init__(self, method, url, *,
                  params=None, headers=None, skip_auto_headers=frozenset(),
-                 data=None, cookies=None,
+                 # TODO: Implement ability to request files in "files=".
+                 data=None, files=files, cookies=None,
                  auth=None, encoding='utf-8',
                  version=aiohttp.HttpVersion11, compress=None,
                  chunked=None, expect100=False,
@@ -98,7 +99,7 @@ class ClientRequest:
         self.update_cookies(cookies)
         self.update_content_encoding(data)
         self.update_auth(auth)
-        self.update_proxy(proxy, proxy_auth)
+        self.update_proxy(proxy, proxy_auth
 
         self.update_body_from_data(data, skip_auto_headers)
         self.update_transfer_encoding()

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -61,7 +61,7 @@ class ClientRequest:
     def __init__(self, method, url, *,
                  params=None, headers=None, skip_auto_headers=frozenset(),
                  # TODO: Implement ability to request files in "files=".
-                 data=None, files=files, cookies=None,
+                 data=None, files=None, cookies=None,
                  auth=None, encoding='utf-8',
                  version=aiohttp.HttpVersion11, compress=None,
                  chunked=None, expect100=False,

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -79,6 +79,12 @@ class ClientRequest:
             url2 = url.with_query(params)
             q.extend(url2.query)
             url = url.with_query(q)
+        # these 2 lines stolen from
+        # https://github.com/kennethreitz/requests/blob/master
+        # /requests/models.py#L217-#L239
+        files = [] if files is None else files
+        self.files = files
+        # the rest for "files=" isd TBD.
         self.url = url.with_fragment(None)
         self.original_url = url
         self.method = method.upper()

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -99,7 +99,7 @@ class ClientRequest:
         self.update_cookies(cookies)
         self.update_content_encoding(data)
         self.update_auth(auth)
-        self.update_proxy(proxy, proxy_auth
+        self.update_proxy(proxy, proxy_auth)
 
         self.update_body_from_data(data, skip_auto_headers)
         self.update_transfer_encoding()


### PR DESCRIPTION
This is a starter commit that adds ``files=`` to ``ClientSession()._request`` to allow it to be used in ``ClientSession().request``. This should hopefully make things that works in the requests package also work in aiohttp. I just need to look into the actual way to make it really work for when an API expects to see something in 'files', but not in 'data'.

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
They allow someone to tell request to use files and not data when an aip does not check for files in 'data' but does in 'files'.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No changes other than they can tell request files instead of data to make requests work on uploading files to servers.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#1651 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
