### PR TITLE
Fix body_length/output_length for StreamResponse after eof.

### DIFF
--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -916,7 +916,6 @@ class StreamResponse(HeadersMixin):
         self._eof_sent = True
         self._body_length = self._resp_impl.body_length
         self._req = None
-        self._body_length = self._resp_impl.body_length
         self._resp_impl = None
 
     def __repr__(self):

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -589,10 +589,13 @@ class StreamResponse(HeadersMixin):
 
     @property
     def body_length(self):
-        return self._resp_impl.body_length
+        return self._body_length
 
     @property
     def output_length(self):
+        if not self.prepared:
+            raise RuntimeError('Cannot get output_length for unprepared '
+                               'response')
         return self._resp_impl.output_length
 
     def enable_chunked_encoding(self, chunk_size=None):
@@ -742,33 +745,29 @@ class StreamResponse(HeadersMixin):
 
     @property
     def tcp_nodelay(self):
-        resp_impl = self._resp_impl
-        if resp_impl is None:
+        if not self.prepared:
             raise RuntimeError("Cannot get tcp_nodelay for "
                                "not prepared response")
-        return resp_impl.transport.tcp_nodelay
+        return self._resp_impl.transport.tcp_nodelay
 
     def set_tcp_nodelay(self, value):
-        resp_impl = self._resp_impl
-        if resp_impl is None:
+        if not self.prepared:
             raise RuntimeError("Cannot set tcp_nodelay for "
                                "not prepared response")
-        resp_impl.transport.set_tcp_nodelay(value)
+        self._resp_impl.transport.set_tcp_nodelay(value)
 
     @property
     def tcp_cork(self):
-        resp_impl = self._resp_impl
-        if resp_impl is None:
+        if not self.prepared:
             raise RuntimeError("Cannot get tcp_cork for "
                                "not prepared response")
-        return resp_impl.transport.tcp_cork
+        return self._resp_impl.transport.tcp_cork
 
     def set_tcp_cork(self, value):
-        resp_impl = self._resp_impl
-        if resp_impl is None:
+        if not self.prepared:
             raise RuntimeError("Cannot set tcp_cork for "
                                "not prepared response")
-        resp_impl.transport.set_tcp_cork(value)
+        self._resp_impl.transport.set_tcp_cork(value)
 
     def _generate_content_type_header(self, CONTENT_TYPE=hdrs.CONTENT_TYPE):
         params = '; '.join("%s=%s" % i for i in self._content_dict.items())
@@ -779,7 +778,7 @@ class StreamResponse(HeadersMixin):
         self.headers[CONTENT_TYPE] = ctype
 
     def _start_pre_check(self, request):
-        if self._resp_impl is not None:
+        if self.prepared:
             if self._req is not request:
                 raise RuntimeError(
                     "Response has been started with different request.")
@@ -891,7 +890,7 @@ class StreamResponse(HeadersMixin):
 
         if self._eof_sent:
             raise RuntimeError("Cannot call write() after write_eof()")
-        if self._resp_impl is None:
+        if not self.prepared:
             raise RuntimeError("Cannot call write() before start()")
 
         if data:
@@ -901,7 +900,7 @@ class StreamResponse(HeadersMixin):
 
     @asyncio.coroutine
     def drain(self):
-        if self._resp_impl is None:
+        if not self.prepared:
             raise RuntimeError("Response has not been started")
         yield from self._resp_impl.transport.drain()
 
@@ -909,16 +908,17 @@ class StreamResponse(HeadersMixin):
     def write_eof(self):
         if self._eof_sent:
             return
-        if self._resp_impl is None:
+        if not self.prepared:
             raise RuntimeError("Response has not been started")
 
         yield from self._resp_impl.write_eof()
         self._eof_sent = True
         self._req = None
+        self._body_length = self._resp_impl.body_length
         self._resp_impl = None
 
     def __repr__(self):
-        if self.started:
+        if self.prepared:
             info = "{} {} ".format(self._req.method, self._req.path)
         else:
             info = "not started"

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -409,6 +409,13 @@ def test_body_length_after_eof():
 
 
 @asyncio.coroutine
+def test_unprepared_output_length():
+    resp = StreamResponse()
+    with pytest.raises(RuntimeError):
+        resp.output_length
+
+
+@asyncio.coroutine
 def test_cannot_write_eof_before_headers():
     resp = StreamResponse()
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -397,6 +397,17 @@ def test_repr_after_eof():
 
 
 @asyncio.coroutine
+def test_body_length_after_eof():
+    resp = StreamResponse()
+    writer = mock.Mock()
+    yield from resp.prepare(make_request('GET', '/', writer=writer))
+    resp.write(b'datadata')
+    writer.drain.return_value = ()
+    yield from resp.write_eof()
+    assert resp.body_length == 8
+
+
+@asyncio.coroutine
 def test_cannot_write_eof_before_headers():
     resp = StreamResponse()
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -401,10 +401,11 @@ def test_body_length_after_eof():
     resp = StreamResponse()
     writer = mock.Mock()
     yield from resp.prepare(make_request('GET', '/', writer=writer))
-    resp.write(b'datadata')
+    resp.write(b'data')
+    resp.write(b'next data')
     writer.drain.return_value = ()
     yield from resp.write_eof()
-    assert resp.body_length == 8
+    assert resp.body_length == 28
 
 
 @asyncio.coroutine


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

After #1663 body length attribute is broken if eof received.

## Are there changes in behavior for the user?

Nope

## Related issue number

Nope

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
