### PR TITLE
add allow_head to add_get

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,3 +46,6 @@ CHANGES
   attributes and `resolve` constructor  parameter #1607
 
 - Dropped `ProxyConnector` #1609
+
+- Add the `allow_head` keyword argument for `add_get` and
+  `router.set_defaults(allow_head=True/False)` #1618

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -14,10 +14,9 @@ class AbstractRouter(ABC):
     def post_init(self, app):
         """Post init stage.
 
-        It's not an abstract method for sake of backward compatibility
-        but if router wans to be aware about application it should
-        override it.
-
+        Not an abstract method for sake of backward compatibility,
+        but if the router wants to be aware of the application
+        it can override this.
         """
 
     @property

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -715,6 +715,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         super().__init__()
         self._resources = []
         self._named_resources = {}
+        self._default_allow_head = False
 
     @asyncio.coroutine
     def resolve(self, request):
@@ -754,6 +755,9 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
 
     def named_resources(self):
         return MappingProxyType(self._named_resources)
+
+    def set_defaults(self, *, allow_head):
+        self._default_allow_head = allow_head
 
     def register_resource(self, resource):
         assert isinstance(resource, AbstractResource), \
@@ -855,11 +859,16 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         """
         return self.add_route(hdrs.METH_HEAD, *args, **kwargs)
 
-    def add_get(self, *args, **kwargs):
+    def add_get(self, *args, allow_head=None, name=None, **kwargs):
         """
-        Shortcut for add_route with method GET
+        Shortcut for add_route with method GET, if allow_head is true another
+        route is added allowing head requests to the same endpoint
         """
-        return self.add_route(hdrs.METH_GET, *args, **kwargs)
+        if allow_head or (allow_head is None and self._default_allow_head):
+            # the head route can't have "name" set or it would conflict with
+            # the GET route below
+            self.add_route(hdrs.METH_HEAD, *args, **kwargs)
+        return self.add_route(hdrs.METH_GET, *args, name=name, **kwargs)
 
     def add_post(self, *args, **kwargs):
         """

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -715,7 +715,6 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         super().__init__()
         self._resources = []
         self._named_resources = {}
-        self._default_allow_head = False
 
     @asyncio.coroutine
     def resolve(self, request):
@@ -755,9 +754,6 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
 
     def named_resources(self):
         return MappingProxyType(self._named_resources)
-
-    def set_defaults(self, *, allow_head):
-        self._default_allow_head = allow_head
 
     def register_resource(self, resource):
         assert isinstance(resource, AbstractResource), \
