### PR TITLE
support all the Content-Transfer-Encoding in the rfc1341

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -467,7 +467,7 @@ class BodyPartReader(object):
             return base64.b64decode(data)
         elif encoding == 'quoted-printable':
             return binascii.a2b_qp(data)
-        elif encoding == 'binary':
+        elif encoding in ('binary', '8bit', '7bit'):
             return data
         else:
             raise RuntimeError('unknown content transfer encoding: {}'


### PR DESCRIPTION
Support all the `Content-Transfer-Encoding` defined in the RFC (see https://www.w3.org/Protocols/rfc1341/5_Content-Transfer-Encoding.html )


According to RFC1341:
```
The difference between "8bit" (or any other conceivable bit-width token) and the "binary" token is that "binary" does not require adherence to any limits on line length or to the SMTP CRLF semantics
```

so we could do additional checks to validate the body here if the encoding is `8bit` or `7bit`, but imo it would bring much anyway.


[I need this because the `HttpClient` from apache commons v3 (in java) uses `8bit` encoding for text parts -.- ]