### PR TITLE
fixing client.rst documentation linting

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -443,16 +443,15 @@ Limiting connection pool size
 To limit amount of simultaneously opened connections you can pass *limit*
 parameter to *connector*::
 
-  conn = aiohttp.TCPConnector(limit=30)
+    conn = aiohttp.TCPConnector(limit=30)
 
-  The example limits total amount of parallel connections to `30`.
+The example limits total amount of parallel connections to `30`.
 
-  The default is `100`.
+The default is `100`.
 
 If you explicitly want not to have limits, pass `0`. For example::
 
-  conn = aiohttp.TCPConnector(limit=0)
-
+    conn = aiohttp.TCPConnector(limit=0)
 
 To limit amount of simultaneously opened connection to the same
 endpoint (``(host, port, is_ssl)`` triple) you can pass *limit_per_host*


### PR DESCRIPTION
## What do these changes do?

correct linting of `client.rst` docs, without this fix I get 

    aiohttp/docs/client.rst:446: WARNING: Could not lex literal_block as "python3". Highlighting skipped.

When running `make doc`