### PR TITLE
_resp_impl going back to None is insane

### DIFF
--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -926,7 +926,6 @@ class StreamResponse(HeadersMixin):
         self._eof_sent = True
         self._body_length = self._resp_impl.body_length
         self._req = None
-        self._resp_impl = None
 
     def __repr__(self):
         if self._eof_sent:

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -390,8 +390,8 @@ def test_repr_after_eof():
     resp.write(b'data')
     writer.drain.return_value = ()
     yield from resp.write_eof()
-    assert not resp.started
-    assert not resp.prepared
+    assert resp.started
+    assert resp.prepared
     resp_repr = repr(resp)
     assert resp_repr == '<StreamResponse OK eof>'
 


### PR DESCRIPTION
Introduced by #1663 :

 - After a `write_eof`, `Response.prepared` and `Response.started` are False again (?!)
 - Because of https://github.com/KeepSafe/aiohttp/blob/master/aiohttp/web_server.py#L90 the request is prepared twice
 - and the headers are sent again in the pipe after the complete body has been sent (!)

This behaviour is very problematic, but quite hidden because most clients use the `Content-Length` or `Transfer-Encoding` headers to stop reading what the server is sending once they have received all the data they expect.
Even a `curl` shows nothing anormal. But an actual telnet is pretty obvious:
```
% telnet 0.0.0.0 1111
Trying 0.0.0.0...
Connected to 0.0.0.0.
Escape character is '^]'.
GET / HTTP/1.1
 
HTTP/1.1 200 OK
Server: …
Content-Type: text/plain; charset=utf-8
Date: Tue, 07 Mar 2017 16:49:48 GMT
Transfer-Encoding: chunked

10
My actual body
0

HTTP/1.1 200 OK
Server: …
Content-Type: text/plain; charset=utf-8
Date: Tue, 07 Mar 2017 16:49:48 GMT
Transfer-Encoding: chunked
```

Also, nginx when doing a `proxy_pass`, does not actually respect the `Transfer-Encoding` header, read the additional data sent by aiohttp, and send them back to the client.


I tried adding a test catching this, but this seems pretty hard because the test_client drops the connections as soon as he has read enough data.