@@ -859,12 +855,12 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         """
         return self.add_route(hdrs.METH_HEAD, *args, **kwargs)
 
-    def add_get(self, *args, allow_head=None, name=None, **kwargs):
+    def add_get(self, *args, name=None, allow_head=True, **kwargs):
         """
         Shortcut for add_route with method GET, if allow_head is true another
         route is added allowing head requests to the same endpoint
         """
-        if allow_head or (allow_head is None and self._default_allow_head):
+        if allow_head:
             # the head route can't have "name" set or it would conflict with
             # the GET route below
             self.add_route(hdrs.METH_HEAD, *args, **kwargs)

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -85,22 +85,9 @@ Handlers are setup to handle requests by registering them with the
 *path* pair) using methods like :class:`UrlDispatcher.add_get` and
 :class:`UrlDispatcher.add_post`::
 
-   app.router.set_defaults(allow_head=True)
    app.router.add_get('/', handler)
    app.router.add_post('/post', post_handler)
    app.router.add_put('/put', put_handler)
-
-Setting ``allow_head=True`` in :meth:`~UrlDispatcher.set_defaults` means
-endpoints added with :meth:`~UrlDispatcher.add_get` will accept ``HEAD``
-requests by default, this is the standard for most http servers and is
-recommended. You can also set ``HEAD`` request permissions on each route::
-
-   app.router.add_get('/a', handler, allow_head=True)  # will allow HEAD requests
-   app.router.add_get('/a', handler, allow_head=False)  # will not allow HEAD requests
-
-If ``set_defaults(allow_head=True)`` is not called or called with ``False``
-or ``allow_head=False`` is explicitly set on the route, ``HEAD`` requests to
-routes added with :meth:`~UrlDispatcher.add_get will return ``405``.
 
 :meth:`~UrlDispatcher.add_route` also supports the wildcard *HTTP method*,
 allowing a handler to serve incoming requests on a *path* having **any**
@@ -111,6 +98,26 @@ allowing a handler to serve incoming requests on a *path* having **any**
 The *HTTP method* can be queried later in the request handler using the
 :attr:`Request.method` property.
 
+By default endpoints added with :meth:`~UrlDispatcher.add_get` will accept
+``HEAD`` requests and return the same response headers as they would
+for a ``GET`` request. You can also deny ``HEAD`` requests on a route::
+
+   app.router.add_get('/', handler, allow_head=False)
+
+Here ``handler`` won't be called and the server will response with ``405``.
+
+.. note::
+
+   This is a change as of **aiohttp v2.0** to act in accordance with
+   `RFC 7231 <https://tools.ietf.org/html/rfc7231#section-4.3.2>`_.
+
+   Previous version always returned ``405`` for ``HEAD`` requests
+   to routes added with :meth:`~UrlDispatcher.add_get`.
+
+If you have handlers which perform lots of processing to write the response
+body you may wish to improve performance by skipping that processing
+in the case of ``HEAD`` requests while still taking care to respond with
+the same headers as with ``GET`` requests.
 
 .. _aiohttp-web-resource-and-route:
 

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -85,9 +85,22 @@ Handlers are setup to handle requests by registering them with the
 *path* pair) using methods like :class:`UrlDispatcher.add_get` and
 :class:`UrlDispatcher.add_post`::
 
+   app.router.set_defaults(allow_head=True)
    app.router.add_get('/', handler)
    app.router.add_post('/post', post_handler)
    app.router.add_put('/put', put_handler)
+
+Setting ``allow_head=True`` in :meth:`~UrlDispatcher.set_defaults` means
+endpoints added with :meth:`~UrlDispatcher.add_get` will accept ``HEAD``
+requests by default, this is the standard for most http servers and is
+recommended. You can also set ``HEAD`` request permissions on each route::
+
+   app.router.add_get('/a', handler, allow_head=True)  # will allow HEAD requests
+   app.router.add_get('/a', handler, allow_head=False)  # will not allow HEAD requests
+
+If ``set_defaults(allow_head=True)`` is not called or called with ``False``
+or ``allow_head=False`` is explicitly set on the route, ``HEAD`` requests to
+routes added with :meth:`~UrlDispatcher.add_get will return ``405``.
 
 :meth:`~UrlDispatcher.add_route` also supports the wildcard *HTTP method*,
 allowing a handler to serve incoming requests on a *path* having **any**

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -321,7 +321,7 @@ def test_allow_head(loop, test_client):
 
     def handler(_):
         return web.Response()
-    app.router.add_get('/a', handler, allow_head=True, name='a')
+    app.router.add_get('/a', handler, name='a')
     app.router.add_get('/b', handler, allow_head=False, name='b')
     client = yield from test_client(app)
 
@@ -339,34 +339,4 @@ def test_allow_head(loop, test_client):
 
     r = yield from client.head('/b')
     assert r.status == 405
-    yield from r.release()
-
-
-@pytest.mark.parametrize('dft_allow_head,allow_head,status', [
-    (True, False, 405),
-    (True, True, 200),
-    (True, None, 200),
-    (False, False, 405),
-    (False, True, 200),
-    (False, None, 405),
-])
-@asyncio.coroutine
-def test_allow_head(loop, test_client, dft_allow_head, allow_head, status):
-    """
-    Test allow_head on routes.
-    """
-    app = web.Application(loop=loop)
-
-    def handler(_):
-        return web.Response()
-    app.router.set_defaults(allow_head=dft_allow_head)
-    app.router.add_get('/', handler, allow_head=allow_head)
-    client = yield from test_client(app)
-
-    r = yield from client.get('/')
-    assert r.status == 200
-    yield from r.release()
-
-    r = yield from client.head('/')
-    assert r.status == status
     yield from r.release()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -310,3 +310,63 @@ def test_412_is_returned(loop, test_client):
     resp = yield from client.get('/')
 
     assert resp.status == 412
+
+
+@asyncio.coroutine
+def test_allow_head(loop, test_client):
+    """
+    Test allow_head on routes.
+    """
+    app = web.Application(loop=loop)
+
+    def handler(_):
+        return web.Response()
+    app.router.add_get('/a', handler, allow_head=True, name='a')
+    app.router.add_get('/b', handler, allow_head=False, name='b')
+    client = yield from test_client(app)
+
+    r = yield from client.get('/a')
+    assert r.status == 200
+    yield from r.release()
+
+    r = yield from client.head('/a')
+    assert r.status == 200
+    yield from r.release()
+
+    r = yield from client.get('/b')
+    assert r.status == 200
+    yield from r.release()
+
+    r = yield from client.head('/b')
+    assert r.status == 405
+    yield from r.release()
+
+
+@pytest.mark.parametrize('dft_allow_head,allow_head,status', [
+    (True, False, 405),
+    (True, True, 200),
+    (True, None, 200),
+    (False, False, 405),
+    (False, True, 200),
+    (False, None, 405),
+])
+@asyncio.coroutine
+def test_allow_head(loop, test_client, dft_allow_head, allow_head, status):
+    """
+    Test allow_head on routes.
+    """
+    app = web.Application(loop=loop)
+
+    def handler(_):
+        return web.Response()
+    app.router.set_defaults(allow_head=dft_allow_head)
+    app.router.add_get('/', handler, allow_head=allow_head)
+    client = yield from test_client(app)
+
+    r = yield from client.get('/')
+    assert r.status == 200
+    yield from r.release()
+
+    r = yield from client.head('/')
+    assert r.status == status
+    yield from r.release()


### PR DESCRIPTION
## What do these changes do?

Add the `allow_head` keyword argument for `add_get` to encourage aiohttp server applications to correctly implement http and allow `HEAD` requests to endpoints generally used for `GET` requests. 

Also adds `app.router.set_defaults(allow_head=True)` to switch behaviour of all endpoints for the app.

## Related issue number

#1618

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
